### PR TITLE
Release/0.8.0

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,4 +1,4 @@
-# The nancy command has found a vulnerability, which is an out of date version of GoGo Protobuf. However, this cannot be updated due to the project also having an indirect dependency of something called 
+# The nancy command has found a vulnerability, which is an out of date version of GoGo Protobuf. However, this cannot be updated due to the project also having an indirect dependency of something called
 # scram; the latest version of scram has a new path in github, which also needs to be changed (instead of http://github.com/xdg/scram it is now http://github.com/xdg-go/scram I believe). The problem is 
 # that if I manually amend this path and version in the go.sum file then it reverts back when I try to commit and push the code (so it won't let me update GoGo Protobuf either). So I need to update the
 # dependency that is actually using scram directly. That dependency is actually mongo-driver, which itself is a dependency in dp-component-test, which is a dependency in this project. But on further

--- a/README.md
+++ b/README.md
@@ -1,23 +1,45 @@
 dp-search-reindex-api
-================
-Provides details about search reindex jobs and enables creation and running of them
+=====================
+Provides detail about search reindex jobs and enables creation and running of them
 
 ### Getting started
 
-* Run `make debug`
+* Set up dependencies then run `make debug`
 
 ### Dependencies
 
+* Requires MongoDB running on port 27017
 * No further dependencies other than those defined in `go.mod`
 
 ### Configuration
 
-| Environment variable         | Default   | Description
-| ---------------------------- | --------- | -----------
-| BIND_ADDR                    | :25700    | The host and port to bind to
-| GRACEFUL_SHUTDOWN_TIMEOUT    | 20s        | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 30s       | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| Environment variable         | Default         | Description
+| ---------------------------- | --------------- | -----------
+| BIND_ADDR                    | :25700          | The host and port to bind to
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 20s             | The graceful shutdown timeout in seconds (`time.Duration` format)
+| HEALTHCHECK_INTERVAL         | 30s             | Time between self-healthchecks (`time.Duration` format)
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s             | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| MAX_REINDEX_JOB_RUNTIME      | 3600s           | The maximum amount of time that a reindex job is allowed to run before another reindex job can be started
+| MONGODB_BIND_ADDR            | localhost:27017 | The MongoDB bind address
+| MONGODB_COLLECTION           | jobs            | MongoDB collection
+| MONGODB_LOCKS_COLLECTION     | jobs_locks      | MongoDB locks collection
+| MONGODB_DATABASE             | search          | The MongoDB search database
+| DEFAULT_MAXIMUM_LIMIT        | 1000            | The maximum number of reindex jobs to be returned in any list (to prevent performance issues)
+| DEFAULT_LIMIT                | 20              | The maximum number of reindex jobs to be returned in a particular list (for a particular request)
+| DEFAULT_OFFSET               | 0               | The number of Job resources into the full list (i.e. the 0-based index) that a particular response is starting at
+
+### Testing
+
+* Run the component tests with this command `go test -component`
+* Run the unit tests with this command `make test`
+
+Postman can be used to test that the endpoints all work as defined in the swagger:
+- POST: http://localhost:25700/jobs (should post a default job into mongoDB and return a JSON representation of it)
+- GET: http://localhost:25700/jobs/<id> NB. Use the id returned by the POST call above e.g. http://localhost:25700/jobs/bc7b87de-abf5-45c5-8e3c-e2a575cab28a (should get a job from mongoDB)
+- GET: http://localhost:25700/jobs (should get all the jobs from mongoDB)
+- GET: http://localhost:25700/jobs?offset=1&limit=2 (should get no more than 2 jobs, from mongoDB, starting from index 1)
+- PUT: http://localhost:25700/jobs/<id>/number_of_tasks/10 (should put a value of 10 in the number_of_tasks field for the job with that particular id)
+- GET: http://localhost:25700/health (should show the health check details)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ Provides detail about search reindex jobs and enables creation and running of th
 | MONGODB_DATABASE             | search          | The MongoDB search database
 | DEFAULT_MAXIMUM_LIMIT        | 1000            | The maximum number of reindex jobs to be returned in any list (to prevent performance issues)
 | DEFAULT_LIMIT                | 20              | The maximum number of reindex jobs to be returned in a particular list (for a particular request)
-| DEFAULT_OFFSET               | 0               | The number of Job resources into the full list (i.e. the 0-based index) that a particular response is starting at
+| DEFAULT_OFFSET               | 0               | The number of reindex jobs into the full list (i.e. the 0-based index) that a particular response is starting at
 
 ### Testing
 
 * Run the component tests with this command `go test -component`
 * Run the unit tests with this command `make test`
 
-Postman can be used to test that the endpoints all work as defined in the swagger:
+Postman can be used to test that the endpoints all work as defined in the swagger (replace "ID" with the id value where applicable):
 - POST: http://localhost:25700/jobs (should post a default job into mongoDB and return a JSON representation of it)
-- GET: http://localhost:25700/jobs/<id> NB. Use the id returned by the POST call above e.g. http://localhost:25700/jobs/bc7b87de-abf5-45c5-8e3c-e2a575cab28a (should get a job from mongoDB)
+- GET: http://localhost:25700/jobs/ID NB. Use the id returned by the POST call above e.g. http://localhost:25700/jobs/bc7b87de-abf5-45c5-8e3c-e2a575cab28a (should get a job from mongoDB)
 - GET: http://localhost:25700/jobs (should get all the jobs from mongoDB)
 - GET: http://localhost:25700/jobs?offset=1&limit=2 (should get no more than 2 jobs, from mongoDB, starting from index 1)
-- PUT: http://localhost:25700/jobs/<id>/number_of_tasks/10 (should put a value of 10 in the number_of_tasks field for the job with that particular id)
+- PUT: http://localhost:25700/jobs/ID/number_of_tasks/10 (should put a value of 10 in the number_of_tasks field for the job with that particular id)
 - GET: http://localhost:25700/health (should show the health check details)
 
 ### Contributing

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 )
 
@@ -12,8 +11,13 @@ import (
 type JobStorer interface {
 	CreateJob(ctx context.Context, id string) (job models.Job, err error)
 	GetJob(ctx context.Context, id string) (job models.Job, err error)
-	GetJobs(ctx context.Context) (job models.Jobs, err error)
+	GetJobs(ctx context.Context, offsetParam string, limitParam string) (job models.Jobs, err error)
 	AcquireJobLock(ctx context.Context, id string) (lockID string, err error)
 	UnlockJob(lockID string) error
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
+}
+
+// Paginator defines the required methods from the paginator package
+type Paginator interface {
+	ValidatePaginationParameters(offsetParam string, limitParam string, totalCount int) (offset int, limit int, err error)
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -109,8 +109,10 @@ func (api *JobStoreAPI) GetJobHandler(ctx context.Context) http.HandlerFunc {
 func (api *JobStoreAPI) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	log.Event(ctx, "Entering handler function, which calls GetJobs and returns a list of existing Job resources held in the JobStore.", log.INFO)
+	offsetParameter := req.URL.Query().Get("offset")
+	limitParameter := req.URL.Query().Get("limit")
 
-	jobs, err := api.jobStore.GetJobs(ctx)
+	jobs, err := api.jobStore.GetJobs(ctx, offsetParameter, limitParameter)
 	if err != nil {
 		log.Event(ctx, "getting list of jobs failed", log.Error(err), log.ERROR)
 		http.Error(w, serverErrorMessage, http.StatusInternalServerError)

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -3,12 +3,12 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"github.com/ONSdigital/dp-search-reindex-api/pagination"
 	"math"
 	"net/http"
 	"strconv"
 
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
+	"github.com/ONSdigital/dp-search-reindex-api/pagination"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -230,7 +230,7 @@ func TestGetJobsHandler(t *testing.T) {
 	t.Parallel()
 	Convey("Given a Search Reindex Job API that returns a list of jobs", t, func() {
 		jobsCollectionMock := &apiMock.JobStorerMock{
-			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
 				jobs := models.Jobs{}
 				jobsList := make([]models.Job, 2)
 
@@ -297,7 +297,7 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 	t.Parallel()
 	Convey("Given a Search Reindex Job API that returns an empty list of jobs", t, func() {
 		jobsCollectionMock := &apiMock.JobStorerMock{
-			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
 				jobs := models.Jobs{}
 
 				return jobs, nil
@@ -332,7 +332,7 @@ func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 	t.Parallel()
 	Convey("Given a Search Reindex Job API that that failed to connect to the Job Store", t, func() {
 		jobsCollectionMock := &apiMock.JobStorerMock{
-			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
 				jobs := models.Jobs{}
 
 				return jobs, errors.New("something went wrong in the server")

--- a/api/mock/job_storer.go
+++ b/api/mock/job_storer.go
@@ -257,13 +257,13 @@ func (mock *JobStorerMock) GetJobs(ctx context.Context, offsetParam string, limi
 		return results, nil
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx         context.Context
 		OffsetParam string
-		LimitParam string
+		LimitParam  string
 	}{
-		Ctx: ctx,
+		Ctx:         ctx,
 		OffsetParam: offsetParam,
-		LimitParam: limitParam,
+		LimitParam:  limitParam,
 	}
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
 	return mock.GetJobsFunc(ctx, offsetParam, limitParam)
@@ -273,14 +273,14 @@ func (mock *JobStorerMock) GetJobs(ctx context.Context, offsetParam string, limi
 // Check the length with:
 //     len(mockedJobStorer.GetJobsCalls())
 func (mock *JobStorerMock) GetJobsCalls() []struct {
-	Ctx context.Context
+	Ctx         context.Context
 	OffsetParam string
-	LimitParam string
+	LimitParam  string
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx         context.Context
 		OffsetParam string
-		LimitParam string
+		LimitParam  string
 	}
 	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs

--- a/api/mock/job_storer.go
+++ b/api/mock/job_storer.go
@@ -36,7 +36,7 @@ var _ api.JobStorer = &JobStorerMock{}
 // 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
 // 				panic("mock out the GetJob method")
 // 			},
-// 			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+// 			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
 // 				panic("mock out the GetJobs method")
 // 			},
 // 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
@@ -62,7 +62,7 @@ type JobStorerMock struct {
 	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
-	GetJobsFunc func(ctx context.Context) (models.Jobs, error)
+	GetJobsFunc func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error)
 
 	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
 	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
@@ -97,6 +97,10 @@ type JobStorerMock struct {
 		GetJobs []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// OffsetParam is the offsetParam argument value.
+			OffsetParam string
+			// LimitParam is the limitParam argument value.
+			LimitParam string
 		}
 		// PutNumberOfTasks holds details about calls to the PutNumberOfTasks method.
 		PutNumberOfTasks []struct {
@@ -243,7 +247,7 @@ func (mock *JobStorerMock) GetJobCalls() []struct {
 }
 
 // GetJobs calls GetJobsFunc.
-func (mock *JobStorerMock) GetJobs(ctx context.Context) (job models.Jobs, err error) {
+func (mock *JobStorerMock) GetJobs(ctx context.Context, offsetParam string, limitParam string) (job models.Jobs, err error) {
 	if mock.GetJobsFunc == nil {
 		results := models.Jobs{}
 		jobs := make([]models.Job, 2)
@@ -254,11 +258,15 @@ func (mock *JobStorerMock) GetJobs(ctx context.Context) (job models.Jobs, err er
 	}
 	callInfo := struct {
 		Ctx context.Context
+		OffsetParam string
+		LimitParam string
 	}{
 		Ctx: ctx,
+		OffsetParam: offsetParam,
+		LimitParam: limitParam,
 	}
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	return mock.GetJobsFunc(ctx)
+	return mock.GetJobsFunc(ctx, offsetParam, limitParam)
 }
 
 // GetJobsCalls gets all the calls that were made to GetJobs.
@@ -266,9 +274,13 @@ func (mock *JobStorerMock) GetJobs(ctx context.Context) (job models.Jobs, err er
 //     len(mockedJobStorer.GetJobsCalls())
 func (mock *JobStorerMock) GetJobsCalls() []struct {
 	Ctx context.Context
+	OffsetParam string
+	LimitParam string
 } {
 	var calls []struct {
 		Ctx context.Context
+		OffsetParam string
+		LimitParam string
 	}
 	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs

--- a/config/config.go
+++ b/config/config.go
@@ -14,8 +14,9 @@ type Config struct {
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	MaxReindexJobRuntime       time.Duration `envconfig:"MAX_REINDEX_JOB_RUNTIME"`
 	MongoConfig                MongoConfig
-	Offset					   int           `envconfig:"OFFSET"`
-	Limit					   int			 `envconfig:"LIMIT"`
+	DefaultMaxLimit            int `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
+	DefaultLimit               int `envconfig:"DEFAULT_LIMIT"`
+	DefaultOffset              int `envconfig:"DEFAULT_OFFSET"`
 }
 
 // MongoConfig contains the config required to connect to MongoDB.
@@ -47,8 +48,9 @@ func Get() (*Config, error) {
 			LocksCollection: "jobs_locks",
 			Database:        "search",
 		},
-		Limit: 20,
-		Offset: 0,
+		DefaultMaxLimit: 1000,
+		DefaultLimit:    20,
+		DefaultOffset:   0,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	MaxReindexJobRuntime       time.Duration `envconfig:"MAX_REINDEX_JOB_RUNTIME"`
 	MongoConfig                MongoConfig
+	Offset					   int           `envconfig:"OFFSET"`
+	Limit					   int			 `envconfig:"LIMIT"`
 }
 
 // MongoConfig contains the config required to connect to MongoDB.
@@ -45,6 +47,8 @@ func Get() (*Config, error) {
 			LocksCollection: "jobs_locks",
 			Database:        "search",
 		},
+		Limit: 20,
+		Offset: 0,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,7 @@ func TestConfig(t *testing.T) {
 						Database:        "search",
 					},
 					Limit: 20,
+					Offset: 0,
 				})
 			})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func TestConfig(t *testing.T) {
 						LocksCollection: "jobs_locks",
 						Database:        "search",
 					},
+					Limit: 20,
 				})
 			})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,8 +34,9 @@ func TestConfig(t *testing.T) {
 						LocksCollection: "jobs_locks",
 						Database:        "search",
 					},
-					Limit: 20,
-					Offset: 0,
+					DefaultMaxLimit: 1000,
+					DefaultLimit:    20,
+					DefaultOffset:   0,
 				})
 			})
 

--- a/features/getting_jobs.feature
+++ b/features/getting_jobs.feature
@@ -31,3 +31,26 @@ Feature: Getting a list of jobs
     """
     Then I would expect the response to be an empty list
     And the HTTP status code should be "200"
+
+  Scenario: Six jobs exist and a get request with offset and limit correctly returns four
+
+    Given I have generated six jobs in the Job Store
+    When I GET "/jobs?offset=1&limit=4"
+    """
+    """
+    Then I would expect there to be four jobs returned in a list
+    And in each job I would expect id, last_updated, and links to have this structure
+      | id           | UUID                                   |
+      | last_updated | Not in the future                      |
+      | links: tasks | http://localhost:12150/jobs/{id}/tasks |
+      | links: self  | http://localhost:12150/jobs/{id}       |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | search_index_name               | Default Search Index Name |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first

--- a/features/getting_jobs.feature
+++ b/features/getting_jobs.feature
@@ -54,3 +54,35 @@ Feature: Getting a list of jobs
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the jobs should be ordered, by last_updated, with the oldest first
+
+  Scenario: Three jobs exist and a get request with negative offset returns an error
+
+    Given I have generated three jobs in the Job Store
+    When I GET "/jobs?offset=-2"
+    """
+    """
+    Then the HTTP status code should be "400"
+
+  Scenario: Three jobs exist and a get request with offset greater than three returns an error
+
+    Given I have generated three jobs in the Job Store
+    When I GET "/jobs?offset=4"
+    """
+    """
+    Then the HTTP status code should be "400"
+
+  Scenario: Three jobs exist and a get request with negative limit returns an error
+
+    Given I have generated three jobs in the Job Store
+    When I GET "/jobs?limit=-3"
+    """
+    """
+    Then the HTTP status code should be "400"
+
+  Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
+
+    Given I have generated three jobs in the Job Store
+    When I GET "/jobs?limit=1001"
+    """
+    """
+    Then the HTTP status code should be "400"

--- a/features/steps/jobs_steps.go
+++ b/features/steps/jobs_steps.go
@@ -106,6 +106,7 @@ func (f *JobsFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I call GET \/jobs\/{id} using the generated id$`, f.iCallGETJobsidUsingTheGeneratedId)
 	ctx.Step(`^I have generated three jobs in the Job Store$`, f.iHaveGeneratedThreeJobsInTheJobStore)
 	ctx.Step(`^I would expect there to be three or more jobs returned in a list$`, f.iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList)
+	ctx.Step(`^I would expect there to be four jobs returned in a list$`, f.iWouldExpectThereToBeFourJobsReturnedInAList)
 	ctx.Step(`^in each job I would expect id, last_updated, and links to have this structure$`, f.inEachJobIWouldExpectIdLast_updatedAndLinksToHaveThisStructure)
 	ctx.Step(`^each job should also contain the following values:$`, f.eachJobShouldAlsoContainTheFollowingValues)
 	ctx.Step(`^the jobs should be ordered, by last_updated, with the oldest first$`, f.theJobsShouldBeOrderedByLast_updatedWithTheOldestFirst)
@@ -118,6 +119,7 @@ func (f *JobsFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I call PUT \/jobs\/{id}\/number_of_tasks\/{"([^"]*)"} using the generated id with an invalid count$`, f.iCallPUTJobsidnumber_of_tasksUsingTheGeneratedIdWithAnInvalidCount)
 	ctx.Step(`^I call PUT \/jobs\/{id}\/number_of_tasks\/{"([^"]*)"} using the generated id with a negative count$`, f.iCallPUTJobsidnumber_of_tasksUsingTheGeneratedIdWithANegativeCount)
 	ctx.Step(`^the search reindex api loses its connection to mongo DB$`, f.theSearchReindexApiLosesItsConnectionToMongoDB)
+	ctx.Step(`^I have generated six jobs in the Job Store$`, f.iHaveGeneratedSixJobsInTheJobStore)
 }
 
 // Reset sets the resources within a specific JobsFeature back to their default values.
@@ -330,6 +332,43 @@ func (f *JobsFeature) iHaveGeneratedThreeJobsInTheJobStore() error {
 	return f.ErrorFeature.StepError()
 }
 
+// iHaveGeneratedSixJobsInTheJobStore is a feature step that can be defined for a specific JobsFeature.
+// It calls POST /jobs with an empty body, three times, which causes three default job resources to be generated.
+func (f *JobsFeature) iHaveGeneratedSixJobsInTheJobStore() error {
+	// call POST /jobs five times
+	err := f.callPostJobs()
+	if err != nil {
+		return fmt.Errorf("error occurred in callPostJobs first time: %w", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	err = f.callPostJobs()
+	if err != nil {
+		return fmt.Errorf("error occurred in callPostJobs second time: %w", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	err = f.callPostJobs()
+	if err != nil {
+		return fmt.Errorf("error occurred in callPostJobs third time: %w", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	err = f.callPostJobs()
+	if err != nil {
+		return fmt.Errorf("error occurred in callPostJobs fourth time: %w", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	err = f.callPostJobs()
+	if err != nil {
+		return fmt.Errorf("error occurred in callPostJobs fifth time: %w", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	err = f.callPostJobs()
+	if err != nil {
+		return fmt.Errorf("error occurred in callPostJobs sixth time: %w", err)
+	}
+
+	return f.ErrorFeature.StepError()
+}
+
 // iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList is a feature step that can be defined for a specific JobsFeature.
 // It checks the response from calling GET /jobs to make sure that a list containing three or more jobs has been returned.
 func (f *JobsFeature) iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() error {
@@ -342,6 +381,22 @@ func (f *JobsFeature) iWouldExpectThereToBeThreeOrMoreJobsReturnedInAList() erro
 	}
 	numJobsFound := len(response.JobList)
 	assert.True(&f.ErrorFeature, numJobsFound >= 3, "The list should contain three or more jobs but it only contains "+strconv.Itoa(numJobsFound))
+
+	return f.ErrorFeature.StepError()
+}
+
+// iWouldExpectThereToBeFourJobsReturnedInAList is a feature step that can be defined for a specific JobsFeature.
+// It checks the response from calling GET /jobs to make sure that a list containing three or more jobs has been returned.
+func (f *JobsFeature) iWouldExpectThereToBeFourJobsReturnedInAList() error {
+	f.responseBody, _ = ioutil.ReadAll(f.ApiFeature.HttpResponse.Body)
+
+	var response models.Jobs
+	err := json.Unmarshal(f.responseBody, &response)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json response: %w", err)
+	}
+	numJobsFound := len(response.JobList)
+	assert.True(&f.ErrorFeature, numJobsFound == 4, "The list should contain four jobs but it contains "+strconv.Itoa(numJobsFound))
 
 	return f.ErrorFeature.StepError()
 }

--- a/models/jobs.go
+++ b/models/jobs.go
@@ -2,9 +2,9 @@ package models
 
 // Jobs represents an array of Job resources and json representation for API
 type Jobs struct {
-	Count      int     `bson:"count,omitempty"        json:"count"`
-	JobList    []Job   `bson:"jobs,omitempty"         json:"jobs"`
-	Limit      int     `bson:"limit,omitempty"        json:"limit"`
-	Offset     int     `bson:"offset_index,omitempty" json:"offset_index"`
-	TotalCount int     `bson:"total_count,omitempty"  json:"total_count"`
+	Count      int   `bson:"count,omitempty"        json:"count"`
+	JobList    []Job `bson:"jobs,omitempty"         json:"jobs"`
+	Limit      int   `bson:"limit,omitempty"        json:"limit"`
+	Offset     int   `bson:"offset_index,omitempty" json:"offset_index"`
+	TotalCount int   `bson:"total_count,omitempty"  json:"total_count"`
 }

--- a/models/jobs.go
+++ b/models/jobs.go
@@ -2,5 +2,9 @@ package models
 
 // Jobs represents an array of Job resources and json representation for API
 type Jobs struct {
-	JobList []Job `json:"jobs"`
+	Count      int     `bson:"count,omitempty"        json:"count"`
+	JobList    []Job   `bson:"jobs,omitempty"         json:"jobs"`
+	Limit      int     `bson:"limit,omitempty"        json:"limit"`
+	Offset     int     `bson:"offset_index,omitempty" json:"offset_index"`
+	TotalCount int     `bson:"total_count,omitempty"  json:"total_count"`
 }

--- a/models/jobs.go
+++ b/models/jobs.go
@@ -5,6 +5,6 @@ type Jobs struct {
 	Count      int   `bson:"count,omitempty"        json:"count"`
 	JobList    []Job `bson:"jobs,omitempty"         json:"jobs"`
 	Limit      int   `bson:"limit,omitempty"        json:"limit"`
-	Offset     int   `bson:"offset_index,omitempty" json:"offset_index"`
+	Offset     int   `bson:"offset,omitempty"       json:"offset"`
 	TotalCount int   `bson:"total_count,omitempty"  json:"total_count"`
 }

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -168,6 +168,7 @@ func (m *JobStore) GetJobs(ctx context.Context) (models.Jobs, error) {
 	}
 
 	results.JobList = jobs
+	results.Count = len(jobs)
 	log.Event(ctx, "list of jobs - sorted by last_updated", log.Data{"Sorted jobs: ": results.JobList}, log.INFO)
 
 	return results, nil

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -242,10 +242,10 @@ func (m *JobStore) UpdateJob(updates bson.M, s *mgo.Session, id string) error {
 // modifyJobs takes a slice, of all the jobs in the Job Store, determined by the offset and limit values
 func modifyJobs(jobs []models.Job, offset int, limit int) []models.Job {
 	var modifiedJobs []models.Job
-	if limit >= len(jobs) {
+	lastIndex := offset + limit
+	if lastIndex >= len(jobs) {
 		modifiedJobs = jobs[offset:]
 	} else {
-		lastIndex := offset + limit
 		modifiedJobs = jobs[offset:lastIndex]
 	}
 	return modifiedJobs

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -1,0 +1,75 @@
+package pagination
+
+import (
+	"errors"
+	"strconv"
+)
+
+var (
+	// ErrInvalidOffsetParameter represents an error case where an invalid offset value is provided
+	ErrInvalidOffsetParameter = errors.New("invalid offset query parameter")
+
+	// ErrOffsetOverTotalCount represents an error case where the given offset value is larger than the total count
+	ErrOffsetOverTotalCount = errors.New("offset query parameter is larger than the total count of jobs")
+
+	// ErrInvalidLimitParameter represents an error case where an invalid limit value is provided
+	ErrInvalidLimitParameter = errors.New("invalid limit query parameter")
+
+	// ErrLimitOverMax represents an error case where the given limit value is larger than the maximum allowed
+	ErrLimitOverMax = errors.New("limit query parameter is larger than the maximum allowed")
+)
+
+// Paginator is a type to hold pagination related defaults, and provides helper functions using the defaults if needed
+type Paginator struct {
+	DefaultLimit    int
+	DefaultOffset   int
+	DefaultMaxLimit int
+}
+
+// PaginatedResponse represents the pagination related values that go into list based response
+type PaginatedResponse struct {
+	Count      int `json:"count"`
+	Offset     int `json:"offset"`
+	Limit      int `json:"limit"`
+	TotalCount int `json:"total_count"`
+}
+
+// NewPaginator creates a new instance
+func NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit int) *Paginator {
+	return &Paginator{
+		DefaultLimit:    defaultLimit,
+		DefaultOffset:   defaultOffset,
+		DefaultMaxLimit: defaultMaxLimit,
+	}
+}
+
+// ValidatePaginationParameters returns pagination related values based on the given request
+func (p *Paginator) ValidatePaginationParameters(offsetParameter string, limitParameter string, totalCount int) (offset int, limit int, err error) {
+
+	offset = p.DefaultOffset
+	limit = p.DefaultLimit
+
+	if offsetParameter != "" {
+		offset, err = strconv.Atoi(offsetParameter)
+		if err != nil || offset < 0 {
+			return 0, 0, ErrInvalidOffsetParameter
+		}
+	}
+
+	if offset > totalCount {
+		return 0, 0, ErrOffsetOverTotalCount
+	}
+
+	if limitParameter != "" {
+		limit, err = strconv.Atoi(limitParameter)
+		if err != nil || limit < 0 {
+			return 0, 0, ErrInvalidLimitParameter
+		}
+	}
+
+	if limit > p.DefaultMaxLimit {
+		return 0, 0, ErrLimitOverMax
+	}
+
+	return
+}

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -7,17 +7,24 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+// Constants for testing
+const (
+	defaultLimit    = 20
+	defaultOffset   = 0
+	defaultMaxLimit = 1000
+)
+
 func TestValidatePaginationParametersReturnsErrorWhenOffsetIsNegative(t *testing.T) {
 
-	Convey("Given a minus offset value passed in and a JobStore containing 20 jobs", t, func() {
+	Convey("Given a minus offset value and a JobStore containing 20 jobs", t, func() {
 
 		offset := "-1"
 		limit := ""
 		totalCount := 20
 
-		Convey("When ReadPaginationValues is called", func() {
+		Convey("When ValidatePaginationValues is called", func() {
 
-			paginator := pagination.NewPaginator(20, 0, 1000)
+			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
 			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
 
 			Convey("Then the expected error is returned", func() {
@@ -30,86 +37,94 @@ func TestValidatePaginationParametersReturnsErrorWhenOffsetIsNegative(t *testing
 	})
 }
 
-//func TestReadPaginationParametersReturnsErrorWhenLimitIsNegative(t *testing.T) {
-//
-//	Convey("Given a request with a minus limit value", t, func() {
-//
-//		r := httptest.NewRequest("GET", "/test?limit=-1", nil)
-//
-//		Convey("When ReadPaginationValues is called", func() {
-//
-//			paginator := pagination.Paginator{}
-//			offset, limit, err := paginator.ReadPaginationParameters(r)
-//
-//			Convey("Then the expected error is returned", func() {
-//				So(err, ShouldEqual, pagination.ErrInvalidLimitParameter)
-//				So(offset, ShouldBeZeroValue)
-//				So(limit, ShouldBeZeroValue)
-//			})
-//		})
-//	})
-//}
+func TestValidatePaginationParametersReturnsErrorWhenLimitIsNegative(t *testing.T) {
 
-//func TestReadPaginationParametersReturnsErrorWhenLimitIsGreaterThanMaxLimit(t *testing.T) {
-//
-//	Convey("Given a request with a limit value over the maximum", t, func() {
-//
-//		r := httptest.NewRequest("GET", "/test?limit=1001", nil)
-//
-//		Convey("When ReadPaginationValues is called", func() {
-//
-//			paginator := pagination.Paginator{DefaultMaxLimit: 1000}
-//			offset, limit, err := paginator.ReadPaginationParameters(r)
-//
-//			Convey("Then the expected error is returned", func() {
-//				So(err, ShouldEqual, pagination.ErrLimitOverMax)
-//				So(offset, ShouldBeZeroValue)
-//				So(limit, ShouldBeZeroValue)
-//			})
-//		})
-//	})
-//}
+	Convey("Given a minus limit value and a JobStore containing 20 jobs", t, func() {
 
-//func TestReadPaginationParametersReturnsLimitAndOffsetProvidedFromQuery(t *testing.T) {
-//
-//	Convey("Given a request with a valid limit and offset", t, func() {
-//
-//		r := httptest.NewRequest("GET", "/test?limit=10&offset=5", nil)
-//
-//		Convey("When ReadPaginationValues is called", func() {
-//
-//			paginator := pagination.Paginator{DefaultMaxLimit: 1000}
-//			offset, limit, err := paginator.ReadPaginationParameters(r)
-//
-//			Convey("Then the expected values are returned", func() {
-//				So(err, ShouldBeNil)
-//				So(offset, ShouldEqual, 5)
-//				So(limit, ShouldEqual, 10)
-//			})
-//		})
-//	})
-//}
+		offset := ""
+		limit := "-1"
+		totalCount := 20
 
-//func TestReadPaginationParametersReturnsDefaultValuesWhenNotProvided(t *testing.T) {
-//
-//	Convey("Given a request without pagination parameters", t, func() {
-//
-//		r := httptest.NewRequest("GET", "/test", nil)
-//
-//		Convey("When ReadPaginationValues is called", func() {
-//			expectedLimit := 20
-//			expectedOffset := 1
-//			paginator := pagination.Paginator{DefaultLimit: expectedLimit, DefaultOffset: expectedOffset, DefaultMaxLimit: 1000}
-//			offset, limit, err := paginator.ReadPaginationParameters(r)
-//
-//			Convey("Then the configured default values are returned", func() {
-//				So(err, ShouldBeNil)
-//				So(offset, ShouldEqual, expectedOffset)
-//				So(limit, ShouldEqual, expectedLimit)
-//			})
-//		})
-//	})
-//}
+		Convey("When ValidatePaginationValues is called", func() {
+
+			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldEqual, pagination.ErrInvalidLimitParameter)
+				So(offset, ShouldBeZeroValue)
+				So(limit, ShouldBeZeroValue)
+			})
+		})
+	})
+}
+
+func TestValidatePaginationParametersReturnsErrorWhenLimitIsGreaterThanMaxLimit(t *testing.T) {
+
+	Convey("Given a request with a limit value over the maximum", t, func() {
+
+		offset := ""
+		limit := "1001"
+		totalCount := 20
+
+		Convey("When ValidatePaginationValues is called", func() {
+
+			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldEqual, pagination.ErrLimitOverMax)
+				So(offset, ShouldBeZeroValue)
+				So(limit, ShouldBeZeroValue)
+			})
+		})
+	})
+}
+
+func TestValidatePaginationParametersReturnsLimitAndOffsetProvidedFromQuery(t *testing.T) {
+
+	Convey("Given a request with a valid limit and offset", t, func() {
+
+		offset := "5"
+		limit := "10"
+		totalCount := 20
+
+		Convey("When ValidatePaginationValues is called", func() {
+
+			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+
+			Convey("Then the expected values are returned", func() {
+				So(err, ShouldBeNil)
+				So(offset, ShouldEqual, 5)
+				So(limit, ShouldEqual, 10)
+			})
+		})
+	})
+}
+
+func TestValidatePaginationParametersReturnsDefaultValuesWhenNotProvided(t *testing.T) {
+
+	Convey("Given a request without pagination parameters", t, func() {
+
+		offset := ""
+		limit := ""
+		totalCount := 20
+
+		Convey("When ValidatePaginationValues is called", func() {
+			expectedLimit := 15
+			expectedOffset := 1
+			paginator := pagination.NewPaginator(expectedLimit, expectedOffset, defaultMaxLimit)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+
+			Convey("Then the configured default values are returned", func() {
+				So(err, ShouldBeNil)
+				So(offset, ShouldEqual, expectedOffset)
+				So(limit, ShouldEqual, expectedLimit)
+			})
+		})
+	})
+}
 
 func TestNewPaginatorReturnsPaginatorStructWithFilledValues(t *testing.T) {
 

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -1,0 +1,133 @@
+package pagination_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-search-reindex-api/pagination"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestValidatePaginationParametersReturnsErrorWhenOffsetIsNegative(t *testing.T) {
+
+	Convey("Given a minus offset value passed in and a JobStore containing 20 jobs", t, func() {
+
+		offset := "-1"
+		limit := ""
+		totalCount := 20
+
+		Convey("When ReadPaginationValues is called", func() {
+
+			paginator := pagination.NewPaginator(20, 0, 1000)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+
+			Convey("Then the expected error is returned", func() {
+
+				So(err, ShouldEqual, pagination.ErrInvalidOffsetParameter)
+				So(offset, ShouldBeZeroValue)
+				So(limit, ShouldBeZeroValue)
+			})
+		})
+	})
+}
+
+//func TestReadPaginationParametersReturnsErrorWhenLimitIsNegative(t *testing.T) {
+//
+//	Convey("Given a request with a minus limit value", t, func() {
+//
+//		r := httptest.NewRequest("GET", "/test?limit=-1", nil)
+//
+//		Convey("When ReadPaginationValues is called", func() {
+//
+//			paginator := pagination.Paginator{}
+//			offset, limit, err := paginator.ReadPaginationParameters(r)
+//
+//			Convey("Then the expected error is returned", func() {
+//				So(err, ShouldEqual, pagination.ErrInvalidLimitParameter)
+//				So(offset, ShouldBeZeroValue)
+//				So(limit, ShouldBeZeroValue)
+//			})
+//		})
+//	})
+//}
+
+//func TestReadPaginationParametersReturnsErrorWhenLimitIsGreaterThanMaxLimit(t *testing.T) {
+//
+//	Convey("Given a request with a limit value over the maximum", t, func() {
+//
+//		r := httptest.NewRequest("GET", "/test?limit=1001", nil)
+//
+//		Convey("When ReadPaginationValues is called", func() {
+//
+//			paginator := pagination.Paginator{DefaultMaxLimit: 1000}
+//			offset, limit, err := paginator.ReadPaginationParameters(r)
+//
+//			Convey("Then the expected error is returned", func() {
+//				So(err, ShouldEqual, pagination.ErrLimitOverMax)
+//				So(offset, ShouldBeZeroValue)
+//				So(limit, ShouldBeZeroValue)
+//			})
+//		})
+//	})
+//}
+
+//func TestReadPaginationParametersReturnsLimitAndOffsetProvidedFromQuery(t *testing.T) {
+//
+//	Convey("Given a request with a valid limit and offset", t, func() {
+//
+//		r := httptest.NewRequest("GET", "/test?limit=10&offset=5", nil)
+//
+//		Convey("When ReadPaginationValues is called", func() {
+//
+//			paginator := pagination.Paginator{DefaultMaxLimit: 1000}
+//			offset, limit, err := paginator.ReadPaginationParameters(r)
+//
+//			Convey("Then the expected values are returned", func() {
+//				So(err, ShouldBeNil)
+//				So(offset, ShouldEqual, 5)
+//				So(limit, ShouldEqual, 10)
+//			})
+//		})
+//	})
+//}
+
+//func TestReadPaginationParametersReturnsDefaultValuesWhenNotProvided(t *testing.T) {
+//
+//	Convey("Given a request without pagination parameters", t, func() {
+//
+//		r := httptest.NewRequest("GET", "/test", nil)
+//
+//		Convey("When ReadPaginationValues is called", func() {
+//			expectedLimit := 20
+//			expectedOffset := 1
+//			paginator := pagination.Paginator{DefaultLimit: expectedLimit, DefaultOffset: expectedOffset, DefaultMaxLimit: 1000}
+//			offset, limit, err := paginator.ReadPaginationParameters(r)
+//
+//			Convey("Then the configured default values are returned", func() {
+//				So(err, ShouldBeNil)
+//				So(offset, ShouldEqual, expectedOffset)
+//				So(limit, ShouldEqual, expectedLimit)
+//			})
+//		})
+//	})
+//}
+
+func TestNewPaginatorReturnsPaginatorStructWithFilledValues(t *testing.T) {
+
+	Convey("Given a set of expected paginator values", t, func() {
+
+		expectedPaginator := &pagination.Paginator{
+			DefaultLimit:    10,
+			DefaultOffset:   5,
+			DefaultMaxLimit: 100,
+		}
+
+		Convey("When NewPaginator is called", func() {
+
+			actualPaginator := pagination.NewPaginator(10, 5, 100)
+
+			Convey("Then the paginator is configured as expected", func() {
+				So(actualPaginator, ShouldResemble, expectedPaginator)
+			})
+		})
+	})
+}

--- a/service/mock/mongo_job_storer.go
+++ b/service/mock/mongo_job_storer.go
@@ -322,13 +322,13 @@ func (mock *MongoJobStorerMock) GetJobs(ctx context.Context, offsetParam string,
 		panic("MongoJobStorerMock.GetJobsFunc: method is nil but MongoJobStorer.GetJobs was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx         context.Context
 		OffsetParam string
-		LimitParam string
+		LimitParam  string
 	}{
-		Ctx: ctx,
+		Ctx:         ctx,
 		OffsetParam: offsetParam,
-		LimitParam: limitParam,
+		LimitParam:  limitParam,
 	}
 	mock.lockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
@@ -340,14 +340,14 @@ func (mock *MongoJobStorerMock) GetJobs(ctx context.Context, offsetParam string,
 // Check the length with:
 //     len(mockedMongoJobStorer.GetJobsCalls())
 func (mock *MongoJobStorerMock) GetJobsCalls() []struct {
-	Ctx context.Context
+	Ctx         context.Context
 	OffsetParam string
-	LimitParam string
+	LimitParam  string
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx         context.Context
 		OffsetParam string
-		LimitParam string
+		LimitParam  string
 	}
 	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs

--- a/service/mock/mongo_job_storer.go
+++ b/service/mock/mongo_job_storer.go
@@ -36,7 +36,7 @@ var _ service.MongoJobStorer = &MongoJobStorerMock{}
 // 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
 // 				panic("mock out the GetJob method")
 // 			},
-// 			GetJobsFunc: func(ctx context.Context) (models.Jobs, error) {
+// 			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
 // 				panic("mock out the GetJobs method")
 // 			},
 // 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
@@ -68,7 +68,7 @@ type MongoJobStorerMock struct {
 	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
-	GetJobsFunc func(ctx context.Context) (models.Jobs, error)
+	GetJobsFunc func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error)
 
 	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
 	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
@@ -115,6 +115,10 @@ type MongoJobStorerMock struct {
 		GetJobs []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// OffsetParam is the offsetParam argument value.
+			OffsetParam string
+			// LimitParam is the limitParam argument value.
+			LimitParam string
 		}
 		// PutNumberOfTasks holds details about calls to the PutNumberOfTasks method.
 		PutNumberOfTasks []struct {
@@ -313,19 +317,23 @@ func (mock *MongoJobStorerMock) GetJobCalls() []struct {
 }
 
 // GetJobs calls GetJobsFunc.
-func (mock *MongoJobStorerMock) GetJobs(ctx context.Context) (models.Jobs, error) {
+func (mock *MongoJobStorerMock) GetJobs(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
 	if mock.GetJobsFunc == nil {
 		panic("MongoJobStorerMock.GetJobsFunc: method is nil but MongoJobStorer.GetJobs was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
+		OffsetParam string
+		LimitParam string
 	}{
 		Ctx: ctx,
+		OffsetParam: offsetParam,
+		LimitParam: limitParam,
 	}
 	mock.lockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
 	mock.lockGetJobs.Unlock()
-	return mock.GetJobsFunc(ctx)
+	return mock.GetJobsFunc(ctx, offsetParam, limitParam)
 }
 
 // GetJobsCalls gets all the calls that were made to GetJobs.
@@ -333,9 +341,13 @@ func (mock *MongoJobStorerMock) GetJobs(ctx context.Context) (models.Jobs, error
 //     len(mockedMongoJobStorer.GetJobsCalls())
 func (mock *MongoJobStorerMock) GetJobsCalls() []struct {
 	Ctx context.Context
+	OffsetParam string
+	LimitParam string
 } {
 	var calls []struct {
 		Ctx context.Context
+		OffsetParam string
+		LimitParam string
 	}
 	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
These are the changes in this release:

The endpoint that allows a GET request to be made, which lists search reindex job documents from mongoDB, has been amended so that the list returned will also be determined by pagination functionality i.e. offset and limit query parameters.

The pagination functionality should meet the API standards defined here: https://github.com/ONSdigital/dp/blob/main/standards/API_STANDARDS.md

If the offset or limit query parameters fail validation then a 400 (Bad Request) error occurs.

Also, as well as returning the list of jobs, the endpoint now returns the following values (as defined by the swagger spec):

- count (The number of Job resources returned in this response.)
- limit (The max number of Job resources that should be returned in this response.)
- offset (The number of Job resources into the full list, that is the 0-based index, that this particular response is starting at.)
- total_count (How many total items there may be - the total number of jobs in mongoDB.)

Default values have also been added, for the limit and offset query parameters, and a default maximum limit. These are configurable and given by the following environment variables:

DEFAULT_OFFSET (currently set to 0)
DEFAULT_LIMIT (currently set to 20)
DEFAULT_MAXIMUM_LIMIT (currently set to 1000)

Five component tests have been added to the getting_jobs feature, as follows:

1. Scenario: Six jobs exist and a get request with offset and limit correctly returns four
2. Scenario: Three jobs exist and a get request with negative offset returns an error
3. Scenario: Three jobs exist and a get request with offset greater than three returns an error
4. Scenario: Three jobs exist and a get request with negative limit returns an error
5. Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error

# How to review
<!--- Describe in detail how you tested your changes. -->

Check only expected commits present

NB. The new functionality can be tested locally as follows:

First use dp-compose to run mongoDB in a docker container. Then hit the POST endpoint a few times to create some jobs:
http://localhost:25700/jobs

The changes can then be tested locally using this GET URL or similar: 
http://localhost:25700/jobs?offset=2&limit=10

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
