### PR TITLE
Feature/add get jobs endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	store "github.com/ONSdigital/dp-search-reindex-api/store"
 	"github.com/gorilla/mux"
 )

--- a/api/api.go
+++ b/api/api.go
@@ -21,5 +21,6 @@ func Setup(ctx context.Context, router *mux.Router, jobStore store.JobStore) *Jo
 
 	router.HandleFunc("/jobs", api.CreateJobHandler(ctx)).Methods("POST")
 	router.HandleFunc("/jobs/{id}", api.GetJobHandler(ctx)).Methods("GET")
+	//router.HandleFunc("/jobs", api.GetJobsHandler(ctx)).Methods("GET")
 	return api
 }

--- a/api/api.go
+++ b/api/api.go
@@ -22,6 +22,6 @@ func Setup(ctx context.Context, router *mux.Router, jobStore store.JobStore) *Jo
 
 	router.HandleFunc("/jobs", api.CreateJobHandler(ctx)).Methods("POST")
 	router.HandleFunc("/jobs/{id}", api.GetJobHandler(ctx)).Methods("GET")
-	router.HandleFunc("/jobs", api.GetJobsHandler(ctx)).Methods("GET")
+	router.HandleFunc("/jobs", api.GetJobsHandler)
 	return api
 }

--- a/api/api.go
+++ b/api/api.go
@@ -21,6 +21,6 @@ func Setup(ctx context.Context, router *mux.Router, jobStore store.JobStore) *Jo
 
 	router.HandleFunc("/jobs", api.CreateJobHandler(ctx)).Methods("POST")
 	router.HandleFunc("/jobs/{id}", api.GetJobHandler(ctx)).Methods("GET")
-	//router.HandleFunc("/jobs", api.GetJobsHandler(ctx)).Methods("GET")
+	router.HandleFunc("/jobs", api.GetJobsHandler(ctx)).Methods("GET")
 	return api
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,6 +20,7 @@ func TestSetup(t *testing.T) {
 		Convey("When created the following routes should have been added", func() {
 			So(hasRoute(api.Router, "/jobs", "POST"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/jobs/{id}", "GET"), ShouldBeTrue)
+			So(hasRoute(api.Router, "/jobs", "GET"), ShouldBeTrue)
 		})
 	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2,12 +2,12 @@ package api
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-search-reindex-api/store"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-search-reindex-api/store"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
+	"net/http/httptest"
 )
 
 func TestSetup(t *testing.T) {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -88,35 +88,34 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 	}
 }
 
-//GetJobsHandler returns a function that gets a list of existing Job resources, from the Job Store, sorted by
-//their values of last_updated time (ascending).
-func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
-	log.Event(ctx, "Creating handler function, which calls GetJobs and returns a list of existing Job resources held in the JobStore.", log.INFO)
-	return func(w http.ResponseWriter, req *http.Request) {
-		ctx := req.Context()
+//GetJobsHandler gets a list of existing Job resources, from the Job Store, sorted by their values of
+//last_updated time (ascending).
+func (api *JobStoreAPI) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	log.Event(ctx, "Entering handler function, which calls GetJobs and returns a list of existing Job resources held in the JobStore.", log.INFO)
 
-		//get jobs from jobStore
-		jobs, err := api.jobStore.GetJobs(ctx, sync_mux)
-		if err != nil {
-			log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
-			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		jsonResponse, err := json.Marshal(jobs)
-		if err != nil {
-			log.Event(ctx, "marshalling response failed", log.Error(err), log.ERROR)
-			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		_, err = w.Write(jsonResponse)
-		if err != nil {
-			log.Event(ctx, "writing response failed", log.Error(err), log.ERROR)
-			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
-			return
-		}
+	//get jobs from jobStore
+	jobs, err := api.jobStore.GetJobs(ctx, sync_mux)
+	if err != nil {
+		log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
 	}
+
+	w.Header().Set("Content-Type", "application/json")
+	jsonResponse, err := json.Marshal(jobs)
+	if err != nil {
+		log.Event(ctx, "marshalling response failed", log.Error(err), log.ERROR)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(jsonResponse)
+	if err != nil {
+		log.Event(ctx, "writing response failed", log.Error(err), log.ERROR)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	"encoding/json"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -17,7 +17,7 @@ var NewID = func() string {
 
 // CreateJobHandler returns a function that generates a new Job resource containing default values in its fields.
 func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
-	log.Event(ctx, "Entering CreateJobHandler function, which generates a new Job resource.", log.INFO)
+	log.Event(ctx, "Creating handler function, which calls CreateJob and returns a new Job resource.", log.INFO)
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
@@ -51,7 +51,7 @@ func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
 
 //GetJobHandler returns a function that gets an existing Job resource, from the Job Store, that's associated with the id passed in.
 func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
-	log.Event(ctx, "Entering GetJobHandler function, which returns an existing Job resource associated with the supplied id.", log.INFO)
+	log.Event(ctx, "Creating handler function, which calls GetJob and returns an existing Job resource associated with the supplied id.", log.INFO)
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		vars := mux.Vars(req)
@@ -87,7 +87,7 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 //GetJobsHandler returns a function that gets a list of existing Job resources, from the Job Store, sorted by
 //their values of last_updated time (ascending).
 func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
-	log.Event(ctx, "Entering GetJobsHandler function, which returns a list of existing Job resources held in the JobStore.", log.INFO)
+	log.Event(ctx, "Creating handler function, which calls GetJobs and returns a list of existing Job resources held in the JobStore.", log.INFO)
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -83,13 +83,8 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 	}
 }
 
-//GetJobsHandler returns a function that gets a list of existing Job resources, from the Job Store, as defined by the four query parameters passed in.
-//Those query parameters are named limit, offset, sort, and state. They are described as follows:
-//limit - The maximum number of Job resources we're returning in this Jobs resource. The default limit is 20.
-//offset - The number of Job objects into the full list that this particular response is starting at. The default number to start at is 0.
-//sort - The sort order in which to return a list of reindex job resources. This defaults to last_updated in ascending order.
-//state - Filter option to bring back specific Job objects according to their state.
-//This will be a list of comma separated values that correspond to state enum values e.g. "created,failed".
+//GetJobsHandler returns a function that gets a list of existing Job resources, from the Job Store, sorted by
+//their values of last_updated time (ascending).
 func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
 	log.Event(ctx, "Entering GetJobsHandler function, which returns a list of existing Job resources held in the JobStore.", log.INFO)
 	return func(w http.ResponseWriter, req *http.Request) {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -96,7 +96,7 @@ func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
 		ctx := req.Context()
 
 		//get jobs from jobStore
-		jobs, err := api.jobStore.GetJobs(ctx)
+		jobs, err := api.jobStore.GetJobs(ctx, sync_mux)
 		if err != nil {
 			log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
 			http.Error(w, serverErrorMessage, http.StatusInternalServerError)

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -15,6 +15,8 @@ var NewID = func() string {
 	return uuid.NewV4().String()
 }
 
+var serverErrorMessage = "internal server error"
+
 // CreateJobHandler returns a function that generates a new Job resource containing default values in its fields.
 func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
 	log.Event(ctx, "Creating handler function, which calls CreateJob and returns a new Job resource.", log.INFO)
@@ -27,7 +29,7 @@ func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
 		newJob, err := api.jobStore.CreateJob(ctx, id)
 		if err != nil {
 			log.Event(ctx, "creating and storing job failed", log.Error(err), log.ERROR)
-			http.Error(w, "Failed to create and store job", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 
@@ -35,7 +37,7 @@ func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
 		jsonResponse, err := json.Marshal(newJob)
 		if err != nil {
 			log.Event(ctx, "marshalling response failed", log.Error(err), log.ERROR)
-			http.Error(w, "Failed to marshall json response", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 
@@ -43,7 +45,7 @@ func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
 		_, err = w.Write(jsonResponse)
 		if err != nil {
 			log.Event(ctx, "writing response failed", log.Error(err), log.ERROR)
-			http.Error(w, "Failed to write http response", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 	}
@@ -70,7 +72,7 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 		jsonResponse, err := json.Marshal(job)
 		if err != nil {
 			log.Event(ctx, "marshalling response failed", log.Error(err), logData, log.ERROR)
-			http.Error(w, "Failed to marshall json response", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 
@@ -78,7 +80,7 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 		_, err = w.Write(jsonResponse)
 		if err != nil {
 			log.Event(ctx, "writing response failed", log.Error(err), logData, log.ERROR)
-			http.Error(w, "Failed to write http response", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 	}
@@ -95,7 +97,7 @@ func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
 		jobs, err := api.jobStore.GetJobs(ctx)
 		if err != nil {
 			log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
-			http.Error(w, "Failed to get list of jobs from job store", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 
@@ -103,7 +105,7 @@ func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
 		jsonResponse, err := json.Marshal(jobs)
 		if err != nil {
 			log.Event(ctx, "marshalling response failed", log.Error(err), log.ERROR)
-			http.Error(w, "Failed to marshall json response", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 
@@ -111,7 +113,7 @@ func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
 		_, err = w.Write(jsonResponse)
 		if err != nil {
 			log.Event(ctx, "writing response failed", log.Error(err), log.ERROR)
-			http.Error(w, "Failed to write http response", http.StatusInternalServerError)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 	}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -91,32 +91,32 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 //state - Filter option to bring back specific Job objects according to their state.
 //This will be a list of comma separated values that correspond to state enum values e.g. "created,failed".
 func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
-	log.Event(ctx, "Entering GetJobHandler function, which returns an existing Job resource associated with the supplied id.", log.INFO)
+	log.Event(ctx, "Entering GetJobsHandler function, which returns a list of existing Job resources held in the JobStore.", log.INFO)
 	return func(w http.ResponseWriter, req *http.Request) {
-		//ctx := req.Context()
+		ctx := req.Context()
 
-		// get all jobs from jobStore and sort them by last_updated in ascending order
-		//job, err := api.jobStore.GetJobs(req.Context())
-		//if err != nil {
-		//	log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
-		//	//http.Error(w, "Failed to find job in job store", http.StatusNotFound)
-		//	return
-		//}
-		//
-		//w.Header().Set("Content-Type", "application/json")
-		//jsonResponse, err := json.Marshal(job)
-		//if err != nil {
-		//	log.Event(ctx, "marshalling response failed", log.Error(err), log.ERROR)
-		//	http.Error(w, "Failed to marshall json response", http.StatusInternalServerError)
-		//	return
-		//}
-		//
-		//w.WriteHeader(http.StatusOK)
-		//_, err = w.Write(jsonResponse)
-		//if err != nil {
-		//	log.Event(ctx, "writing response failed", log.Error(err), log.ERROR)
-		//	http.Error(w, "Failed to write http response", http.StatusInternalServerError)
-		//	return
-		//}
+		//get jobs from jobStore
+		jobs, err := api.jobStore.GetJobs(ctx)
+		if err != nil {
+			log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
+			//http.Error(w, "Failed to find job in job store", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		jsonResponse, err := json.Marshal(jobs)
+		if err != nil {
+			log.Event(ctx, "marshalling response failed", log.Error(err), log.ERROR)
+			http.Error(w, "Failed to marshall json response", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(jsonResponse)
+		if err != nil {
+			log.Event(ctx, "writing response failed", log.Error(err), log.ERROR)
+			http.Error(w, "Failed to write http response", http.StatusInternalServerError)
+			return
+		}
 	}
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -82,3 +82,41 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 		}
 	}
 }
+
+//GetJobsHandler returns a function that gets a list of existing Job resources, from the Job Store, as defined by the four query parameters passed in.
+//Those query parameters are named limit, offset, sort, and state. They are described as follows:
+//limit - The maximum number of Job resources we're returning in this Jobs resource. The default limit is 20.
+//offset - The number of Job objects into the full list that this particular response is starting at. The default number to start at is 0.
+//sort - The sort order in which to return a list of reindex job resources. This defaults to last_updated in ascending order.
+//state - Filter option to bring back specific Job objects according to their state.
+//This will be a list of comma separated values that correspond to state enum values e.g. "created,failed".
+func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
+	log.Event(ctx, "Entering GetJobHandler function, which returns an existing Job resource associated with the supplied id.", log.INFO)
+	return func(w http.ResponseWriter, req *http.Request) {
+		//ctx := req.Context()
+
+		// get all jobs from jobStore and sort them by last_updated in ascending order
+		//job, err := api.jobStore.GetJobs(req.Context())
+		//if err != nil {
+		//	log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
+		//	//http.Error(w, "Failed to find job in job store", http.StatusNotFound)
+		//	return
+		//}
+		//
+		//w.Header().Set("Content-Type", "application/json")
+		//jsonResponse, err := json.Marshal(job)
+		//if err != nil {
+		//	log.Event(ctx, "marshalling response failed", log.Error(err), log.ERROR)
+		//	http.Error(w, "Failed to marshall json response", http.StatusInternalServerError)
+		//	return
+		//}
+		//
+		//w.WriteHeader(http.StatusOK)
+		//_, err = w.Write(jsonResponse)
+		//if err != nil {
+		//	log.Event(ctx, "writing response failed", log.Error(err), log.ERROR)
+		//	http.Error(w, "Failed to write http response", http.StatusInternalServerError)
+		//	return
+		//}
+	}
+}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -99,7 +99,7 @@ func (api *JobStoreAPI) GetJobsHandler(ctx context.Context) http.HandlerFunc {
 		jobs, err := api.jobStore.GetJobs(ctx)
 		if err != nil {
 			log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
-			//http.Error(w, "Failed to find job in job store", http.StatusNotFound)
+			http.Error(w, "Failed to get list of jobs from job store", http.StatusInternalServerError)
 			return
 		}
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -24,6 +24,7 @@ const (
 	testJobID1 = "UUID1"
 	testJobID2 = "UUID2"
 	emptyJobID = ""
+	expectedServerErrorMsg = "internal server error"
 )
 
 var ctx = context.Background()
@@ -145,7 +146,7 @@ func TestCreateJobHandlerWithInvalidID(t *testing.T) {
 			Convey("Then an empty search reindex job is returned with status code 500", func() {
 				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
 				errMsg := strings.TrimSpace(resp.Body.String())
-				So(errMsg, ShouldEqual, "Failed to create and store job")
+				So(errMsg, ShouldEqual, expectedServerErrorMsg)
 			})
 		})
 	})
@@ -274,7 +275,7 @@ func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 			Convey("Then a jobs resource is returned with status code 500", func() {
 				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
 				errMsg := strings.TrimSpace(resp.Body.String())
-				So(errMsg, ShouldEqual, "Failed to get list of jobs from job store")
+				So(errMsg, ShouldEqual, expectedServerErrorMsg)
 			})
 		})
 	})

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -157,7 +157,7 @@ func TestGetJobsHandler(t *testing.T) {
 	t.Parallel()
 	Convey("Given a Search Reindex Job API that returns a list of jobs", t, func() {
 		jobStoreMock := &mock.JobStoreMock{
-			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, mux *sync.Mutex) (models.Jobs, error) {
 				jobs := models.Jobs{}
 				jobsList := make([]models.Job, 2)
 
@@ -224,7 +224,7 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 	Convey("Given a Search Reindex Job API that returns an empty list of jobs", t, func() {
 
 		jobStoreMock := &mock.JobStoreMock{
-			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, mux *sync.Mutex) (models.Jobs, error) {
 				jobs := models.Jobs{}
 
 				return jobs, nil
@@ -258,7 +258,7 @@ func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 	t.Parallel()
 	Convey("Given a Search Reindex Job API that generates an internal server error", t, func() {
 		jobStoreMock := &mock.JobStoreMock{
-			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, mux *sync.Mutex) (models.Jobs, error) {
 				jobs := models.Jobs{}
 
 				return jobs, errors.New("something went wrong in the server")

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -164,7 +164,7 @@ func TestGetJobsHandler(t *testing.T) {
 				jobsList[0] = models.NewJob(testJobID1)
 				jobsList[1] = models.NewJob(testJobID2)
 
-				jobs.Job_List = jobsList
+				jobs.JobList = jobsList
 
 				return jobs, nil
 			},
@@ -189,7 +189,7 @@ func TestGetJobsHandler(t *testing.T) {
 				expectedJob2 := ExpectedJob(testJobID2, zeroTime, 0, zeroTime, zeroTime, zeroTime, "Default Search Index Name", "created", 0, 0)
 
 				Convey("And the returned list should contain expected jobs", func() {
-					returnedJobList := jobsReturned.Job_List
+					returnedJobList := jobsReturned.JobList
 					So(returnedJobList, ShouldHaveLength, 2)
 					returnedJob1 := returnedJobList[0]
 					So(returnedJob1.ID, ShouldEqual, expectedJob1.ID)
@@ -247,7 +247,7 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 				err = json.Unmarshal(payload, &jobsReturned)
 
 				Convey("And the returned jobs list should be empty", func() {
-					So(jobsReturned.Job_List, ShouldHaveLength, 0)
+					So(jobsReturned.JobList, ShouldHaveLength, 0)
 				})
 			})
 		})

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestGetJobHandler(t *testing.T) {
 	t.Parallel()
 	Convey("Given a Search Reindex Job API that returns specific jobs using their id as a key", t, func() {
 		jobStoreMock := &mock.JobStoreMock{
-			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
+			GetJobFunc: func(ctx context.Context, id string, mux *sync.Mutex) (models.Job, error) {
 				switch id {
 				case testJobID2:
 					return models.NewJob(testJobID2), nil

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -266,6 +266,8 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 
 func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 
+	t.Parallel()
+
 	Convey("Given a Search Reindex Job API that generates an internal server error", t, func() {
 
 		jobStoreMock := &mock.JobStoreMock{

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -28,12 +28,10 @@ const (
 var ctx = context.Background()
 
 func TestCreateJobHandlerWithValidID(t *testing.T) {
-
 	t.Parallel()
 	NewID = func() string { return testJobID1 }
 
 	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a map", t, func() {
-
 		api := Setup(ctx, mux.NewRouter(), &store.DataStore{})
 		createJobHandler := api.CreateJobHandler(ctx)
 
@@ -70,11 +68,8 @@ func TestCreateJobHandlerWithValidID(t *testing.T) {
 }
 
 func TestGetJobHandler(t *testing.T) {
-
 	t.Parallel()
-
 	Convey("Given a Search Reindex Job API that returns specific jobs using their id as a key", t, func() {
-
 		jobStoreMock := &mock.JobStoreMock{
 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
 				switch id {
@@ -135,9 +130,7 @@ func TestGetJobHandler(t *testing.T) {
 }
 
 func TestCreateJobHandlerWithInvalidID(t *testing.T) {
-
 	NewID = func() string { return emptyJobID }
-
 	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a map", t, func() {
 		api := Setup(ctx, mux.NewRouter(), &store.DataStore{})
 		createJobHandler := api.CreateJobHandler(ctx)
@@ -158,11 +151,8 @@ func TestCreateJobHandlerWithInvalidID(t *testing.T) {
 }
 
 func TestGetJobsHandler(t *testing.T) {
-
 	t.Parallel()
-
 	Convey("Given a Search Reindex Job API that returns a list of jobs", t, func() {
-
 		jobStoreMock := &mock.JobStoreMock{
 			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
 				jobs := models.Jobs{}
@@ -227,9 +217,7 @@ func TestGetJobsHandler(t *testing.T) {
 }
 
 func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
-
 	t.Parallel()
-
 	Convey("Given a Search Reindex Job API that returns an empty list of jobs", t, func() {
 
 		jobStoreMock := &mock.JobStoreMock{
@@ -265,11 +253,8 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 }
 
 func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
-
 	t.Parallel()
-
 	Convey("Given a Search Reindex Job API that generates an internal server error", t, func() {
-
 		jobStoreMock := &mock.JobStoreMock{
 			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
 				jobs := models.Jobs{}

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -256,7 +256,7 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 
 func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 	t.Parallel()
-	Convey("Given a Search Reindex Job API that generates an internal server error", t, func() {
+	Convey("Given a Search Reindex Job API that that failed to connect to the Job Store", t, func() {
 		jobStoreMock := &mock.JobStoreMock{
 			GetJobsFunc: func(ctx context.Context, mux *sync.Mutex) (models.Jobs, error) {
 				jobs := models.Jobs{}

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -21,9 +21,9 @@ import (
 
 // Constants for testing
 const (
-	testJobID1 = "UUID1"
-	testJobID2 = "UUID2"
-	emptyJobID = ""
+	testJobID1             = "UUID1"
+	testJobID2             = "UUID2"
+	emptyJobID             = ""
 	expectedServerErrorMsg = "internal server error"
 )
 

--- a/api/mock/job_store.go
+++ b/api/mock/job_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/store"
+	"sync"
 )
 
 // Ensure, that JobStoreMock does implement api.JobStore.
@@ -12,10 +13,10 @@ var _ store.JobStore = &JobStoreMock{}
 
 type JobStoreMock struct {
 	// CreateJobFunc mocks the CreateJob method.
-	CreateJobFunc func(ctx context.Context, id string) (models.Job, error)
+	CreateJobFunc func(ctx context.Context, id string, mux *sync.Mutex) (models.Job, error)
 
 	// GetJobFunc mocks the GetJob method.
-	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
+	GetJobFunc func(ctx context.Context, id string, mux *sync.Mutex) (models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
 	GetJobsFunc func(ctx context.Context) (models.Jobs, error)
@@ -28,6 +29,8 @@ type JobStoreMock struct {
 			Ctx context.Context
 			// ID is the id argument value.
 			ID string
+			// Mux is the mux argument value.
+			Mux *sync.Mutex
 		}
 		// GetJob holds details about calls to the GetJob method.
 		GetJob []struct {
@@ -35,6 +38,8 @@ type JobStoreMock struct {
 			Ctx context.Context
 			// ID is the id argument value.
 			ID string
+			// Mux is the mux argument value.
+			Mux *sync.Mutex
 		}
 		// GetJobs holds details about calls to the GetJobs method.
 		GetJobs []struct {
@@ -45,35 +50,39 @@ type JobStoreMock struct {
 }
 
 // CreateJob calls CreateJobFunc.
-func (mock *JobStoreMock) CreateJob(ctx context.Context, id string) (job models.Job, err error) {
+func (mock *JobStoreMock) CreateJob(ctx context.Context, id string, mux *sync.Mutex) (job models.Job, err error) {
 	if mock.CreateJobFunc == nil {
 		panic("JobStoreMock.CreateJobFunc: method is nil but CreateJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 		ID  string
+		Mux *sync.Mutex
 	}{
 		Ctx: ctx,
 		ID:  id,
+		Mux: mux,
 	}
 	mock.calls.CreateJob = append(mock.calls.CreateJob, callInfo)
-	return mock.CreateJobFunc(ctx, id)
+	return mock.CreateJobFunc(ctx, id, mux)
 }
 
 // GetJob calls GetJobFunc.
-func (mock *JobStoreMock) GetJob(ctx context.Context, id string) (job models.Job, err error) {
+func (mock *JobStoreMock) GetJob(ctx context.Context, id string, mux *sync.Mutex) (job models.Job, err error) {
 	if mock.GetJobFunc == nil {
 		panic("JobStoreMock.GetJobFunc: method is nil but GetJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 		ID  string
+		Mux *sync.Mutex
 	}{
 		Ctx: ctx,
 		ID:  id,
+		Mux: mux,
 	}
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
-	return mock.GetJobFunc(ctx, id)
+	return mock.GetJobFunc(ctx, id, mux)
 }
 
 // GetJobs calls GetJobsFunc.

--- a/api/mock/job_store.go
+++ b/api/mock/job_store.go
@@ -11,7 +11,6 @@ import (
 var _ store.JobStore = &JobStoreMock{}
 
 type JobStoreMock struct {
-
 	// CreateJobFunc mocks the CreateJob method.
 	CreateJobFunc func(ctx context.Context, id string) (models.Job, error)
 

--- a/api/mock/job_store.go
+++ b/api/mock/job_store.go
@@ -19,7 +19,7 @@ type JobStoreMock struct {
 	GetJobFunc func(ctx context.Context, id string, mux *sync.Mutex) (models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
-	GetJobsFunc func(ctx context.Context) (models.Jobs, error)
+	GetJobsFunc func(ctx context.Context, mux *sync.Mutex) (models.Jobs, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -45,6 +45,8 @@ type JobStoreMock struct {
 		GetJobs []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// Mux is the mux argument value.
+			Mux *sync.Mutex
 		}
 	}
 }
@@ -86,15 +88,17 @@ func (mock *JobStoreMock) GetJob(ctx context.Context, id string, mux *sync.Mutex
 }
 
 // GetJobs calls GetJobsFunc.
-func (mock *JobStoreMock) GetJobs(ctx context.Context) (job models.Jobs, err error) {
+func (mock *JobStoreMock) GetJobs(ctx context.Context, mux *sync.Mutex) (job models.Jobs, err error) {
 	if mock.GetJobsFunc == nil {
 		panic("JobStoreMock.GetJobFunc: method is nil but GetJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
+		Mux *sync.Mutex
 	}{
 		Ctx: ctx,
+		Mux: mux,
 	}
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	return mock.GetJobsFunc(ctx)
+	return mock.GetJobsFunc(ctx, mux)
 }

--- a/api/mock/job_store.go
+++ b/api/mock/job_store.go
@@ -18,6 +18,9 @@ type JobStoreMock struct {
 	// GetJobFunc mocks the GetJob method.
 	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
 
+	// GetJobsFunc mocks the GetJobs method.
+	GetJobsFunc func(ctx context.Context) (models.Jobs, error)
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// CreateJob holds details about calls to the CreateJob method.
@@ -33,6 +36,11 @@ type JobStoreMock struct {
 			Ctx context.Context
 			// ID is the id argument value.
 			ID string
+		}
+		// GetJobs holds details about calls to the GetJobs method.
+		GetJobs []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 		}
 	}
 }
@@ -67,4 +75,18 @@ func (mock *JobStoreMock) GetJob(ctx context.Context, id string) (job models.Job
 	}
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
 	return mock.GetJobFunc(ctx, id)
+}
+
+// GetJobs calls GetJobsFunc.
+func (mock *JobStoreMock) GetJobs(ctx context.Context) (job models.Jobs, err error) {
+	if mock.GetJobsFunc == nil {
+		panic("JobStoreMock.GetJobFunc: method is nil but GetJob was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
+	return mock.GetJobsFunc(ctx)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,6 @@ func TestConfig(t *testing.T) {
 		})
 
 		Convey("When the config values are retrieved", func() {
-
 			Convey("Then there should be no error returned, and values are as expected", func() {
 				configuration, err = Get() // This Get() is only called once, when inside this function
 				So(err, ShouldBeNil)

--- a/features/getting_jobs.feature
+++ b/features/getting_jobs.feature
@@ -1,0 +1,24 @@
+Feature: Getting a list of jobs
+
+  Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
+
+    Given I have generated three jobs in the Job Store
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three jobs returned in a list
+    And in each job I would expect id, last_updated, and links to have this structure
+      | id           | UUID                                   |
+      | last_updated | Not in the future                      |
+      | links: tasks | http://localhost:12150/jobs/{id}/tasks |
+      | links: self  | http://localhost:12150/jobs/{id}       |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | search_index_name               | Default Search Index Name |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first

--- a/features/getting_jobs.feature
+++ b/features/getting_jobs.feature
@@ -6,7 +6,7 @@ Feature: Getting a list of jobs
     When I GET "/jobs"
     """
     """
-    Then I would expect there to be three jobs returned in a list
+    Then I would expect there to be three or more jobs returned in a list
     And in each job I would expect id, last_updated, and links to have this structure
       | id           | UUID                                   |
       | last_updated | Not in the future                      |

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -140,9 +140,9 @@ func (f *JobsFeature) iWouldExpectIdLast_updatedAndLinksToHaveThisStructure(tabl
 	lastUpdated := response.LastUpdated
 	links := response.Links
 
-	err2 := f.checkStructure(err, id, lastUpdated, expectedResult, links)
-	if err2 != nil {
-		return err2
+	err = f.checkStructure(id, lastUpdated, expectedResult, links)
+	if err != nil {
+		return err
 	}
 
 	return f.ErrorFeature.StepError()
@@ -150,8 +150,8 @@ func (f *JobsFeature) iWouldExpectIdLast_updatedAndLinksToHaveThisStructure(tabl
 
 //checkStructure is a utility method that can be called by a feature step to assert that a job contains the expected structure in its values of
 //id, last_updated, and links. It confirms that last_updated is a current or past time, and that the tasks and self links have the correct paths.
-func (f *JobsFeature) checkStructure(err error, id string, lastUpdated time.Time, expectedResult map[string]string, links *models.JobLinks) error {
-	_, err = uuid.FromString(id)
+func (f *JobsFeature) checkStructure(id string, lastUpdated time.Time, expectedResult map[string]string, links *models.JobLinks) error {
+	_, err := uuid.FromString(id)
 	if err != nil {
 		fmt.Println("Got uuid: " + id)
 		return err
@@ -292,9 +292,9 @@ func (f *JobsFeature) inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStruc
 
 	for j := range response.JobList {
 		job := response.JobList[j]
-		err2 := f.checkStructure(err, job.ID, job.LastUpdated, expectedResult, job.Links)
-		if err2 != nil {
-			return err2
+		err := f.checkStructure(job.ID, job.LastUpdated, expectedResult, job.Links)
+		if err != nil {
+			return err
 		}
 
 	}

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -268,7 +268,7 @@ func (f *JobsFeature) iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() erro
 	if err != nil {
 		return err
 	}
-	numJobsFound := len(response.Job_List)
+	numJobsFound := len(response.JobList)
 	assert.True(&f.ErrorFeature, numJobsFound >= 3, "The list should contain three or more jobs but it only contains "+strconv.Itoa(numJobsFound))
 
 	return f.ErrorFeature.StepError()
@@ -290,8 +290,8 @@ func (f *JobsFeature) inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStruc
 		return err
 	}
 
-	for j := range response.Job_List {
-		job := response.Job_List[j]
+	for j := range response.JobList {
+		job := response.JobList[j]
 		err2 := f.checkStructure(err, job.ID, job.LastUpdated, expectedResult, job.Links)
 		if err2 != nil {
 			return err2
@@ -317,7 +317,7 @@ func (f *JobsFeature) eachJobShouldAlsoContainTheFollowingValues(table *godog.Ta
 		return err
 	}
 
-	for _, job := range response.Job_List {
+	for _, job := range response.JobList {
 		f.checkValuesInJob(expectedResult, job)
 	}
 
@@ -333,7 +333,7 @@ func (f *JobsFeature) theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst() e
 	if err != nil {
 		return err
 	}
-	job_list := response.Job_List
+	job_list := response.JobList
 	timeToCheck := job_list[0].LastUpdated
 
 	for j := 1; j < len(job_list); j++ {

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"io/ioutil"
+	"net/http"
+
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-search-reindex-api/config"
@@ -21,8 +24,6 @@ import (
 	"github.com/rdumont/assistdog"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"net/http"
 )
 
 //JobsFeature is a type that contains all the requirements for running a godog (cucumber) feature that tests the /jobs endpoint.
@@ -252,7 +253,7 @@ func (f *JobsFeature) iHaveGeneratedThreeJobsInTheJobStore() error {
 
 //iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList is a feature step that can be defined for a specific JobsFeature.
 //It checks the response from calling GET /jobs to make sure that a list containing three or more jobs has been returned.
-func (f *JobsFeature)iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() error {
+func (f *JobsFeature) iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() error {
 	f.responseBody, _ = ioutil.ReadAll(f.ApiFeature.HttpResponse.Body)
 
 	var response models.Jobs
@@ -260,8 +261,8 @@ func (f *JobsFeature)iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() error
 	if err != nil {
 		return err
 	}
-
-	assert.True(&f.ErrorFeature, len(response.Job_List) >= 3, "The list correctly contains three or more jobs.")
+	numJobsFound := len(response.Job_List)
+	assert.True(&f.ErrorFeature, numJobsFound >= 3, "The list should contain three or more jobs but it only contains "+strconv.Itoa(numJobsFound))
 
 	return f.ErrorFeature.StepError()
 }
@@ -269,7 +270,7 @@ func (f *JobsFeature)iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() error
 //inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStructure is a feature step that can be defined for a specific JobsFeature.
 //It checks the response from calling GET /jobs to make sure that each job contains the expected types of values of id,
 //last_updated, and links.
-func (f *JobsFeature)inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStructure(table *godog.Table) error {
+func (f *JobsFeature) inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStructure(table *godog.Table) error {
 	assist := assistdog.NewDefault()
 	expectedResult, err := assist.ParseMap(table)
 	if err != nil {

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -75,6 +75,7 @@ func (f *JobsFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the response should also contain the following values:$`, f.theResponseShouldAlsoContainTheFollowingValues)
 	ctx.Step(`^I have generated a job in the Job Store$`, f.iHaveGeneratedAJobInTheJobStore)
 	ctx.Step(`^I call GET \/jobs\/{id} using the generated id$`, f.iCallGETJobsidUsingTheGeneratedId)
+	ctx.Step(`^I have generated three jobs in the Job Store$`, f.iHaveGeneratedThreeJobsInTheJobStore)
 }
 
 //Reset sets the resources within a specific JobsFeature back to their default values.
@@ -179,13 +180,17 @@ func (f *JobsFeature) theResponseShouldAlsoContainTheFollowingValues(table *godo
 //The newly created job resource is stored in the Job Store and also returned in the response body.
 func (f *JobsFeature) iHaveGeneratedAJobInTheJobStore() error {
 	//call POST /jobs
+	f.callPostJobs()
+
+	return f.ErrorFeature.StepError()
+}
+
+func (f *JobsFeature) callPostJobs() {
 	var emptyBody = godog.DocString{}
 	err := f.ApiFeature.IPostToWithBody("/jobs", &emptyBody)
 	if err != nil {
 		os.Exit(1)
 	}
-
-	return f.ErrorFeature.StepError()
 }
 
 //iCallGETJobsidUsingTheGeneratedId is a feature step that can be defined for a specific JobsFeature.
@@ -211,6 +216,17 @@ func (f *JobsFeature) iCallGETJobsidUsingTheGeneratedId() error {
 	if err != nil {
 		os.Exit(1)
 	}
+
+	return f.ErrorFeature.StepError()
+}
+
+//iHaveGeneratedThreeJobsInTheJobStore is a feature step that can be defined for a specific JobsFeature.
+//It calls POST /jobs with an empty body, three times, which causes three default job resources to be generated.
+func (f *JobsFeature) iHaveGeneratedThreeJobsInTheJobStore() error {
+	//call POST /jobs three times
+	f.callPostJobs()
+	f.callPostJobs()
+	f.callPostJobs()
 
 	return f.ErrorFeature.StepError()
 }

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -332,19 +332,17 @@ func (f *JobsFeature) theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst() e
 		return err
 	}
 	job_list := response.Job_List
-	//job_list[0].LastUpdated = time.Date(2022, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	timeToCheck := job_list[0].LastUpdated
 
-	for j := range job_list {
-		if j + 1 == len(job_list) {
-			break
-		}
+	j := 0
+	for j < (len(job_list) - 1) {
 		index := strconv.Itoa(j)
-		nextIndex := strconv.Itoa(j+1)
-		nextTime := job_list[j + 1].LastUpdated
+		nextIndex := strconv.Itoa(j + 1)
+		nextTime := job_list[j+1].LastUpdated
 		assert.True(&f.ErrorFeature, timeToCheck.Before(nextTime),
-			"The value of last_updated at job_list[" + index + "] should be earlier than that at job_list[" + nextIndex + "]")
+			"The value of last_updated at job_list["+index+"] should be earlier than that at job_list["+nextIndex+"]")
 		timeToCheck = nextTime
+		j++
 	}
 	return f.ErrorFeature.StepError()
 }

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -312,10 +312,12 @@ func (f *JobsFeature) eachJobShouldAlsoContainTheFollowingValues(table *godog.Ta
 	}
 	var response models.Jobs
 
-	_ = json.Unmarshal(f.responseBody, &response)
+	err = json.Unmarshal(f.responseBody, &response)
+	if err != nil {
+		return err
+	}
 
-	for j := range response.Job_List {
-		job := response.Job_List[j]
+	for _, job := range response.Job_List {
 		f.checkValuesInJob(expectedResult, job)
 	}
 
@@ -334,15 +336,13 @@ func (f *JobsFeature) theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst() e
 	job_list := response.Job_List
 	timeToCheck := job_list[0].LastUpdated
 
-	j := 0
-	for j < (len(job_list) - 1) {
-		index := strconv.Itoa(j)
-		nextIndex := strconv.Itoa(j + 1)
-		nextTime := job_list[j+1].LastUpdated
+	for j := 1; j < len(job_list); j++ {
+		index := strconv.Itoa(j-1)
+		nextIndex := strconv.Itoa(j)
+		nextTime := job_list[j].LastUpdated
 		assert.True(&f.ErrorFeature, timeToCheck.Before(nextTime),
 			"The value of last_updated at job_list["+index+"] should be earlier than that at job_list["+nextIndex+"]")
 		timeToCheck = nextTime
-		j++
 	}
 	return f.ErrorFeature.StepError()
 }

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -308,7 +308,7 @@ func (f *JobsFeature) inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStruc
 func (f *JobsFeature) eachJobShouldAlsoContainTheFollowingValues(table *godog.Table) error {
 	expectedResult, err := assistdog.NewDefault().ParseMap(table)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	var response models.Jobs
 

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -337,7 +337,7 @@ func (f *JobsFeature) theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst() e
 	timeToCheck := job_list[0].LastUpdated
 
 	for j := 1; j < len(job_list); j++ {
-		index := strconv.Itoa(j-1)
+		index := strconv.Itoa(j - 1)
 		nextIndex := strconv.Itoa(j)
 		nextTime := job_list[j].LastUpdated
 		assert.True(&f.ErrorFeature, timeToCheck.Before(nextTime),

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -161,13 +161,13 @@ func (f *JobsFeature) checkStructure(id string, lastUpdated time.Time, expectedR
 		return errors.New("expected LastUpdated to be now or earlier but it was: " + lastUpdated.String())
 	}
 
-	linksTasks := strings.Replace(expectedResult["links: tasks"], "{id}", id, 1)
+	expectedLinksTasks := strings.Replace(expectedResult["links: tasks"], "{id}", id, 1)
 
-	assert.Equal(&f.ErrorFeature, linksTasks, links.Tasks)
+	assert.Equal(&f.ErrorFeature, expectedLinksTasks, links.Tasks)
 
-	linksSelf := strings.Replace(expectedResult["links: self"], "{id}", id, 1)
+	expectedLinksSelf := strings.Replace(expectedResult["links: self"], "{id}", id, 1)
 
-	assert.Equal(&f.ErrorFeature, linksSelf, links.Self)
+	assert.Equal(&f.ErrorFeature, expectedLinksSelf, links.Self)
 	return nil
 }
 
@@ -212,12 +212,14 @@ func (f *JobsFeature) iHaveGeneratedAJobInTheJobStore() error {
 
 //callPostJobs is a utility method that can be called by a feature step in order to call the POST jobs/ endpoint
 //Calling that endpoint results in the creation of a job, in the Job Store, containing a unique id and default values.
-func (f *JobsFeature) callPostJobs() {
+func (f *JobsFeature) callPostJobs() error {
 	var emptyBody = godog.DocString{}
 	err := f.ApiFeature.IPostToWithBody("/jobs", &emptyBody)
 	if err != nil {
-		os.Exit(1)
+		return err
 	}
+
+	return err
 }
 
 //iCallGETJobsidUsingTheGeneratedId is a feature step that can be defined for a specific JobsFeature.
@@ -281,7 +283,7 @@ func (f *JobsFeature) inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStruc
 	assist := assistdog.NewDefault()
 	expectedResult, err := assist.ParseMap(table)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	var response models.Jobs
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rdumont/assistdog v0.0.0-20201106100018-168b06230d14
 	github.com/satori/go.uuid v1.2.0
-	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/text v0.3.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-search-reindex-api
 
-go 1.15
+go 1.16
 
 require (
 	github.com/ONSdigital/dp-component-test v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rdumont/assistdog v0.0.0-20201106100018-168b06230d14
 	github.com/satori/go.uuid v1.2.0
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/text v0.3.5 // indirect

--- a/models/job.go
+++ b/models/job.go
@@ -27,7 +27,7 @@ type JobLinks struct {
 
 //Jobs represents an array of Job resources and json representation for API
 type Jobs struct {
-	Job_List      []Job `json:"jobs"`
+	Job_List []Job `json:"jobs"`
 }
 
 //NewJob returns a new Job resource that it creates and populates with default values.

--- a/models/job.go
+++ b/models/job.go
@@ -27,7 +27,7 @@ type JobLinks struct {
 
 //Jobs represents an array of Job resources and json representation for API
 type Jobs struct {
-	Items      []Job `json:"items"`
+	Job_List      []Job `json:"jobs"`
 }
 
 //NewJob returns a new Job resource that it creates and populates with default values.

--- a/models/job.go
+++ b/models/job.go
@@ -25,11 +25,6 @@ type JobLinks struct {
 	Self  string `json:"self"`
 }
 
-//Jobs represents an array of Job resources and json representation for API
-type Jobs struct {
-	Job_List []Job `json:"jobs"`
-}
-
 //NewJob returns a new Job resource that it creates and populates with default values.
 func NewJob(id string) Job {
 	zeroTime := time.Time{}.UTC()

--- a/models/job.go
+++ b/models/job.go
@@ -25,6 +25,11 @@ type JobLinks struct {
 	Self  string `json:"self"`
 }
 
+//Jobs represents an array of Job resources and json representation for API
+type Jobs struct {
+	Items      []Job `json:"items"`
+}
+
 //NewJob returns a new Job resource that it creates and populates with default values.
 func NewJob(id string) Job {
 	zeroTime := time.Time{}.UTC()

--- a/models/jobs.go
+++ b/models/jobs.go
@@ -2,5 +2,5 @@ package models
 
 //Jobs represents an array of Job resources and json representation for API
 type Jobs struct {
-	Job_List []Job `json:"jobs"`
+	JobList []Job `json:"jobs"`
 }

--- a/models/jobs.go
+++ b/models/jobs.go
@@ -1,0 +1,6 @@
+package models
+
+//Jobs represents an array of Job resources and json representation for API
+type Jobs struct {
+	Job_List []Job `json:"jobs"`
+}

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -1,12 +1,10 @@
 package service
 
 import (
-	"net/http"
-
-	"github.com/ONSdigital/dp-search-reindex-api/config"
-
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
+	"net/http"
 )
 
 // ExternalServiceList holds the initialiser and initialisation state of external services.

--- a/service/service.go
+++ b/service/service.go
@@ -23,9 +23,7 @@ type Service struct {
 
 // Run the service
 func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceList, buildTime, gitCommit, version string, svcErrors chan error) (*Service, error) {
-
 	log.Event(ctx, "running service", log.INFO)
-
 	log.Event(ctx, "using service configuration", log.Data{"config": cfg}, log.INFO)
 
 	// Get HTTP Server and ... // ADD CODE: Add any middleware that your service requires

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -40,9 +40,7 @@ var funcDoGetHTTPServerNil = func(bindAddr string, router http.Handler) service.
 }
 
 func TestRun(t *testing.T) {
-
 	Convey("Having a set of mocked dependencies", t, func() {
-
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
 
@@ -79,7 +77,6 @@ func TestRun(t *testing.T) {
 		}
 
 		Convey("Given that initialising healthcheck returns an error", func() {
-
 			// setup (run before each `Convey` at this scope / indentation):
 			initMock := &serviceMock.InitialiserMock{
 				DoGetHTTPServerFunc:  funcDoGetHTTPServerNil,
@@ -100,7 +97,6 @@ func TestRun(t *testing.T) {
 		})
 
 		Convey("Given that all dependencies are successfully initialised", func() {
-
 			// setup (run before each `Convey` at this scope / indentation):
 			initMock := &serviceMock.InitialiserMock{
 				DoGetHTTPServerFunc:  funcDoGetHTTPServer,
@@ -165,7 +161,6 @@ func TestRun(t *testing.T) {
 		})*/
 
 		Convey("Given that all dependencies are successfully initialised but the http server fails", func() {
-
 			// setup (run before each `Convey` at this scope / indentation):
 			initMock := &serviceMock.InitialiserMock{
 				DoGetHealthCheckFunc: funcDoGetHealthcheckOk,
@@ -191,7 +186,6 @@ func TestRun(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-
 	Convey("Having a correctly initialised service", t, func() {
 
 		cfg, err := config.Get()
@@ -238,7 +232,6 @@ func TestClose(t *testing.T) {
 		})
 
 		Convey("If services fail to stop, the Close operation tries to close all dependencies and returns an error", func() {
-
 			failingserverMock := &mock.HTTPServerMock{
 				ListenAndServeFunc: func() error { return nil },
 				ShutdownFunc: func(ctx context.Context) error {

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -95,13 +95,13 @@ func (ds *DataStore) GetJob(ctx context.Context, id string) (models.Job, error) 
 //GetJobs gets a list of Job resources from the JobsMap. It will put all the Job resources into a list, sorted by their
 //last_updated time values, and return the list.
 func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
-	log.Event(ctx, "getting list of jobs")
+	log.Event(ctx, "getting list of jobs", log.INFO)
 
 	jobs := models.Jobs{}
 	numJobs := len(JobsMap)
 
 	if numJobs == 0 {
-		log.Event(ctx, "there are no jobs in the job store - so the list is empty")
+		log.Event(ctx, "there are no jobs in the job store - so the list is empty", log.INFO)
 		return jobs, nil
 	}
 
@@ -112,7 +112,7 @@ func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 	}
 	sort.Sort(jobsToSort)
 	jobs.Job_List = jobsToSort
-	log.Event(ctx, "list of jobs - sorted by last_updated", log.Data{"Sorted jobs: ": jobs.Job_List})
+	log.Event(ctx, "list of jobs - sorted by last_updated", log.Data{"Sorted jobs: ": jobs.Job_List}, log.INFO)
 
 	return jobs, nil
 }

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -113,11 +113,9 @@ func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 	for k := range JobsMap {
 		jobsToSort = append(jobsToSort, JobsMap[k])
 	}
-	log.Event(ctx, "unsorted jobs", log.Data{"Jobs to sort: ": jobsToSort})
 	sort.Sort(jobsToSort)
-	log.Event(ctx, "jobs sorted by last_updated", log.Data{"Sorted jobs: ": jobsToSort})
-
 	jobs.Job_List = jobsToSort
+	log.Event(ctx, "list of jobs - sorted by last_updated", log.Data{"Sorted jobs: ": jobs.Job_List})
 
 	return jobs, nil
 }

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -69,21 +69,27 @@ func (ds *DataStore) GetJob(ctx context.Context, id string) (models.Job, error) 
 //As a default it will return all Job resources sorted by their last_updated time value.
 func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 
-	//log.Event(ctx, "getting jobs", log.Data{"id": id})
-	log.Event(ctx, "getting jobs")
+	log.Event(ctx, "getting list of jobs")
 
-	//Create an empty list to put the Job resources into
-	jobsList := make([]models.Job, len(JobsMap))
+	jobs := models.Jobs{}
+	numJobs := len(JobsMap)
+
+	if numJobs == 0 {
+		log.Event(ctx, "there are no jobs in the job store - so the list is empty")
+		return jobs, nil
+	}
+
+	//Create an empty list, the same length as the JobsMap, to put the requested Job resources into
+	log.Event(ctx, "generating empty list")
+	jobsList := make([]models.Job, numJobs)
 
 	//Loop through the map and add each Job to the list
 	i := 0
 	for k := range JobsMap {
-		log.Event(ctx, "The value of JobsMap["+k+"]", log.Data{"Job details: ": JobsMap[k]})
+		log.Event(ctx, "adding job "+k+" to the list", log.Data{"JobsMap["+k+"]": JobsMap[k]})
 		jobsList[i] = JobsMap[k]
 		i++
 	}
-
-	jobs := models.Jobs{}
 
 	jobs.Job_List = jobsList
 

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -52,7 +52,6 @@ func (ds *DataStore) DeleteAllJobs(ctx context.Context) error {
 
 // CreateJob creates a new Job resource and stores it in the JobsMap.
 func (ds *DataStore) CreateJob(ctx context.Context, id string) (models.Job, error) {
-
 	log.Event(ctx, "creating job", log.Data{"id": id})
 
 	// If an empty id was passed in, return an error with a message.
@@ -76,7 +75,6 @@ func (ds *DataStore) CreateJob(ctx context.Context, id string) (models.Job, erro
 
 //GetJob gets a Job resource, from the JobsMap, that is associated with the id passed in.
 func (ds *DataStore) GetJob(ctx context.Context, id string) (models.Job, error) {
-
 	log.Event(ctx, "getting job", log.Data{"id": id})
 
 	// If an empty id was passed in, return an error with a message.
@@ -97,7 +95,6 @@ func (ds *DataStore) GetJob(ctx context.Context, id string) (models.Job, error) 
 //GetJobs gets a list of Job resources from the JobsMap. It will put all the Job resources into a list, sorted by their
 //last_updated time values, and return the list.
 func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
-
 	log.Event(ctx, "getting list of jobs")
 
 	jobs := models.Jobs{}

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -122,8 +122,8 @@ func (ds *DataStore) GetJobs(ctx context.Context, mux *sync.Mutex) (models.Jobs,
 	}
 	mux.Unlock()
 	sort.Sort(jobsToSort)
-	jobs.Job_List = jobsToSort
-	log.Event(ctx, "list of jobs - sorted by last_updated", log.Data{"Sorted jobs: ": jobs.Job_List}, log.INFO)
+	jobs.JobList = jobsToSort
+	log.Event(ctx, "list of jobs - sorted by last_updated", log.Data{"Sorted jobs: ": jobs.JobList}, log.INFO)
 
 	return jobs, nil
 }

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -86,7 +86,7 @@ func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 	//Loop through the map and add each Job to the list
 	i := 0
 	for k := range JobsMap {
-		log.Event(ctx, "adding job "+k+" to the list", log.Data{"JobsMap["+k+"]": JobsMap[k]})
+		log.Event(ctx, "adding job "+k+" to the list", log.Data{"JobsMap[" + k + "]": JobsMap[k]})
 		jobsList[i] = JobsMap[k]
 		i++
 	}

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -67,13 +67,13 @@ func (ds *DataStore) CreateJob(ctx context.Context, id string, mux *sync.Mutex) 
 
 	//Check that the JobsMap does not already contain the id as a key
 	mux.Lock()
+	defer mux.Unlock()
 	if _, idPresent := JobsMap[id]; idPresent {
 		return models.Job{}, errors.New("id must be unique")
 	}
 
 	JobsMap[id] = newJob
 	log.Event(ctx, "adding job to job store", log.Data{"Job details: ": JobsMap[id], "Map length: ": len(JobsMap)})
-	mux.Unlock()
 
 	return newJob, nil
 }
@@ -89,14 +89,13 @@ func (ds *DataStore) GetJob(ctx context.Context, id string, mux *sync.Mutex) (mo
 
 	//Check that the JobsMap contains the id as a key
 	mux.Lock()
+	defer mux.Unlock()
 	if _, idPresent := JobsMap[id]; idPresent == false {
-		mux.Unlock()
 		return models.Job{}, errors.New("the job store does not contain the job id entered")
 	}
 
 	job := JobsMap[id]
 	log.Event(ctx, "getting job from job store", log.Data{"Job details: ": JobsMap[id]})
-	mux.Unlock()
 
 	return job, nil
 }

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -78,7 +78,7 @@ func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 	//Loop through the map and add each Job to the list
 	i := 0
 	for k := range JobsMap {
-		log.Event(ctx, "The value of JobsMap[" + k + "]", log.Data{"Job details: ": JobsMap[k]})
+		log.Event(ctx, "The value of JobsMap["+k+"]", log.Data{"Job details: ": JobsMap[k]})
 		jobsList[i] = JobsMap[k]
 		i++
 	}

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -94,8 +94,8 @@ func (ds *DataStore) GetJob(ctx context.Context, id string) (models.Job, error) 
 	return job, nil
 }
 
-//GetJobs gets a list of Job resources, from the JobsMap, as defined by the four parameters passed in.
-//As a default it will return all Job resources sorted by their last_updated time value.
+//GetJobs gets a list of Job resources from the JobsMap. It will put all the Job resources into a list, sorted by their
+//last_updated time values, and return the list.
 func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 
 	log.Event(ctx, "getting list of jobs")

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -63,3 +63,29 @@ func (ds *DataStore) GetJob(ctx context.Context, id string) (models.Job, error) 
 	log.Event(ctx, "getting job from job store", log.Data{"Job details: ": JobsMap[id]})
 	return job, nil
 }
+
+//GetJobs gets a list of Job resources, from the JobsMap, as defined by the four parameters passed in.
+func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
+
+	//log.Event(ctx, "getting jobs", log.Data{"id": id})
+	log.Event(ctx, "getting jobs")
+
+	//Create an empty list to put the Job resources into
+	var jobsList []models.Job
+
+	//Loop through the map and add each Job to the list (for now just add the first two)
+	//jobsList[1] = JobsMap[0]
+	//jobsList[2] = JobsMap[1]
+	i := 0
+	for k := range JobsMap {
+		//fmt.Printf("key[%s] value[%s]\n", k, v)
+		jobsList[i] = JobsMap[k]
+		i++
+	}
+
+	jobs := models.Jobs{}
+
+	jobs.Items = jobsList
+
+	return jobs, nil
+}

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -23,22 +23,25 @@ type DataStore struct {
 //JobsMap is a map used for storing Job resources with the keys being string values.
 var JobsMap = make(map[string]models.Job)
 
-//LastUpdatedSlice is a type that implements the sort.Interface so that the jobs in it can be sorted using the generic Sort function.
+//LastUpdatedSlice is a type that implements the sort interface so that the jobs in it can be sorted using the generic Sort function.
 type LastUpdatedSlice []models.Job
 
+//Len is a function that's required by the sort interface.
 func (s LastUpdatedSlice) Len() int {
 	return len(s)
 }
 
+//Less is a function that's required by the sort interface.
 func (s LastUpdatedSlice) Less(i, j int) bool {
 	return s[i].LastUpdated.Before(s[j].LastUpdated)
 }
 
+//Swap is a function that's required by the sort interface.
 func (s LastUpdatedSlice) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-//DeleteAllJobs empties the JobStore by deleting everything from the JobsMap
+//DeleteAllJobs empties the JobStore by deleting everything from the JobsMap.
 func (ds *DataStore) DeleteAllJobs(ctx context.Context) error {
 	log.Event(ctx, "deleting all jobs from the job store")
 	for k := range JobsMap {

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -21,6 +21,15 @@ type DataStore struct {
 //JobsMap is a map used for storing Job resources with the keys being string values.
 var JobsMap = make(map[string]models.Job)
 
+//DeleteAllJobs empties the JobStore by deleting everything from the JobsMap
+func (ds *DataStore) DeleteAllJobs(ctx context.Context) error {
+	log.Event(ctx, "deleting all jobs from the job store")
+	for k := range JobsMap {
+		delete(JobsMap, k)
+	}
+	return nil
+}
+
 // CreateJob creates a new Job resource and stores it in the JobsMap.
 func (ds *DataStore) CreateJob(ctx context.Context, id string) (models.Job, error) {
 

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -3,8 +3,11 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	models "github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/log.go/log"
+	"sort"
+	"time"
 )
 
 type JobStore interface {
@@ -20,6 +23,20 @@ type DataStore struct {
 
 //JobsMap is a map used for storing Job resources with the keys being string values.
 var JobsMap = make(map[string]models.Job)
+
+type timeSlice []models.Job
+
+func (p timeSlice) Len() int {
+	return len(p)
+}
+
+func (p timeSlice) Less(i, j int) bool {
+	return p[i].LastUpdated.Before(p[j].LastUpdated)
+}
+
+func (p timeSlice) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
 
 //DeleteAllJobs empties the JobStore by deleting everything from the JobsMap
 func (ds *DataStore) DeleteAllJobs(ctx context.Context) error {
@@ -88,6 +105,25 @@ func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 		return jobs, nil
 	}
 
+	//Use a temporary map to order the jobs by last_updated in ascending order (i.e. oldest first)
+	//Start by adding all the jobs from the JobsMap into the tempMap using last_updated as the key
+	//tempMap := make(map[time.Time]models.Job)
+	//ds.MoveJobs(ctx, tempMap)
+
+	//Then delete everything from JobsMap
+	//ds.DeleteAllJobs()
+
+	//Use a sorted slice of last_updated times to put the jobs back into JobsMap but in last_updated order
+	jobsToSort := make(timeSlice, 0, len(JobsMap))
+	for k := range JobsMap {
+		jobsToSort = append(jobsToSort, JobsMap[k])
+	}
+	fmt.Println("before...")
+	fmt.Println(jobsToSort)
+	sort.Sort(jobsToSort)
+	fmt.Println("after...")
+	fmt.Println(jobsToSort)
+
 	//Create an empty list, the same length as the JobsMap, to put the requested Job resources into
 	log.Event(ctx, "generating empty list")
 	jobsList := make([]models.Job, numJobs)
@@ -103,4 +139,13 @@ func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 	jobs.Job_List = jobsList
 
 	return jobs, nil
+}
+
+//moveJobs moves all the jobs from the JobsMap into the tempMap, which uses last_updated as its key
+func (ds *DataStore) MoveJobs(ctx context.Context, tempMap map[time.Time]models.Job) {
+	for k := range JobsMap {
+		keyVal := JobsMap[k].LastUpdated
+		tempMap[keyVal] = JobsMap[k]
+		log.Event(ctx, "adding job "+k+" to the temporary map", log.Data{"tempMap[" + keyVal.String() + "]": tempMap[keyVal]})
+	}
 }

--- a/store/job_store.go
+++ b/store/job_store.go
@@ -10,6 +10,7 @@ import (
 type JobStore interface {
 	CreateJob(ctx context.Context, id string) (job models.Job, err error)
 	GetJob(ctx context.Context, id string) (job models.Job, err error)
+	GetJobs(ctx context.Context) (job models.Jobs, err error)
 }
 
 //DataStore is a type that contains an implementation of the JobStore interface, which can be used for creating and getting Job resources.
@@ -65,27 +66,26 @@ func (ds *DataStore) GetJob(ctx context.Context, id string) (models.Job, error) 
 }
 
 //GetJobs gets a list of Job resources, from the JobsMap, as defined by the four parameters passed in.
+//As a default it will return all Job resources sorted by their last_updated time value.
 func (ds *DataStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 
 	//log.Event(ctx, "getting jobs", log.Data{"id": id})
 	log.Event(ctx, "getting jobs")
 
 	//Create an empty list to put the Job resources into
-	var jobsList []models.Job
+	jobsList := make([]models.Job, len(JobsMap))
 
-	//Loop through the map and add each Job to the list (for now just add the first two)
-	//jobsList[1] = JobsMap[0]
-	//jobsList[2] = JobsMap[1]
+	//Loop through the map and add each Job to the list
 	i := 0
 	for k := range JobsMap {
-		//fmt.Printf("key[%s] value[%s]\n", k, v)
+		log.Event(ctx, "The value of JobsMap[" + k + "]", log.Data{"Job details: ": JobsMap[k]})
 		jobsList[i] = JobsMap[k]
 		i++
 	}
 
 	jobs := models.Jobs{}
 
-	jobs.Items = jobsList
+	jobs.Job_List = jobsList
 
 	return jobs, nil
 }

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -12,6 +12,8 @@ const (
 	testJobID1 = "UUID1"
 	testJobID2 = "UUID2"
 	testJobID3 = "UUID3"
+	testJobID4 = "UUID4"
+	testJobID5 = "UUID5"
 )
 
 var ctx = context.Background()
@@ -112,4 +114,41 @@ func TestGetJob(t *testing.T) {
 		So(job, ShouldResemble, models.Job{})
 		So(err.Error(), ShouldEqual, expectedErrorMsg)
 	})
+}
+
+//TestGetJobs tests the GetJob function in job_store.
+func TestGetJobs(t *testing.T) {
+
+	Convey("Successfully return without any errors", t, func() {
+		Convey("when the job store contains some jobs", func() {
+			jobStore := DataStore{}
+
+			//first create some jobs so that they exist in the job store
+			job1, err := jobStore.CreateJob(ctx, testJobID4)
+			So(err, ShouldBeNil)
+			job2, err := jobStore.CreateJob(ctx, testJobID5)
+			So(err, ShouldBeNil)
+
+			//then get all the jobs from the jobStore and check that the newly created ones are amongst them
+			jobs_returned, err := jobStore.GetJobs(ctx)
+			So(err, ShouldBeNil)
+			job_list_returned := jobs_returned.Job_List
+			isJob1InList := contains(job_list_returned, job1)
+			So(isJob1InList, ShouldEqual, true)
+			isJob2InList := contains(job_list_returned, job2)
+			So(isJob2InList, ShouldEqual, true)
+		})
+	})
+}
+
+// https://play.golang.org/p/Qg_uv_inCek
+// contains checks if a Job is present in a slice
+func contains(jobs_list []models.Job, job models.Job) bool {
+	for _, v := range jobs_list {
+		if v == job {
+			return true
+		}
+	}
+
+	return false
 }

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -22,9 +22,7 @@ var jobStore = DataStore{}
 
 //TestCreateJob tests the CreateJob function in job_store.
 func TestCreateJob(t *testing.T) {
-
 	t.Parallel()
-
 	Convey("Successfully return without any errors", t, func() {
 		Convey("when the job id is unique and is not an empty string", func() {
 			inputID := testJobID1
@@ -66,7 +64,6 @@ func TestCreateJob(t *testing.T) {
 
 //TestGetJob tests the GetJob function in job_store.
 func TestGetJob(t *testing.T) {
-
 	Convey("Successfully return without any errors", t, func() {
 		Convey("when the job id exists in the jobStore", func() {
 			inputID := testJobID2
@@ -115,7 +112,6 @@ func TestGetJob(t *testing.T) {
 
 //TestGetJobs tests the GetJob function in job_store.
 func TestGetJobs(t *testing.T) {
-
 	Convey("Successfully return without any errors", t, func() {
 		Convey("when the job store contains some jobs", func() {
 			inputID1 := testJobID4

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -120,10 +120,13 @@ func TestGetJob(t *testing.T) {
 func TestGetJobs(t *testing.T) {
 
 	Convey("Successfully return without any errors", t, func() {
+
+		jobStore := DataStore{}
+
 		Convey("when the job store contains some jobs", func() {
+
 			inputID1 := testJobID4
 			inputID2 := testJobID5
-			jobStore := DataStore{}
 
 			//first create some jobs so that they exist in the job store
 			job1, err := jobStore.CreateJob(ctx, inputID1)
@@ -140,11 +143,22 @@ func TestGetJobs(t *testing.T) {
 			isJob2InList := contains(job_list_returned, job2)
 			So(isJob2InList, ShouldEqual, true)
 		})
+		Convey("when the job store contains no jobs", func() {
+
+			//first delete any jobs that exist in the job store
+			err := jobStore.DeleteAllJobs(ctx)
+			So(err, ShouldBeNil)
+
+			//then get all the jobs from the jobStore and check that the returned list of jobs is empty
+			jobs_returned, err := jobStore.GetJobs(ctx)
+			So(err, ShouldBeNil)
+			job_list_returned := jobs_returned.Job_List
+			So(len(job_list_returned), ShouldEqual, 0)
+		})
 	})
 }
 
-// https://play.golang.org/p/Qg_uv_inCek
-// contains checks if a Job is present in a slice of Jobs
+//contains checks if a Job is present in a slice of Jobs
 func contains(jobs_list []models.Job, job models.Job) bool {
 	for _, v := range jobs_list {
 		if v == job {

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -135,6 +135,9 @@ func TestGetJobs(t *testing.T) {
 			So(isJob1InList, ShouldEqual, true)
 			isJob2InList := contains(job_list_returned, job2)
 			So(isJob2InList, ShouldEqual, true)
+
+			//then check that the first job in the list was last updated earlier than the second
+			So(job_list_returned[0].LastUpdated, ShouldHappenBefore, job_list_returned[1].LastUpdated)
 		})
 		Convey("when the job store contains no jobs", func() {
 			//first delete any jobs that exist in the job store

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -126,7 +126,7 @@ func TestGetJobs(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			//then get all the jobs from the jobStore and check that the newly created ones are amongst them
-			jobs_returned, err := jobStore.GetJobs(ctx)
+			jobs_returned, err := jobStore.GetJobs(ctx, mux)
 			So(err, ShouldBeNil)
 			job_list_returned := jobs_returned.Job_List
 			isJob1InList := contains(job_list_returned, job1)
@@ -143,7 +143,7 @@ func TestGetJobs(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			//then get all the jobs from the jobStore and check that the returned list of jobs is empty
-			jobs_returned, err := jobStore.GetJobs(ctx)
+			jobs_returned, err := jobStore.GetJobs(ctx, mux)
 			So(err, ShouldBeNil)
 			job_list_returned := jobs_returned.Job_List
 			So(len(job_list_returned), ShouldEqual, 0)

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -121,12 +121,14 @@ func TestGetJobs(t *testing.T) {
 
 	Convey("Successfully return without any errors", t, func() {
 		Convey("when the job store contains some jobs", func() {
+			inputID1 := testJobID4
+			inputID2 := testJobID5
 			jobStore := DataStore{}
 
 			//first create some jobs so that they exist in the job store
-			job1, err := jobStore.CreateJob(ctx, testJobID4)
+			job1, err := jobStore.CreateJob(ctx, inputID1)
 			So(err, ShouldBeNil)
-			job2, err := jobStore.CreateJob(ctx, testJobID5)
+			job2, err := jobStore.CreateJob(ctx, inputID2)
 			So(err, ShouldBeNil)
 
 			//then get all the jobs from the jobStore and check that the newly created ones are amongst them
@@ -142,7 +144,7 @@ func TestGetJobs(t *testing.T) {
 }
 
 // https://play.golang.org/p/Qg_uv_inCek
-// contains checks if a Job is present in a slice
+// contains checks if a Job is present in a slice of Jobs
 func contains(jobs_list []models.Job, job models.Job) bool {
 	for _, v := range jobs_list {
 		if v == job {

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -128,7 +128,7 @@ func TestGetJobs(t *testing.T) {
 			//then get all the jobs from the jobStore and check that the newly created ones are amongst them
 			jobs_returned, err := jobStore.GetJobs(ctx, mux)
 			So(err, ShouldBeNil)
-			job_list_returned := jobs_returned.Job_List
+			job_list_returned := jobs_returned.JobList
 			isJob1InList := contains(job_list_returned, job1)
 			So(isJob1InList, ShouldEqual, true)
 			isJob2InList := contains(job_list_returned, job2)
@@ -145,7 +145,7 @@ func TestGetJobs(t *testing.T) {
 			//then get all the jobs from the jobStore and check that the returned list of jobs is empty
 			jobs_returned, err := jobStore.GetJobs(ctx, mux)
 			So(err, ShouldBeNil)
-			job_list_returned := jobs_returned.Job_List
+			job_list_returned := jobs_returned.JobList
 			So(len(job_list_returned), ShouldEqual, 0)
 		})
 	})

--- a/store/job_store_test.go
+++ b/store/job_store_test.go
@@ -2,9 +2,10 @@ package store
 
 import (
 	"context"
+	"testing"
+
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 // Constants for testing
@@ -17,6 +18,7 @@ const (
 )
 
 var ctx = context.Background()
+var jobStore = DataStore{}
 
 //TestCreateJob tests the CreateJob function in job_store.
 func TestCreateJob(t *testing.T) {
@@ -27,7 +29,6 @@ func TestCreateJob(t *testing.T) {
 		Convey("when the job id is unique and is not an empty string", func() {
 			inputID := testJobID1
 
-			jobStore := DataStore{}
 			job, err := jobStore.CreateJob(ctx, inputID)
 			So(err, ShouldBeNil)
 			expectedJob := models.NewJob(testJobID1)
@@ -55,7 +56,6 @@ func TestCreateJob(t *testing.T) {
 	Convey("Return with error when the job id is an empty string", t, func() {
 		inputID := ""
 		expectedErrorMsg := "id must not be an empty string"
-		jobStore := DataStore{}
 		job, err := jobStore.CreateJob(ctx, inputID)
 
 		So(job, ShouldResemble, models.Job{})
@@ -70,7 +70,6 @@ func TestGetJob(t *testing.T) {
 	Convey("Successfully return without any errors", t, func() {
 		Convey("when the job id exists in the jobStore", func() {
 			inputID := testJobID2
-			jobStore := DataStore{}
 
 			//first create a job so that it exists in the job store
 			job, err := jobStore.CreateJob(ctx, inputID)
@@ -97,7 +96,6 @@ func TestGetJob(t *testing.T) {
 	Convey("Return with error when the job id does not exist in the jobStore", t, func() {
 		inputID := testJobID3
 		expectedErrorMsg := "the job store does not contain the job id entered"
-		jobStore := DataStore{}
 		job, err := jobStore.GetJob(ctx, inputID)
 
 		So(err, ShouldNotBeNil)
@@ -107,7 +105,6 @@ func TestGetJob(t *testing.T) {
 	Convey("Return with error when the job id is an empty String", t, func() {
 		inputID := ""
 		expectedErrorMsg := "id must not be an empty string"
-		jobStore := DataStore{}
 		job, err := jobStore.GetJob(ctx, inputID)
 
 		So(err, ShouldNotBeNil)
@@ -120,11 +117,7 @@ func TestGetJob(t *testing.T) {
 func TestGetJobs(t *testing.T) {
 
 	Convey("Successfully return without any errors", t, func() {
-
-		jobStore := DataStore{}
-
 		Convey("when the job store contains some jobs", func() {
-
 			inputID1 := testJobID4
 			inputID2 := testJobID5
 
@@ -144,7 +137,6 @@ func TestGetJobs(t *testing.T) {
 			So(isJob2InList, ShouldEqual, true)
 		})
 		Convey("when the job store contains no jobs", func() {
-
 			//first delete any jobs that exist in the job store
 			err := jobStore.DeleteAllJobs(ctx)
 			So(err, ShouldBeNil)


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
An endpoint has been added, which allows a GET request to be made, to provide details of all the search reindex jobs currently held in the job store. This results in the relevant Job resources being returned, in a list, or otherwise a null value is returned (if no Job resources exist).

NB. The swagger spec. is slightly different to the current functionality because the trello ticket specifies the following: ignore request query parameters, offset, limit, sort and state for now.

Example of the GET request:
http://localhost:25700/jobs

Example of a list of two Job resources being returned:
```json
{
    "jobs": [
        {
            "id": "fc0c8f28-0f2a-4ded-b27c-18f2d8748b76",
            "last_updated": "2021-04-27T14:27:13.599666Z",
            "links": {
                "tasks": "http://localhost:12150/jobs/fc0c8f28-0f2a-4ded-b27c-18f2d8748b76/tasks",
                "self": "http://localhost:12150/jobs/fc0c8f28-0f2a-4ded-b27c-18f2d8748b76"
            },
            "number_of_tasks": 0,
            "reindex_completed": "0001-01-01T00:00:00Z",
            "reindex_failed": "0001-01-01T00:00:00Z",
            "reindex_started": "0001-01-01T00:00:00Z",
            "search_index_name": "Default Search Index Name",
            "state": "created",
            "total_search_documents": 0,
            "total_inserted_search_documents": 0
        },
        {
            "id": "f207826a-e8ad-4202-a5f0-9f10e2a32e2c",
            "last_updated": "2021-04-27T14:27:15.50031Z",
            "links": {
                "tasks": "http://localhost:12150/jobs/f207826a-e8ad-4202-a5f0-9f10e2a32e2c/tasks",
                "self": "http://localhost:12150/jobs/f207826a-e8ad-4202-a5f0-9f10e2a32e2c"
            },
            "number_of_tasks": 0,
            "reindex_completed": "0001-01-01T00:00:00Z",
            "reindex_failed": "0001-01-01T00:00:00Z",
            "reindex_started": "0001-01-01T00:00:00Z",
            "search_index_name": "Default Search Index Name",
            "state": "created",
            "total_search_documents": 0,
            "total_inserted_search_documents": 0
        }
    ]
}
```

Example of a null value being returned if no Job resources exist:
```json
{
    "jobs": null
}
```

Logging has been added to show the sorted list of Job resources if returned successfully. 

Unit tests have been added for the api, the handler, and the storer.

A component test has also been added, which tests that the expected number and details of Job resources will be returned in chronological order of last_updated.

# How to review
<!--- Describe in detail how you tested your changes. -->
The endpoint can be tested locally by first using this POST URL a number of times to create that number of Job resources in the Job Store: http://localhost:25700/jobs
The endpoint, which has a similar URL, can then be used as a GET URL to retrieve those same jobs in a single sorted list: http://localhost:25700/jobs

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
