### PR TITLE
Feature/check no inflight jobs

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -78,7 +78,11 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 		job, err := api.jobStore.GetJob(req.Context(), id)
 		if err != nil {
 			log.Event(ctx, "getting job failed", log.Error(err), logData, log.ERROR)
-			http.Error(w, "Failed to find job in job store", http.StatusNotFound)
+			if err == mongo.ErrJobNotFound {
+				http.Error(w, "Failed to find job in job store", http.StatusNotFound)
+			} else {
+				http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+			}
 			return
 		}
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -32,7 +32,11 @@ func (api *JobStoreAPI) CreateJobHandler(ctx context.Context) http.HandlerFunc {
 		newJob, err := api.jobStore.CreateJob(ctx, id)
 		if err != nil {
 			log.Event(ctx, "creating and storing job failed", log.Error(err), log.ERROR)
-			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+			if err == mongo.ErrExistingJobInProgress {
+				http.Error(w, "existing reindex job in progress", http.StatusConflict)
+			} else {
+				http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+			}
 			return
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	MaxReindexJobRuntime       time.Duration `envconfig:"MAX_REINDEX_JOB_RUNTIME"`
 	MongoConfig                MongoConfig
 }
 
@@ -37,6 +38,7 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    20 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
+		MaxReindexJobRuntime:       3600 * time.Second,
 		MongoConfig: MongoConfig{
 			BindAddr:        "localhost:27017",
 			Collection:      "jobs",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,7 @@ func TestConfig(t *testing.T) {
 					GracefulShutdownTimeout:    20 * time.Second,
 					HealthCheckInterval:        30 * time.Second,
 					HealthCheckCriticalTimeout: 90 * time.Second,
+					MaxReindexJobRuntime:       3600 * time.Second,
 					MongoConfig: MongoConfig{
 						BindAddr:        "localhost:27017",
 						Collection:      "jobs",

--- a/features/getting_a_job.feature
+++ b/features/getting_a_job.feature
@@ -24,3 +24,9 @@ Feature: Getting a job
     Given no jobs have been generated in the Job Store
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "404"
+
+  Scenario: The connection to mongo DB is lost and a get request returns an internal server error
+
+    Given the search reindex api loses its connection to mongo DB
+    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
+    Then the HTTP status code should be "500"

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -65,7 +65,7 @@ func NewJobsFeature(mongoFeature *componentTest.MongoFeature) (*JobsFeature, err
 		URI:        mongoFeature.Server.URI(),
 	}
 	ctx := context.Background()
-	if err := mongodb.Init(ctx); err != nil {
+	if err := mongodb.Init(ctx, cfg); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,11 @@ func (f *JobsFeature) Reset(mongoFail bool) *JobsFeature {
 		f.MongoClient.Database = memongo.RandomDatabase()
 	}
 	ctx := context.Background()
-	err := f.MongoClient.Init(ctx)
+	cfg, err := config.Get()
+	if err != nil {
+		return nil
+	}
+	err = f.MongoClient.Init(ctx, cfg)
 	if err != nil {
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/benweissmann/memongo v0.1.1
 	github.com/cucumber/godog v0.10.0
-	github.com/cucumber/messages-go/v10 v10.0.3
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gorilla/mux v1.8.0
 	github.com/justinas/alice v1.2.0

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -6,7 +6,8 @@ import (
 
 // A list of error messages for Mongo
 var (
-	ErrJobNotFound         = errors.New("the job id could not be found in the jobs collection")
-	ErrEmptyIDProvided     = errors.New("id must not be an empty string")
-	ErrDuplicateIDProvided = errors.New("id must be unique")
+	ErrJobNotFound           = errors.New("the job id could not be found in the jobs collection")
+	ErrEmptyIDProvided       = errors.New("id must not be an empty string")
+	ErrDuplicateIDProvided   = errors.New("id must be unique")
+	ErrExistingJobInProgress = errors.New("there is an existing job currently in progress")
 )

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -54,7 +54,7 @@ func (m *JobStore) CreateJob(ctx context.Context, id string) (job models.Job, er
 	checkFromTime := time.Now().Add(-1 * m.cfg.MaxReindexJobRuntime)
 	var jobStartTime time.Time
 	for iter.Next(&result) {
-		//if the start time of the job in progress is later than the checkFromTime but earlier than now then a new job should not be created yet.
+		// If the start time of the job in progress is later than the checkFromTime but earlier than now then a new job should not be created yet.
 		jobStartTime = result.ReindexStarted
 		if jobStartTime.After(checkFromTime) && jobStartTime.Before(time.Now()) {
 			log.Event(ctx, "found job in progress", log.Data{"id": result.ID, "state": result.State, "start time": jobStartTime})
@@ -62,8 +62,7 @@ func (m *JobStore) CreateJob(ctx context.Context, id string) (job models.Job, er
 		}
 	}
 	defer func() {
-		err := iter.Close()
-		if err != nil {
+		if err := iter.Close(); err != nil {
 			log.Event(ctx, "error closing iterator", log.ERROR, log.Error(err))
 		}
 	}()

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -91,7 +91,7 @@ func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (MongoJobSt
 		Database:        cfg.MongoConfig.Database,
 		URI:             cfg.MongoConfig.BindAddr,
 	}
-	if err := mongodb.Init(ctx); err != nil {
+	if err := mongodb.Init(ctx, cfg); err != nil {
 		return nil, err
 	}
 	return mongodb, nil


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changes have been made for the purpose of the following story:

As an API user
I do not want to trigger multiple reindexes in a short space of time
so that the backend processing of a reindex job has time to successfully finish before a new reindex job can be triggered

These are the changes:

The endpoint that allows a POST request to be made, which creates a search reindex job document in mongoDB, has been amended so that the new job will only get created if there are no jobs currently in progress.

If a job is currently in progress then it will contain the following value of state:

"state": "in-progress"

So the endpoint now creates an iteration of all the jobs that have a state set to "in-progress" and orders it so that the one with the most recent reindex_started time is first.

It uses a new environment variable named MAX_REINDEX_JOB_RUNTIME, which gives a duration in seconds, and subtracts this from the current time to calculate a "check from" time.

It then loops through the iteration and checks each reindex_started time to see if it falls between the "check from" time and now. If it does then a 409 conflict error occurs with the following message:

"existing reindex job in progress"

A unit test has been added for the POST request handler.

A few other changes have been made to refactor existing code and increase the coverage of both unit tests and component tests.

# How to review
<!--- Describe in detail how you tested your changes. -->
The endpoint can be tested locally using this POST URL: http://localhost:25700/jobs

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
