### PR TITLE
Improve the Validation on the CreateTask endpoint

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -28,13 +28,17 @@ func (api *JobStoreAPI) CreateTaskHandler(ctx context.Context) http.HandlerFunc 
 			return
 		}
 
+		if err := taskToCreate.Validate(); err != nil {
+			log.Error(ctx, "CreateTask endpoint: Invalid request body", err)
+			http.Error(w, invalidBodyErrorMessage, http.StatusBadRequest)
+			return
+		}
+
 		newTask, err := api.jobStore.CreateTask(ctx, jobID, taskToCreate.TaskName, taskToCreate.NumberOfDocuments)
 		if err != nil {
 			log.Error(ctx, "creating and storing a task failed", err, log.Data{"job id": jobID})
 			if err == mongo.ErrJobNotFound {
 				http.Error(w, "Failed to find job that has the specified id", http.StatusNotFound)
-			} else if err == mongo.ErrEmptyTaskNameProvided {
-				http.Error(w, invalidBodyErrorMessage, http.StatusBadRequest)
 			} else {
 				http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			}

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -6,6 +6,7 @@ import (
 
 // A list of error messages for JobStore API
 var (
-	ErrUnableToReadMessage = errors.New("failed to read message body")
-	ErrUnableToParseJSON   = errors.New("failed to parse json body")
+	ErrUnableToReadMessage   = errors.New("failed to read message body")
+	ErrUnableToParseJSON     = errors.New("failed to parse json body")
+	ErrEmptyTaskNameProvided = errors.New("task name must not be an empty string")
 )

--- a/models/task.go
+++ b/models/task.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/ONSdigital/dp-search-reindex-api/apierrors"
 	"github.com/ONSdigital/dp-search-reindex-api/url"
 )
 
@@ -43,4 +44,11 @@ func NewTask(jobID string, taskName string, numDocuments int, bindAddress string
 type TaskToCreate struct {
 	TaskName          string `json:"task_name"`
 	NumberOfDocuments int    `json:"number_of_documents"`
+}
+
+func (task TaskToCreate) Validate() error {
+	if task.TaskName == "" {
+		return apierrors.ErrEmptyTaskNameProvided
+	}
+	return nil
 }

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -8,6 +8,7 @@ import (
 var (
 	ErrJobNotFound           = errors.New("the job id could not be found in the jobs collection")
 	ErrEmptyIDProvided       = errors.New("id must not be an empty string")
+	ErrEmptyTaskNameProvided = errors.New("task name must not be an empty string")
 	ErrDuplicateIDProvided   = errors.New("id must be unique")
 	ErrExistingJobInProgress = errors.New("there is an existing job currently in progress")
 )

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -8,7 +8,6 @@ import (
 var (
 	ErrJobNotFound           = errors.New("the job id could not be found in the jobs collection")
 	ErrEmptyIDProvided       = errors.New("id must not be an empty string")
-	ErrEmptyTaskNameProvided = errors.New("task name must not be an empty string")
 	ErrDuplicateIDProvided   = errors.New("id must be unique")
 	ErrExistingJobInProgress = errors.New("there is an existing job currently in progress")
 )

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -106,10 +106,6 @@ func (m *JobStore) CreateTask(ctx context.Context, jobID string, taskName string
 		return models.Task{}, ErrEmptyIDProvided
 	}
 
-	if taskName == "" {
-		return models.Task{}, ErrEmptyTaskNameProvided
-	}
-
 	s := m.Session.Copy()
 	defer s.Close()
 

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -98,12 +98,16 @@ func (m *JobStore) CreateJob(ctx context.Context, id string) (models.Job, error)
 }
 
 // CreateTask creates a new task, for the given API and job ID, in the collection, and assigns default values to its attributes
-func (m *JobStore) CreateTask(ctx context.Context, jobID string, nameOfApi string, numDocuments int) (models.Task, error) {
-	log.Info(ctx, "creating task in mongo DB", log.Data{"jobID": jobID, "nameOfApi": nameOfApi, "numDocuments": numDocuments})
+func (m *JobStore) CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
+	log.Info(ctx, "creating task in mongo DB", log.Data{"jobID": jobID, "taskName": taskName, "numDocuments": numDocuments})
 
 	// If an empty job id was passed in, return an error with a message.
 	if jobID == "" {
 		return models.Task{}, ErrEmptyIDProvided
+	}
+
+	if taskName == "" {
+		return models.Task{}, ErrEmptyTaskNameProvided
 	}
 
 	s := m.Session.Copy()
@@ -122,9 +126,9 @@ func (m *JobStore) CreateTask(ctx context.Context, jobID string, nameOfApi strin
 		}
 	}
 
-	newTask := models.NewTask(jobID, nameOfApi, numDocuments, m.cfg.BindAddr)
+	newTask := models.NewTask(jobID, taskName, numDocuments, m.cfg.BindAddr)
 
-	err = m.UpsertTask(jobID, nameOfApi, newTask)
+	err = m.UpsertTask(jobID, taskName, newTask)
 	if err != nil {
 		return models.Task{}, fmt.Errorf("error creating or overwriting task in mongo DB: %w", err)
 	}


### PR DESCRIPTION
### What

Correct the message for a bad request
Check that the task name is not an empty string

### How to review

The endpoint is /jobs/{job id}/tasks

It requires a request body, of this format:
{ “task_name”: <api service>, “number_of_documents”:5}

### Who can review

@nshumoogum 
