### PR TITLE
Register MongoDB Health Checker

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -24,7 +24,6 @@ func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
 
 		id := NewID()
 
-		//Create job in job store
 		newJob, err := api.jobStore.CreateJob(ctx, id)
 		if err != nil {
 			log.Event(ctx, "creating and storing job failed", log.Error(err), log.ERROR)
@@ -59,7 +58,6 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 		id := vars["id"]
 		logData := log.Data{"job_id": id}
 
-		// Acquire lock for job ID, and defer unlocking
 		lockID, err := api.jobStore.AcquireJobLock(ctx, id)
 		if err != nil {
 			log.Event(ctx, "acquiring lock for job ID failed", log.Error(err), logData, log.ERROR)
@@ -68,7 +66,6 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 		}
 		defer api.unlockJob(ctx, lockID)
 
-		// get job, from jobs collection in jobStore, by id
 		job, err := api.jobStore.GetJob(req.Context(), id)
 		if err != nil {
 			log.Event(ctx, "getting job failed", log.Error(err), logData, log.ERROR)
@@ -100,7 +97,6 @@ func (api *JobStoreAPI) GetJobsHandler(w http.ResponseWriter, req *http.Request)
 	ctx := req.Context()
 	log.Event(ctx, "Entering handler function, which calls GetJobs and returns a list of existing Job resources held in the JobStore.", log.INFO)
 
-	//get jobs from jobs collection in jobStore
 	jobs, err := api.jobStore.GetJobs(ctx)
 	if err != nil {
 		log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -101,7 +101,7 @@ func TestGetJobHandler(t *testing.T) {
 				payload, err := ioutil.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 				jobReturned := models.Job{}
-				err = json.Unmarshal(payload, &jobReturned)
+				json.Unmarshal(payload, &jobReturned)
 				expectedJob := models.NewJob(testJobID2)
 
 				Convey("And the returned job resource should contain expected values", func() {
@@ -187,7 +187,7 @@ func TestGetJobsHandler(t *testing.T) {
 				payload, err := ioutil.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 				jobsReturned := models.Jobs{}
-				err = json.Unmarshal(payload, &jobsReturned)
+				json.Unmarshal(payload, &jobsReturned)
 				zeroTime := time.Time{}.UTC()
 				expectedJob1 := ExpectedJob(testJobID1, zeroTime, 0, zeroTime, zeroTime, zeroTime, "Default Search Index Name", "created", 0, 0)
 				expectedJob2 := ExpectedJob(testJobID2, zeroTime, 0, zeroTime, zeroTime, zeroTime, "Default Search Index Name", "created", 0, 0)
@@ -247,7 +247,7 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 				payload, err := ioutil.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 				jobsReturned := models.Jobs{}
-				err = json.Unmarshal(payload, &jobsReturned)
+				json.Unmarshal(payload, &jobsReturned)
 
 				Convey("And the returned jobs list should be empty", func() {
 					So(jobsReturned.JobList, ShouldHaveLength, 0)
@@ -285,7 +285,7 @@ func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 	})
 }
 
-//ExpectedJob returns a Job resource that can be used to define and test expected values within it.
+// ExpectedJob returns a Job resource that can be used to define and test expected values within it.
 func ExpectedJob(id string,
 	lastUpdated time.Time,
 	numberOfTasks int,

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -101,7 +101,8 @@ func TestGetJobHandler(t *testing.T) {
 				payload, err := ioutil.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 				jobReturned := models.Job{}
-				json.Unmarshal(payload, &jobReturned)
+				err = json.Unmarshal(payload, &jobReturned)
+				So(err, ShouldBeNil)
 				expectedJob := models.NewJob(testJobID2)
 
 				Convey("And the returned job resource should contain expected values", func() {
@@ -187,7 +188,8 @@ func TestGetJobsHandler(t *testing.T) {
 				payload, err := ioutil.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 				jobsReturned := models.Jobs{}
-				json.Unmarshal(payload, &jobsReturned)
+				err = json.Unmarshal(payload, &jobsReturned)
+				So(err, ShouldBeNil)
 				zeroTime := time.Time{}.UTC()
 				expectedJob1 := ExpectedJob(testJobID1, zeroTime, 0, zeroTime, zeroTime, zeroTime, "Default Search Index Name", "created", 0, 0)
 				expectedJob2 := ExpectedJob(testJobID2, zeroTime, 0, zeroTime, zeroTime, zeroTime, "Default Search Index Name", "created", 0, 0)
@@ -247,7 +249,8 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 				payload, err := ioutil.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 				jobsReturned := models.Jobs{}
-				json.Unmarshal(payload, &jobsReturned)
+				err = json.Unmarshal(payload, &jobsReturned)
+				So(err, ShouldBeNil)
 
 				Convey("And the returned jobs list should be empty", func() {
 					So(jobsReturned.JobList, ShouldHaveLength, 0)

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -1,4 +1,4 @@
-//Package steps is used to define the steps that are used in the component test, which is written in godog (Go's version of cucumber).
+// Package steps is used to define the steps that are used in the component test, which is written in godog (Go's version of cucumber).
 package steps
 
 import (
@@ -30,7 +30,7 @@ import (
 // jobs collection name
 const jobsCol = "jobs"
 
-//JobsFeature is a type that contains all the requirements for running a godog (cucumber) feature that tests the /jobs endpoint.
+// JobsFeature is a type that contains all the requirements for running a godog (cucumber) feature that tests the /jobs endpoint.
 type JobsFeature struct {
 	ErrorFeature   componentTest.ErrorFeature
 	svc            *service.Service
@@ -44,7 +44,7 @@ type JobsFeature struct {
 	MongoFeature   *componentTest.MongoFeature
 }
 
-//NewJobsFeature returns a pointer to a new JobsFeature, which can then be used for testing the /jobs endpoint.
+// NewJobsFeature returns a pointer to a new JobsFeature, which can then be used for testing the /jobs endpoint.
 func NewJobsFeature(mongoFeature *componentTest.MongoFeature) (*JobsFeature, error) {
 	f := &JobsFeature{
 		HTTPServer:     &http.Server{},
@@ -82,14 +82,14 @@ func NewJobsFeature(mongoFeature *componentTest.MongoFeature) (*JobsFeature, err
 	return f, nil
 }
 
-//InitAPIFeature initialises the ApiFeature that's contained within a specific JobsFeature.
+// InitAPIFeature initialises the ApiFeature that's contained within a specific JobsFeature.
 func (f *JobsFeature) InitAPIFeature() *componentTest.APIFeature {
 	f.ApiFeature = componentTest.NewAPIFeature(f.InitialiseService)
 
 	return f.ApiFeature
 }
 
-//RegisterSteps defines the steps within a specific JobsFeature cucumber test.
+// RegisterSteps defines the steps within a specific JobsFeature cucumber test.
 func (f *JobsFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I would expect id, last_updated, and links to have this structure$`, f.iWouldExpectIdLast_updatedAndLinksToHaveThisStructure)
 	ctx.Step(`^the response should also contain the following values:$`, f.theResponseShouldAlsoContainTheFollowingValues)
@@ -102,7 +102,7 @@ func (f *JobsFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the jobs should be ordered, by last_updated, with the oldest first$`, f.theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst)
 }
 
-//Reset sets the resources within a specific JobsFeature back to their default values.
+// Reset sets the resources within a specific JobsFeature back to their default values.
 func (f *JobsFeature) Reset() *JobsFeature {
 	f.MongoClient.Database = memongo.RandomDatabase()
 	ctx := context.Background()
@@ -113,7 +113,7 @@ func (f *JobsFeature) Reset() *JobsFeature {
 	return f
 }
 
-//Close stops the *service.Service, which is pointed to from within the specific JobsFeature, from running.
+// Close stops the *service.Service, which is pointed to from within the specific JobsFeature, from running.
 func (f *JobsFeature) Close() error {
 	if f.svc != nil && f.ServiceRunning {
 		err := f.svc.Close(context.Background())
@@ -125,20 +125,20 @@ func (f *JobsFeature) Close() error {
 	return nil
 }
 
-//InitialiseService returns the http.Handler that's contained within a specific JobsFeature.
+// InitialiseService returns the http.Handler that's contained within a specific JobsFeature.
 func (f *JobsFeature) InitialiseService() (http.Handler, error) {
 	return f.HTTPServer.Handler, nil
 }
 
-//DoGetHTTPServer takes a bind Address (string) and a router (http.Handler), which are used to set up an HTTPServer.
-//The HTTPServer is in a specific JobsFeature and is returned.
+// DoGetHTTPServer takes a bind Address (string) and a router (http.Handler), which are used to set up an HTTPServer.
+// The HTTPServer is in a specific JobsFeature and is returned.
 func (f *JobsFeature) DoGetHTTPServer(bindAddr string, router http.Handler) service.HTTPServer {
 	f.HTTPServer.Addr = bindAddr
 	f.HTTPServer.Handler = router
 	return f.HTTPServer
 }
 
-//DoGetHealthcheckOk returns a mock HealthChecker service for a specific JobsFeature.
+// DoGetHealthcheckOk returns a mock HealthChecker service for a specific JobsFeature.
 func (f *JobsFeature) DoGetHealthcheckOk(cfg *config.Config, time string, commit string, version string) (service.HealthChecker, error) {
 	return &serviceMock.HealthCheckerMock{
 		AddCheckFunc: func(name string, checker healthcheck.Checker) error { return nil },
@@ -147,13 +147,13 @@ func (f *JobsFeature) DoGetHealthcheckOk(cfg *config.Config, time string, commit
 	}, nil
 }
 
-//DoGetMongoDB returns a MongoDB, for the component test, which has a random database name and different URI to the one used by the API under test.
+// DoGetMongoDB returns a MongoDB, for the component test, which has a random database name and different URI to the one used by the API under test.
 func (f *JobsFeature) DoGetMongoDB(ctx context.Context, cfg *config.Config) (service.MongoJobStorer, error) {
 	return f.MongoClient, nil
 }
 
-//iWouldExpectIdLast_updatedAndLinksToHaveThisStructure is a feature step that can be defined for a specific JobsFeature.
-//It takes a table that contains the expected structures for id, last_updated, and links values. And it asserts whether or not these are found.
+// iWouldExpectIdLast_updatedAndLinksToHaveThisStructure is a feature step that can be defined for a specific JobsFeature.
+// It takes a table that contains the expected structures for id, last_updated, and links values. And it asserts whether or not these are found.
 func (f *JobsFeature) iWouldExpectIdLast_updatedAndLinksToHaveThisStructure(table *godog.Table) error {
 	f.responseBody, _ = ioutil.ReadAll(f.ApiFeature.HttpResponse.Body)
 	assist := assistdog.NewDefault()
@@ -182,8 +182,8 @@ func (f *JobsFeature) iWouldExpectIdLast_updatedAndLinksToHaveThisStructure(tabl
 	return f.ErrorFeature.StepError()
 }
 
-//checkStructure is a utility method that can be called by a feature step to assert that a job contains the expected structure in its values of
-//id, last_updated, and links. It confirms that last_updated is a current or past time, and that the tasks and self links have the correct paths.
+// checkStructure is a utility method that can be called by a feature step to assert that a job contains the expected structure in its values of
+// id, last_updated, and links. It confirms that last_updated is a current or past time, and that the tasks and self links have the correct paths.
 func (f *JobsFeature) checkStructure(id string, lastUpdated time.Time, expectedResult map[string]string, links *models.JobLinks) error {
 	_, err := uuid.FromString(id)
 	if err != nil {
@@ -205,8 +205,8 @@ func (f *JobsFeature) checkStructure(id string, lastUpdated time.Time, expectedR
 	return nil
 }
 
-//theResponseShouldAlsoContainTheFollowingValues is a feature step that can be defined for a specific JobsFeature.
-//It takes a table that contains the expected values for all the remaining attributes, of a Job resource, and it asserts whether or not these are found.
+// theResponseShouldAlsoContainTheFollowingValues is a feature step that can be defined for a specific JobsFeature.
+// It takes a table that contains the expected values for all the remaining attributes, of a Job resource, and it asserts whether or not these are found.
 func (f *JobsFeature) theResponseShouldAlsoContainTheFollowingValues(table *godog.Table) error {
 	expectedResult, err := assistdog.NewDefault().ParseMap(table)
 	if err != nil {
@@ -221,8 +221,8 @@ func (f *JobsFeature) theResponseShouldAlsoContainTheFollowingValues(table *godo
 	return f.ErrorFeature.StepError()
 }
 
-//checkValuesInJob is a utility method that can be called by a feature step in order to check that the values
-//of certain attributes, in a job, are all equal to the expected ones.
+// checkValuesInJob is a utility method that can be called by a feature step in order to check that the values
+// of certain attributes, in a job, are all equal to the expected ones.
 func (f *JobsFeature) checkValuesInJob(expectedResult map[string]string, job models.Job) {
 	assert.Equal(&f.ErrorFeature, expectedResult["number_of_tasks"], strconv.Itoa(job.NumberOfTasks))
 	assert.Equal(&f.ErrorFeature, expectedResult["reindex_completed"], job.ReindexCompleted.Format(time.RFC3339))
@@ -234,11 +234,11 @@ func (f *JobsFeature) checkValuesInJob(expectedResult map[string]string, job mod
 	assert.Equal(&f.ErrorFeature, expectedResult["total_inserted_search_documents"], strconv.Itoa(job.TotalInsertedSearchDocuments))
 }
 
-//iHaveGeneratedAJobInTheJobStore is a feature step that can be defined for a specific JobsFeature.
-//It calls POST /jobs with an empty body, which causes a default job resource to be generated.
-//The newly created job resource is stored in the Job Store and also returned in the response body.
+// iHaveGeneratedAJobInTheJobStore is a feature step that can be defined for a specific JobsFeature.
+// It calls POST /jobs with an empty body, which causes a default job resource to be generated.
+// The newly created job resource is stored in the Job Store and also returned in the response body.
 func (f *JobsFeature) iHaveGeneratedAJobInTheJobStore() error {
-	//call POST /jobs
+	// call POST /jobs
 	err := f.callPostJobs()
 	if err != nil {
 		return err
@@ -247,8 +247,8 @@ func (f *JobsFeature) iHaveGeneratedAJobInTheJobStore() error {
 	return f.ErrorFeature.StepError()
 }
 
-//callPostJobs is a utility method that can be called by a feature step in order to call the POST jobs/ endpoint
-//Calling that endpoint results in the creation of a job, in the Job Store, containing a unique id and default values.
+// callPostJobs is a utility method that can be called by a feature step in order to call the POST jobs/ endpoint
+// Calling that endpoint results in the creation of a job, in the Job Store, containing a unique id and default values.
 func (f *JobsFeature) callPostJobs() error {
 	var emptyBody = godog.DocString{}
 	err := f.ApiFeature.IPostToWithBody("/jobs", &emptyBody)
@@ -259,8 +259,8 @@ func (f *JobsFeature) callPostJobs() error {
 	return err
 }
 
-//iCallGETJobsidUsingTheGeneratedId is a feature step that can be defined for a specific JobsFeature.
-//It gets the id from the response body, generated in the previous step, and then uses this to call GET /jobs/{id}.
+// iCallGETJobsidUsingTheGeneratedId is a feature step that can be defined for a specific JobsFeature.
+// It gets the id from the response body, generated in the previous step, and then uses this to call GET /jobs/{id}.
 func (f *JobsFeature) iCallGETJobsidUsingTheGeneratedId() error {
 	f.responseBody, _ = ioutil.ReadAll(f.ApiFeature.HttpResponse.Body)
 
@@ -278,7 +278,7 @@ func (f *JobsFeature) iCallGETJobsidUsingTheGeneratedId() error {
 		return err
 	}
 
-	//call GET /jobs/{id}
+	// call GET /jobs/{id}
 	err = f.ApiFeature.IGet("/jobs/" + id)
 	if err != nil {
 		os.Exit(1)
@@ -287,10 +287,10 @@ func (f *JobsFeature) iCallGETJobsidUsingTheGeneratedId() error {
 	return f.ErrorFeature.StepError()
 }
 
-//iHaveGeneratedThreeJobsInTheJobStore is a feature step that can be defined for a specific JobsFeature.
-//It calls POST /jobs with an empty body, three times, which causes three default job resources to be generated.
+// iHaveGeneratedThreeJobsInTheJobStore is a feature step that can be defined for a specific JobsFeature.
+// It calls POST /jobs with an empty body, three times, which causes three default job resources to be generated.
 func (f *JobsFeature) iHaveGeneratedThreeJobsInTheJobStore() error {
-	//call POST /jobs three times
+	// call POST /jobs three times
 	err := f.callPostJobs()
 	if err != nil {
 		return err
@@ -309,8 +309,8 @@ func (f *JobsFeature) iHaveGeneratedThreeJobsInTheJobStore() error {
 	return f.ErrorFeature.StepError()
 }
 
-//iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList is a feature step that can be defined for a specific JobsFeature.
-//It checks the response from calling GET /jobs to make sure that a list containing three or more jobs has been returned.
+// iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList is a feature step that can be defined for a specific JobsFeature.
+// It checks the response from calling GET /jobs to make sure that a list containing three or more jobs has been returned.
 func (f *JobsFeature) iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() error {
 	f.responseBody, _ = ioutil.ReadAll(f.ApiFeature.HttpResponse.Body)
 
@@ -325,9 +325,9 @@ func (f *JobsFeature) iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() erro
 	return f.ErrorFeature.StepError()
 }
 
-//inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStructure is a feature step that can be defined for a specific JobsFeature.
-//It checks the response from calling GET /jobs to make sure that each job contains the expected types of values of id,
-//last_updated, and links.
+// inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStructure is a feature step that can be defined for a specific JobsFeature.
+// It checks the response from calling GET /jobs to make sure that each job contains the expected types of values of id,
+// last_updated, and links.
 func (f *JobsFeature) inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStructure(table *godog.Table) error {
 	assist := assistdog.NewDefault()
 	expectedResult, err := assist.ParseMap(table)
@@ -353,9 +353,9 @@ func (f *JobsFeature) inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStruc
 	return f.ErrorFeature.StepError()
 }
 
-//eachJobShouldAlsoContainTheFollowingValues is a feature step that can be defined for a specific JobsFeature.
-//It checks the response from calling GET /jobs to make sure that each job contains the expected values of
-//all the remaining attributes of a job.
+// eachJobShouldAlsoContainTheFollowingValues is a feature step that can be defined for a specific JobsFeature.
+// It checks the response from calling GET /jobs to make sure that each job contains the expected values of
+// all the remaining attributes of a job.
 func (f *JobsFeature) eachJobShouldAlsoContainTheFollowingValues(table *godog.Table) error {
 	expectedResult, err := assistdog.NewDefault().ParseMap(table)
 	if err != nil {
@@ -375,9 +375,9 @@ func (f *JobsFeature) eachJobShouldAlsoContainTheFollowingValues(table *godog.Ta
 	return f.ErrorFeature.StepError()
 }
 
-//theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst is a feature step that can be defined for a specific JobsFeature.
-//It checks the response from calling GET /jobs to make sure that the jobs are in ascending order of their last_updated
-//times i.e. the most recently updated is last in the list.
+// theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst is a feature step that can be defined for a specific JobsFeature.
+// It checks the response from calling GET /jobs to make sure that the jobs are in ascending order of their last_updated
+// times i.e. the most recently updated is last in the list.
 func (f *JobsFeature) theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst() error {
 	var response models.Jobs
 	err := json.Unmarshal(f.responseBody, &response)

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -37,29 +37,28 @@ func (m *JobStore) CreateJob(ctx context.Context, id string) (job models.Job, er
 		return models.Job{}, errors.New("id must not be an empty string")
 	}
 
-	//Create a Job that's populated with default values of all its attributes
+	// Create a Job that's populated with default values of all its attributes
 	newJob := models.NewJob(id)
 
 	s := m.Session.Copy()
 	defer s.Close()
 	var jobToFind models.Job
 
-	//Check that the jobs collection does not already contain the id as a key
+	// Check that the jobs collection does not already contain the id as a key
 	err = s.DB(m.Database).C(m.Collection).Find(bson.M{"id": id}).One(&jobToFind)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			//this means we CAN insert the job as it does not already exist
+			// This means we CAN insert the job as it does not already exist
 			err = s.DB(m.Database).C(m.Collection).Insert(newJob)
 			if err != nil {
 				return models.Job{}, errors.New("error inserting job into mongo DB")
 			}
 			log.Event(ctx, "adding job to jobs collection", log.Data{"Job details: ": newJob})
 		} else {
-			//an unexpected error has occurred
 			return models.Job{}, err
 		}
 	} else {
-		//no error means that it found a job already exists with the id we're trying to insert
+		// As there is no error this means that it found a job with the id we're trying to insert
 		return models.Job{}, errors.New("id must be unique")
 	}
 
@@ -127,7 +126,7 @@ func (m *JobStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 		return results, nil
 	}
 
-	//need to get all the jobs from the jobs collection and order them by lastupdated
+	// Get all the jobs from the jobs collection and order them by lastupdated
 	iter := s.DB(m.Database).C(m.Collection).Find(bson.M{}).Sort("lastupdated").Iter()
 	defer func() {
 		err := iter.Close()

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dpMongodb "github.com/ONSdigital/dp-mongodb"
 	dpMongoLock "github.com/ONSdigital/dp-mongodb/dplock"
 	dpMongoHealth "github.com/ONSdigital/dp-mongodb/health"
@@ -167,4 +168,9 @@ func (m *JobStore) GetJob(ctx context.Context, id string) (models.Job, error) {
 	}
 
 	return job, nil
+}
+
+// Checker is called by the healthcheck library to check the health state of this mongoDB instance
+func (m *JobStore) Checker(ctx context.Context, state *healthcheck.CheckState) error {
+	return m.healthClient.Checker(ctx, state)
 }

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -86,9 +86,10 @@ func (e *Init) DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, versio
 // DoGetMongoDB returns a MongoDB
 func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (MongoJobStorer, error) {
 	mongodb := &mongo.JobStore{
-		Collection: cfg.MongoConfig.Collection,
-		Database:   cfg.MongoConfig.Database,
-		URI:        cfg.MongoConfig.BindAddr,
+		Collection:      cfg.MongoConfig.Collection,
+		LocksCollection: cfg.MongoConfig.LocksCollection,
+		Database:        cfg.MongoConfig.Database,
+		URI:             cfg.MongoConfig.BindAddr,
 	}
 	if err := mongodb.Init(ctx); err != nil {
 		return nil, err

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -40,4 +40,5 @@ type HealthChecker interface {
 type MongoJobStorer interface {
 	api.JobStorer
 	Close(ctx context.Context) error
+	Checker(ctx context.Context, state *healthcheck.CheckState) (err error)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -50,6 +50,9 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		log.Event(ctx, "could not instantiate healthCheck", log.FATAL, log.Error(err))
 		return nil, err
 	}
+	if err = hc.AddCheck("Mongo DB", mongoDB.Checker); err != nil {
+		log.Event(ctx, "error adding check for mongo db", log.ERROR, log.Error(err))
+	}
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 	hc.Start(ctx)

--- a/service/service.go
+++ b/service/service.go
@@ -52,6 +52,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 	if err = hc.AddCheck("Mongo DB", mongoDB.Checker); err != nil {
 		log.Event(ctx, "error adding check for mongo db", log.ERROR, log.Error(err))
+		return nil, err
 	}
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -218,7 +218,6 @@ func TestClose(t *testing.T) {
 
 		hcStopped := false
 		serverStopped := false
-		//mongoStopped := false
 
 		// healthcheck Stop does not depend on any other service being closed/stopped
 		hcMock := &serviceMock.HealthCheckerMock{

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -282,6 +282,31 @@ definitions:
 
   HealthChecker:
     type: object
+    properties:
+      name:
+        type: string
+        description: "The name of external service used by API"
+        enum: [ "mongodb" ]
+      status:
+        type: string
+        description: "The status of the external service"
+        enum: [ "OK", "WARNING", "CRITICAL" ]
+      message:
+        type: string
+        description: "The message status of the external service"
+        example: "mongodb is OK"
+      last_checked:
+        type: string
+        description: "The last health check date and time of the external service"
+        example: "2020-06-11T11:49:50.330089Z"
+      last_success:
+        type: string
+        description: "The last successful health check date and time of the external service"
+        example: "2020-06-11T11:49:50.330089Z"
+      last_failure:
+        type: string
+        description: "The last failed health check date and time of the external service"
+        example: null
 
 parameters:
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -286,7 +286,7 @@ definitions:
       name:
         type: string
         description: "The name of external service used by API"
-        enum: [ "mongodb" ]
+        example: "Mongo DB"
       status:
         type: string
         description: "The status of the external service"
@@ -294,7 +294,7 @@ definitions:
       message:
         type: string
         description: "The message status of the external service"
-        example: "mongodb is OK"
+        example: "mongodb is OK and all expected collections exist"
       last_checked:
         type: string
         description: "The last health check date and time of the external service"


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
A health checker has been added to check the connection from dp-search-reindex-api to MongoDB search database, jobs collection, and jobs_locks collection.

The swagger spec has been updated to include details of the registered health check.

The MongoJobStorerMock has been updated to include the Checker function. 

The service unit tests have been extended to test the AddCheck function of the HealthChecker.

The following changes have been made to the code:
- A Checker function has been added to the list of functions specified in the service.MongoJobStorer interface
- A Checker function has been added to the mongo.JobStore, which implements the MongoJobStorer interface
- After initialising the HealthChecker, the service now calls its "AddCheck" function to add a check for MongoDB

Example of the health check details returned by the /health endpoint:

{
    "status": "OK",
    "version": {
        "build_time": "2021-06-28T15:43:59+01:00",
        "git_commit": "e36fde2acbd2edb1410fb248f0fa5d40eb010273",
        "language": "go",
        "language_version": "go1.16.3",
        "version": ""
    },
    "uptime": 131502,
    "start_time": "2021-06-28T14:44:00.349168Z",
    "checks": [
        {
            "name": "Mongo DB",
            "status": "OK",
            "message": "mongodb is OK and all expected collections exist",
            "last_checked": "2021-06-28T14:45:58.189531Z",
            "last_success": "2021-06-28T14:45:58.189531Z",
            "last_failure": null
        }
    ]
}

# How to review
<!--- Describe in detail how you tested your changes. -->
The endpoint can be tested locally by first running MongoDB locally as follows:
- pull down the latest version of dp-compose and go into it's root directory. Then run these commands:
- docker-compose up -d
- docker start dp-compose_mongodb_1
- mongo

There should now be a local connection to mongodb://127.0.0.1:27017

The functionality can now be tested by moving into the root of dp-search-reindex-api, pulling down this branch, then running this command: make debug
Postman can be used to test that the health endpoint now includes a check for mongo db and works successfully:
- GET: http://localhost:25700/health (should show the health check details)

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
