### PR TITLE
Release/0.3.0

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -71,20 +71,25 @@ paths:
         201:
           description: "Successfully created a new search reindex job."
           schema:
-            $ref: "#/definitions/Job"
+            $ref: "#/definitions/BaseJob"
+        409:
+          $ref: "#/responses/Conflict"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
 
 responses:
 
   InternalError:
-    description: "Failed to process the request due to an internal error"
+    description: "Failed to process the request due to an internal error."
 
   ResourceNotFound:
-    description: "Failed to locate a Job that has the specified id"
+    description: "Failed to locate a Job that has the specified id."
 
   InvalidRequest:
-    description: "The request does not contain the correct parameters and/or values in its parameters"
+    description: "The request does not contain the correct parameters and/or values in its parameters."
+  
+  Conflict:
+    description: "The request could not be completed due to a conflict with the current state of the Job Store."
 
 definitions:
 
@@ -153,6 +158,67 @@ definitions:
       total_search_documents:
         type: integer
         description: "The total number of documents that are held within the search index in question."
+      total_inserted_search_documents:
+        type: integer
+        description: "The total number of documents inserted into the new search index for a reindex job."
+
+  BaseJob:
+    type: object
+    description: "A basic Job object that contains the minimum set of properties i.e. only those properties required to be returned by the POST /jobs endpoint"
+    required:
+      - "id"
+      - "last_updated"
+      - "links"
+      - "search_index_name"
+      - "reindex_started"
+      - "state"
+      - "total_inserted_search_documents"
+    properties:
+      id:
+        type: string
+        description: "A unique identifier for this specific search reindex job."
+      last_updated:
+          type: string
+          format: date-time
+          description: "A ISO8601 timestamp representing the last time the resource was updated."
+          example: "2021-03-18T09:03:41+0000"
+      links:
+          type: object
+          description: "Links that can be used to get the details of the Job (self) or of its tasks."
+          required:
+            - "tasks"
+            - "self"
+          properties:
+            tasks:
+              type: string
+              format: http://localhost:<port>/jobs/{id}/tasks
+              example: http://localhost:12150/jobs/abc123/tasks
+            self:
+              type: string
+              format: http://localhost:<port>/jobs/{id}
+              example: http://localhost:12150/jobs/abc123
+      reindex_failed:
+        type: string
+        format: date-time
+        description: "A ISO8601 timestamp representing the date and time when the reindex job failed."
+        example: "2021-03-18T09:03:41+0000"
+      reindex_started:
+        type: string
+        format: date-time
+        description: "A ISO8601 timestamp representing the date and time when the reindex job was started."
+        example: "2021-03-18T09:03:41+0000"
+      search_index_name:
+        type: string
+        description: "The name of the search index to be recreated by this search reindex job."
+      state:
+        type: string
+        description: "The current state of this search reindex job."
+        example: "created"
+        enum:
+          - created
+          - in-progress
+          - completed
+          - failed
       total_inserted_search_documents:
         type: integer
         description: "The total number of documents inserted into the new search index for a reindex job."

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -32,7 +32,7 @@ paths:
         200:
           description: "Successfully returned a job for the given id."
           schema:
-            $ref: "#/definitions/Job"
+            $ref: "#/definitions/GetReturnJob"
         500:
           $ref: '#/responses/InternalError'
         404:
@@ -71,7 +71,7 @@ paths:
         201:
           description: "Successfully created a new search reindex job."
           schema:
-            $ref: "#/definitions/BaseJob"
+            $ref: "#/definitions/PostReturnJob"
         409:
           $ref: "#/responses/Conflict"
         500:
@@ -177,25 +177,25 @@ definitions:
         type: string
         description: "A unique identifier for this specific search reindex job."
       last_updated:
-          type: string
-          format: date-time
-          description: "A ISO8601 timestamp representing the last time the resource was updated."
-          example: "2021-03-18T09:03:41+0000"
+        type: string
+        format: date-time
+        description: "A ISO8601 timestamp representing the last time the resource was updated."
+        example: "2021-03-18T09:03:41+0000"
       links:
-          type: object
-          description: "Links that can be used to get the details of the Job (self) or of its tasks."
-          required:
-            - "tasks"
-            - "self"
-          properties:
-            tasks:
-              type: string
-              format: http://localhost:<port>/jobs/{id}/tasks
-              example: http://localhost:12150/jobs/abc123/tasks
-            self:
-              type: string
-              format: http://localhost:<port>/jobs/{id}
-              example: http://localhost:12150/jobs/abc123
+        type: object
+        description: "Links that can be used to get the details of the Job (self) or of its tasks."
+        required:
+          - "tasks"
+          - "self"
+        properties:
+          tasks:
+            type: string
+            format: http://localhost:<port>/jobs/{id}/tasks
+            example: http://localhost:12150/jobs/abc123/tasks
+          self:
+            type: string
+            format: http://localhost:<port>/jobs/{id}
+            example: http://localhost:12150/jobs/abc123
       reindex_failed:
         type: string
         format: date-time
@@ -226,9 +226,27 @@ definitions:
     allOf:
       - $ref: '#/definitions/BaseJob'
     type: "object"
-    description: "A search reindex job that extends the basic one only by adding search_index_name to the list of required properties. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
+    description: "A search reindex job that extends the basic one by adding search_index_name to the list of required properties. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
     required:
       - "search_index_name"
+
+  GetReturnJob:
+    allOf:
+      - $ref: '#/definitions/BaseJob'
+    type: "object"
+    description: "A search reindex job that extends the basic one by adding properties named number_of_tasks, total_search_documents, and reindex_completed. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
+    properties:
+      number_of_tasks:
+        type: integer
+        description: "The number of tasks that are part of this search reindex job."
+      reindex_completed:
+        type: string
+        format: date-time
+        description: "A ISO8601 timestamp representing the date and time when the reindex job was completed."
+        example: "2021-03-18T09:03:41+0000"
+      total_search_documents:
+        type: integer
+        description: "The total number of documents that are held within the search index in question."
 
   Jobs:
     type: object
@@ -306,4 +324,3 @@ parameters:
     description: Filter option to bring back specific Job objects according to their state. This will be a list of comma separated values that correspond to state enum values e.g. "created,failed".
     in: query
     type: string
-

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -87,7 +87,7 @@ responses:
 
   InvalidRequest:
     description: "The request does not contain the correct parameters and/or values in its parameters."
-  
+
   Conflict:
     description: "The request could not be completed due to a conflict with the current state of the Job Store."
 
@@ -164,12 +164,11 @@ definitions:
 
   BaseJob:
     type: object
-    description: "A basic Job object that contains the minimum set of properties i.e. only those properties required to be returned by the POST /jobs endpoint"
+    description: "A basic search reindex job object that contains the minimum set of properties. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
     required:
       - "id"
       - "last_updated"
       - "links"
-      - "search_index_name"
       - "reindex_started"
       - "state"
       - "total_inserted_search_documents"
@@ -222,6 +221,14 @@ definitions:
       total_inserted_search_documents:
         type: integer
         description: "The total number of documents inserted into the new search index for a reindex job."
+
+  PostReturnJob:
+    allOf:
+      - $ref: '#/definitions/BaseJob'
+    type: "object"
+    description: "A search reindex job that extends the basic one only by adding search_index_name to the list of required properties. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
+    required:
+      - "search_index_name"
 
   Jobs:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -252,6 +252,8 @@ parameters:
 
   state:
     name: state
-    description: Filter option to bring back specific Job objects according to their state. This will be a list of comma separated values that correspond to state enum values e.g. "created,failed".
+    description: The resulting list of items filtered by the values in state array. This field resembles the list of states set on request.
     in: query
-    type: string
+    type: array
+    items:
+      type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -93,75 +93,6 @@ responses:
 
 definitions:
 
-  Job:
-    type: object
-    description: "A search reindex job. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
-    required:
-      - "id"
-      - "last_updated"
-      - "links"
-      - "search_index_name"
-    properties:
-      id:
-        type: string
-        description: "A unique identifier for this specific search reindex job."
-      last_updated:
-        type: string
-        format: date-time
-        description: "A ISO8601 timestamp representing the last time the resource was updated."
-        example: "2021-03-18T09:03:41+0000"
-      links:
-        type: object
-        description: "Links that can be used to get the details of the Job (self) or of its tasks."
-        required:
-          - "tasks"
-          - "self"
-        properties:
-          tasks:
-            type: string
-            format: http://localhost:<port>/jobs/{id}/tasks
-            example: http://localhost:12150/jobs/abc123/tasks
-          self:
-            type: string
-            format: http://localhost:<port>/jobs/{id}
-            example: http://localhost:12150/jobs/abc123
-      number_of_tasks:
-        type: integer
-        description: "The number of tasks that are part of this search reindex job."
-      reindex_completed:
-        type: string
-        format: date-time
-        description: "A ISO8601 timestamp representing the date and time when the reindex job was completed."
-        example: "2021-03-18T09:03:41+0000"
-      reindex_failed:
-        type: string
-        format: date-time
-        description: "A ISO8601 timestamp representing the date and time when the reindex job failed."
-        example: "2021-03-18T09:03:41+0000"
-      reindex_started:
-        type: string
-        format: date-time
-        description: "A ISO8601 timestamp representing the date and time when the reindex job was started."
-        example: "2021-03-18T09:03:41+0000"
-      search_index_name:
-        type: string
-        description: "The name of the search index to be recreated by this search reindex job."
-      state:
-        type: string
-        description: "The current state of this search reindex job."
-        example: "created"
-        enum:
-          - created
-          - in-progress
-          - completed
-          - failed
-      total_search_documents:
-        type: integer
-        description: "The total number of documents that are held within the search index in question."
-      total_inserted_search_documents:
-        type: integer
-        description: "The total number of documents inserted into the new search index for a reindex job."
-
   BaseJob:
     type: object
     description: "A basic search reindex job object that contains the minimum set of properties. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
@@ -267,7 +198,7 @@ definitions:
         type: array
         description: "The actual list that contains the Job resources."
         items:
-          $ref: '#/definitions/Job'
+          $ref: '#/definitions/GetReturnJob'
       limit:
         type: integer
         description: "The max number of Job resources we're returning in this response. The default is 20."

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -25,7 +25,7 @@ paths:
       summary: Get a specific job.
       description: "Get the specific search reindex job that has the id given in the path."
       parameters:
-        - $ref: '#/parameters/id'
+        - $ref: "#/parameters/id"
       produces:
         - application/json
       responses:
@@ -34,9 +34,9 @@ paths:
           schema:
             $ref: "#/definitions/GetReturnJob"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
         404:
-          $ref: '#/responses/ResourceNotFound'
+          $ref: "#/responses/ResourceNotFound"
 
   /jobs:
     get:
@@ -45,10 +45,10 @@ paths:
       summary: Get a list of jobs.
       description: "Get a list of search reindex jobs that meet the criteria specified by the four query parameters."
       parameters:
-        - $ref: '#/parameters/limit'
-        - $ref: '#/parameters/offset'
-        - $ref: '#/parameters/sort'
-        - $ref: '#/parameters/state'
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/offset"
+        - $ref: "#/parameters/sort"
+        - $ref: "#/parameters/state"
       produces:
         - application/json
       responses:
@@ -57,9 +57,9 @@ paths:
           schema:
             $ref: "#/definitions/Jobs"
         400:
-          $ref: '#/responses/InvalidRequest'
+          $ref: "#/responses/InvalidRequest"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     post:
       tags:
         - "Private User"
@@ -80,16 +80,16 @@ paths:
 responses:
 
   InternalError:
-    description: "Failed to process the request due to an internal error."
+    description: "Failed to process the request due to an internal error"
 
   ResourceNotFound:
-    description: "Failed to locate a Job that has the specified id."
+    description: "Failed to locate a Job that has the specified id"
 
   InvalidRequest:
-    description: "The request does not contain the correct parameters and/or values in its parameters."
+    description: "The request does not contain the correct parameters and/or values in its parameters"
 
   Conflict:
-    description: "The request could not be completed due to a conflict with the current state of the Job Store."
+    description: "The request could not be completed due to a conflict with the current state of the Job Store"
 
 definitions:
 
@@ -155,7 +155,7 @@ definitions:
 
   PostReturnJob:
     allOf:
-      - $ref: '#/definitions/BaseJob'
+      - $ref: "#/definitions/BaseJob"
     type: "object"
     description: "A search reindex job that extends the basic one by adding search_index_name to the list of required properties. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
     required:
@@ -163,7 +163,7 @@ definitions:
 
   GetReturnJob:
     allOf:
-      - $ref: '#/definitions/BaseJob'
+      - $ref: "#/definitions/BaseJob"
     type: "object"
     description: "A search reindex job that extends the basic one by adding properties named number_of_tasks, total_search_documents, and reindex_completed. The information it contains is to be used by the developer who creates the Job, which is to replace an existing elastic search index with a new one."
     properties:
@@ -198,7 +198,7 @@ definitions:
         type: array
         description: "The actual list that contains the Job resources."
         items:
-          $ref: '#/definitions/GetReturnJob'
+          $ref: "#/definitions/GetReturnJob"
       limit:
         type: integer
         description: "The max number of Job resources we're returning in this response. The default is 20."


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Future changes to the following endpoints have been added to the swagger:

POST /jobs
- Removed field "number_of_tasks" from the response as it will get added to the document on a later request.
- Removed field "total_search_documents" from the response as, it will get added to the document on a later request and, at this point in time we won't know the count.
- Removed field "reindex_completed" as this field does not exist until the job has completed.
- Extended possible errors to include 409 status code (conflict) as a response.
- Made sure that the following fields, in the response body, are all set to "required":
  - id
  - last_updated
  - links -> self, tasks
  - reindex_started
  - search_index_name
  - state
  - total_inserted_search_documents

GET /jobs/{id}
- Made sure that the following fields, in the response body, are all set to "required":
  - id
  - last_updated
  - links -> self, tasks
  - reindex_started
  - state
  - total_inserted_search_documents

GET /jobs
- Changed the model (of a Job resource) used in the response (the list of Job resources) to be the same as the new model used in the response for GET /jobs/{id}
- Changed the State filter option to be an array, containing the list of states to filter the list of Job resources by, instead of being a comma separated String of states

Models
* = mandatory fields

BaseJob resource:
{
  "id" *: string,
  "last_updated" *: ISODate, //ISO8601 timestamp
  "links" *: {
    "tasks" *: string // format: http://localhost:<port>/jobs/{id}/tasks
    "self" *: string // format: http://localhost:<port>/jobs/{id}
  },
  "reindex_failed": ISODATE, //ISO8601 timestamp
  "reindex_started" *: ISODATE, //ISO8601 timestamp
  "search_index_name": string,
  "state" *: string, // enum [ created, in-progress, completed, failed ]
  "total_inserted_search_documents" *: integer
}

PostReturnJob resource:
{
  "id" *: string,
  "last_updated" *: ISODate, //ISO8601 timestamp
  "links" *: {
    "tasks" *: string // format: http://localhost:<port>/jobs/{id}/tasks
    "self" *: string // format: http://localhost:<port>/jobs/{id}
  },
  "reindex_failed": ISODATE, //ISO8601 timestamp
  "reindex_started" *: ISODATE, //ISO8601 timestamp
  "search_index_name" *: string,
  "state" *: string, // enum [ created, in-progress, completed, failed ]
  "total_inserted_search_documents" *: integer
}

GetReturnJob resource:
{
  "id" *: string,
  "last_updated" *: ISODate, //ISO8601 timestamp
  "links" *: {
    "tasks" *: string // format: http://localhost:<port>/jobs/{id}/tasks
    "self" *: string // format: http://localhost:<port>/jobs/{id}
  },
  "number_of_tasks" : integer,
  "reindex_completed": ISODATE, //ISO8601 timestamp,
  "reindex_failed": ISODATE, //ISO8601 timestamp
  "reindex_started" *: ISODATE, //ISO8601 timestamp
  "search_index_name": string,
  "state" *: string, // enum [ created, in-progress, completed, failed ]
  "total_search_documents" : integer,
  "total_inserted_search_documents" *: integer
}

Jobs resource:
{
  "count" *: integer
  "items" *: [
    <GetReturnJob>
  ],
  "limit" *: integer,
  "offset" *: integer,
  "total_count" *: integer,
  "sort": integer
}

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the details in the swagger spec match the details in the specification above. 

Use the Swagger Editor to check that there are no errors: https://editor.swagger.io/

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
