### PR TITLE
Feature/improve list tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The endpoint also requires a body, which should contain the task name, and the n
 "number_of_documents": 29
 }`
 - GET: http://localhost:25700/jobs/ID/tasks/TASK_NAME (should get a task from the data store)
+- GET: http://localhost:25700/jobs/ID/tasks (should get all the tasks, for a particular job, from the data store)
 
 ### Contributing
 

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ONSdigital/dp-authorisation/auth"
 	"github.com/ONSdigital/dp-search-reindex-api/apierrors"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 )
@@ -21,15 +22,17 @@ type API struct {
 	dataStore   DataStorer
 	permissions AuthHandler
 	taskNames   map[string]bool
+	cfg         *config.Config
 }
 
 // Setup function sets up the api and returns an api
-func Setup(ctx context.Context, router *mux.Router, dataStore DataStorer, permissions AuthHandler, taskNames map[string]bool) *API {
+func Setup(ctx context.Context, router *mux.Router, dataStore DataStorer, permissions AuthHandler, taskNames map[string]bool, cfg *config.Config) *API {
 	api := &API{
 		Router:      router,
 		dataStore:   dataStore,
 		permissions: permissions,
 		taskNames:   taskNames,
+		cfg:         cfg,
 	}
 
 	router.HandleFunc("/jobs", api.CreateJobHandler(ctx)).Methods("POST")

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-search-reindex-api/api"
 	"github.com/ONSdigital/dp-search-reindex-api/api/mock"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 	"net/http/httptest"
@@ -20,7 +21,10 @@ var taskNames = map[string]bool{
 
 func TestSetup(t *testing.T) {
 	Convey("Given an API instance", t, func() {
-		api := api.Setup(context.Background(), mux.NewRouter(), &mock.DataStorerMock{}, &mock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		api := api.Setup(context.Background(), mux.NewRouter(), &mock.DataStorerMock{}, &mock.AuthHandlerMock{}, taskNames, cfg)
 
 		Convey("When created the following routes should have been added", func() {
 			So(hasRoute(api.Router, "/jobs", "POST"), ShouldBeTrue)
@@ -32,8 +36,10 @@ func TestSetup(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	Convey("Given an API instance", t, func() {
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
 		ctx := context.Background()
-		api := api.Setup(context.Background(), mux.NewRouter(), &mock.DataStorerMock{}, &mock.AuthHandlerMock{}, taskNames)
+		api := api.Setup(context.Background(), mux.NewRouter(), &mock.DataStorerMock{}, &mock.AuthHandlerMock{}, taskNames, cfg)
 
 		Convey("When the api is closed then there is no error returned", func() {
 			err := api.Close(ctx)

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 )
 
-//go:generate moq -out mock/data_storer_temp.go -pkg mock . DataStorer
+//go:generate moq -out mock/data_storer.go -pkg mock . DataStorer
 
 // DataStorer is an interface for a type that can store and retrieve jobs
 type DataStorer interface {
@@ -20,7 +20,7 @@ type DataStorer interface {
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (task models.Task, err error)
 	GetTask(ctx context.Context, jobID string, taskName string) (task models.Task, err error)
-	GetTasks(ctx context.Context, offsetParam string, limitParam string, jobID string) (job models.Tasks, err error)
+	GetTasks(ctx context.Context, offset int, limit int, jobID string) (job models.Tasks, err error)
 }
 
 // Paginator defines the required methods from the paginator package

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -28,7 +28,6 @@ var (
 		pagination.ErrInvalidLimitParameter:  true,
 		pagination.ErrInvalidOffsetParameter: true,
 		pagination.ErrLimitOverMax:           true,
-		pagination.ErrOffsetOverTotalCount:   true,
 	}
 )
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -56,7 +56,9 @@ func TestCreateJobHandler(t *testing.T) {
 
 	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a Job Store", t, func() {
 		api.NewID = func() string { return validJobID1 }
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 		createJobHandler := apiInstance.CreateJobHandler(ctx)
 
 		Convey("When a new reindex job is created and stored", func() {
@@ -93,7 +95,9 @@ func TestCreateJobHandler(t *testing.T) {
 
 	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a Job Store", t, func() {
 		api.NewID = func() string { return validJobID2 }
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 		createJobHandler := apiInstance.CreateJobHandler(ctx)
 
 		Convey("When the jobs endpoint is called to create and store a new reindex job", func() {
@@ -112,7 +116,9 @@ func TestCreateJobHandler(t *testing.T) {
 
 	Convey("Given a Search Reindex Job API that generates an empty job ID", t, func() {
 		api.NewID = func() string { return emptyJobID }
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 		createJobHandler := apiInstance.CreateJobHandler(ctx)
 
 		Convey("When the jobs endpoint is called to create and store a new reindex job", func() {
@@ -155,7 +161,9 @@ func TestGetJobHandler(t *testing.T) {
 			},
 		}
 
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
 		Convey("When a request is made to get a specific job that exists in the Job Store", func() {
 			req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:25700/jobs/%s", validJobID2), nil)
@@ -252,7 +260,9 @@ func TestGetJobsHandler(t *testing.T) {
 			},
 		}
 
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
 		Convey("When a request is made to get a list of all the jobs that exist in the Job Store", func() {
 			req := httptest.NewRequest("GET", "http://localhost:25700/jobs", nil)
@@ -315,7 +325,9 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 			},
 		}
 
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
 		Convey("When a request is made to get a list of all the jobs that exist in the jobs collection", func() {
 			req := httptest.NewRequest("GET", "http://localhost:25700/jobs", nil)
@@ -351,7 +363,9 @@ func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 			},
 		}
 
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
 		Convey("When a request is made to get a list of all the jobs that exist in the jobs collection", func() {
 			req := httptest.NewRequest("GET", "http://localhost:25700/jobs", nil)
@@ -430,7 +444,9 @@ func TestPutNumTasksHandler(t *testing.T) {
 			},
 		}
 
-		apiInstance := api.Setup(ctx, mux.NewRouter(), jobStoreMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), jobStoreMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
 		Convey("When a request is made to update the number of tasks of a specific job that exists in the Job Store", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", validJobID2, validCount), nil)

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -255,6 +255,12 @@ func (mock *DataStorerMock) CreateTask(ctx context.Context, jobID string, taskNa
 	if mock.CreateTaskFunc == nil {
 		panic("DataStorerMock.CreateTaskFunc: method is nil but DataStorer.CreateTask was just called")
 	}
+	switch taskName {
+	case "zebedee":
+		jobID = "UUID1"
+	case "dataset-api":
+		jobID = "UUID3"
+	}
 	callInfo := struct {
 		Ctx          context.Context
 		JobID        string

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -18,10 +18,10 @@ var _ api.DataStorer = &DataStorerMock{}
 
 // DataStorerMock is a mock implementation of api.DataStorer.
 //
-// 	func TestSomethingThatUsesJobStorer(t *testing.T) {
+// 	func TestSomethingThatUsesDataStorer(t *testing.T) {
 //
 // 		// make and configure a mocked api.DataStorer
-// 		mockedJobStorer := &DataStorerMock{
+// 		mockedDataStorer := &DataStorerMock{
 // 			AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
 // 				panic("mock out the AcquireJobLock method")
 // 			},
@@ -40,6 +40,9 @@ var _ api.DataStorer = &DataStorerMock{}
 // 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
 // 				panic("mock out the GetTask method")
 // 			},
+// 			GetTasksFunc: func(ctx context.Context, offset int, limit int, jobID string) (models.Tasks, error) {
+// 				panic("mock out the GetTasks method")
+// 			},
 // 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
 // 				panic("mock out the PutNumberOfTasks method")
 // 			},
@@ -48,7 +51,7 @@ var _ api.DataStorer = &DataStorerMock{}
 // 			},
 // 		}
 //
-// 		// use mockedJobStorer in code that requires api.DataStorer
+// 		// use mockedDataStorer in code that requires api.DataStorer
 // 		// and then make assertions.
 //
 // 	}
@@ -72,7 +75,7 @@ type DataStorerMock struct {
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
 
 	// GetTasksFunc mocks the GetTasks method.
-	GetTasksFunc func(ctx context.Context, offsetParam string, limitParam string, jobID string) (models.Tasks, error)
+	GetTasksFunc func(ctx context.Context, offset int, limit int, jobID string) (models.Tasks, error)
 
 	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
 	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
@@ -136,10 +139,10 @@ type DataStorerMock struct {
 		GetTasks []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// OffsetParam is the offsetParam argument value.
-			OffsetParam string
-			// LimitParam is the limitParam argument value.
-			LimitParam string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 			// JobID is the jobID argument value.
 			JobID string
 		}
@@ -197,7 +200,7 @@ func (mock *DataStorerMock) AcquireJobLock(ctx context.Context, id string) (stri
 
 // AcquireJobLockCalls gets all the calls that were made to AcquireJobLock.
 // Check the length with:
-//     len(mockedJobStorer.AcquireJobLockCalls())
+//     len(mockedDataStorer.AcquireJobLockCalls())
 func (mock *DataStorerMock) AcquireJobLockCalls() []struct {
 	Ctx context.Context
 	ID  string
@@ -215,13 +218,7 @@ func (mock *DataStorerMock) AcquireJobLockCalls() []struct {
 // CreateJob calls CreateJobFunc.
 func (mock *DataStorerMock) CreateJob(ctx context.Context, id string) (models.Job, error) {
 	if mock.CreateJobFunc == nil {
-		if id == "" {
-			return models.Job{}, errors.New("id must not be an empty string")
-		} else if id == duplicateID {
-			return models.Job{}, errors.New("id must be unique")
-		} else {
-			return models.NewJob(id)
-		}
+		panic("DataStorerMock.CreateJobFunc: method is nil but DataStorer.CreateJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
@@ -238,7 +235,7 @@ func (mock *DataStorerMock) CreateJob(ctx context.Context, id string) (models.Jo
 
 // CreateJobCalls gets all the calls that were made to CreateJob.
 // Check the length with:
-//     len(mockedJobStorer.CreateJobCalls())
+//     len(mockedDataStorer.CreateJobCalls())
 func (mock *DataStorerMock) CreateJobCalls() []struct {
 	Ctx context.Context
 	ID  string
@@ -257,12 +254,6 @@ func (mock *DataStorerMock) CreateJobCalls() []struct {
 func (mock *DataStorerMock) CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
 	if mock.CreateTaskFunc == nil {
 		panic("DataStorerMock.CreateTaskFunc: method is nil but DataStorer.CreateTask was just called")
-	}
-	switch taskName {
-	case "zebedee":
-		jobID = "UUID1"
-	case "dataset-api":
-		jobID = "UUID3"
 	}
 	callInfo := struct {
 		Ctx          context.Context
@@ -283,7 +274,7 @@ func (mock *DataStorerMock) CreateTask(ctx context.Context, jobID string, taskNa
 
 // CreateTaskCalls gets all the calls that were made to CreateTask.
 // Check the length with:
-//     len(mockedJobStorer.CreateTaskCalls())
+//     len(mockedDataStorer.CreateTaskCalls())
 func (mock *DataStorerMock) CreateTaskCalls() []struct {
 	Ctx          context.Context
 	JobID        string
@@ -328,7 +319,7 @@ func (mock *DataStorerMock) GetJob(ctx context.Context, id string) (models.Job, 
 
 // GetJobCalls gets all the calls that were made to GetJob.
 // Check the length with:
-//     len(mockedJobStorer.GetJobCalls())
+//     len(mockedDataStorer.GetJobCalls())
 func (mock *DataStorerMock) GetJobCalls() []struct {
 	Ctx context.Context
 	ID  string
@@ -372,7 +363,7 @@ func (mock *DataStorerMock) GetJobs(ctx context.Context, offsetParam string, lim
 
 // GetJobsCalls gets all the calls that were made to GetJobs.
 // Check the length with:
-//     len(mockedJobStorer.GetJobsCalls())
+//     len(mockedDataStorer.GetJobsCalls())
 func (mock *DataStorerMock) GetJobsCalls() []struct {
 	Ctx         context.Context
 	OffsetParam string
@@ -411,7 +402,7 @@ func (mock *DataStorerMock) GetTask(ctx context.Context, jobID string, taskName 
 
 // GetTaskCalls gets all the calls that were made to GetTask.
 // Check the length with:
-//     len(mockedJobStorer.GetTaskCalls())
+//     len(mockedDataStorer.GetTaskCalls())
 func (mock *DataStorerMock) GetTaskCalls() []struct {
 	Ctx      context.Context
 	JobID    string
@@ -429,41 +420,41 @@ func (mock *DataStorerMock) GetTaskCalls() []struct {
 }
 
 // GetTasks calls GetTasksFunc.
-func (mock *DataStorerMock) GetTasks(ctx context.Context, offsetParam string, limitParam string, jobID string) (models.Tasks, error) {
+func (mock *DataStorerMock) GetTasks(ctx context.Context, offset int, limit int, jobID string) (models.Tasks, error) {
 	if mock.GetTasksFunc == nil {
 		panic("DataStorerMock.GetTasksFunc: method is nil but DataStorer.GetTasks was just called")
 	}
 	callInfo := struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
-		JobID       string
+		Ctx    context.Context
+		Offset int
+		Limit  int
+		JobID  string
 	}{
-		Ctx:         ctx,
-		OffsetParam: offsetParam,
-		LimitParam:  limitParam,
-		JobID:       jobID,
+		Ctx:    ctx,
+		Offset: offset,
+		Limit:  limit,
+		JobID:  jobID,
 	}
 	mock.lockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
 	mock.lockGetTasks.Unlock()
-	return mock.GetTasksFunc(ctx, offsetParam, limitParam, jobID)
+	return mock.GetTasksFunc(ctx, offset, limit, jobID)
 }
 
 // GetTasksCalls gets all the calls that were made to GetTasks.
 // Check the length with:
 //     len(mockedDataStorer.GetTasksCalls())
 func (mock *DataStorerMock) GetTasksCalls() []struct {
-	Ctx         context.Context
-	OffsetParam string
-	LimitParam  string
-	JobID       string
+	Ctx    context.Context
+	Offset int
+	Limit  int
+	JobID  string
 } {
 	var calls []struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
-		JobID       string
+		Ctx    context.Context
+		Offset int
+		Limit  int
+		JobID  string
 	}
 	mock.lockGetTasks.RLock()
 	calls = mock.calls.GetTasks
@@ -493,7 +484,7 @@ func (mock *DataStorerMock) PutNumberOfTasks(ctx context.Context, id string, cou
 
 // PutNumberOfTasksCalls gets all the calls that were made to PutNumberOfTasks.
 // Check the length with:
-//     len(mockedJobStorer.PutNumberOfTasksCalls())
+//     len(mockedDataStorer.PutNumberOfTasksCalls())
 func (mock *DataStorerMock) PutNumberOfTasksCalls() []struct {
 	Ctx   context.Context
 	ID    string
@@ -528,7 +519,7 @@ func (mock *DataStorerMock) UnlockJob(lockID string) error {
 
 // UnlockJobCalls gets all the calls that were made to UnlockJob.
 // Check the length with:
-//     len(mockedJobStorer.UnlockJobCalls())
+//     len(mockedDataStorer.UnlockJobCalls())
 func (mock *DataStorerMock) UnlockJobCalls() []struct {
 	LockID string
 } {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -61,7 +61,9 @@ func TestCreateTaskHandler(t *testing.T) {
 	}
 
 	Convey("Given an API that can create valid search reindex tasks and store their details in a Data Store", t, func() {
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 		createTaskHandler := apiInstance.CreateTaskHandler
 
 		Convey("When a new reindex task is created and stored", func() {
@@ -95,7 +97,9 @@ func TestCreateTaskHandler(t *testing.T) {
 	})
 
 	Convey("Given an API that can create valid search reindex tasks and store their details in a Data Store", t, func() {
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 		createTaskHandler := apiInstance.CreateTaskHandler
 
 		Convey("When the tasks endpoint is called to create and store a new reindex task", func() {
@@ -116,7 +120,9 @@ func TestCreateTaskHandler(t *testing.T) {
 	})
 
 	Convey("Given an API that can create valid search reindex tasks and store their details in a Data Store", t, func() {
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 		createTaskHandler := apiInstance.CreateTaskHandler
 
 		Convey("When the tasks endpoint is called to create and store a new reindex task", func() {
@@ -137,7 +143,9 @@ func TestCreateTaskHandler(t *testing.T) {
 	})
 
 	Convey("Given an API that can create valid search reindex tasks and store their details in a Data Store", t, func() {
-		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames)
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 		createTaskHandler := apiInstance.CreateTaskHandler
 
 		Convey("When the tasks endpoint is called to create and store a new reindex task", func() {

--- a/features/getting_jobs.feature
+++ b/features/getting_jobs.feature
@@ -63,14 +63,6 @@ Feature: Getting a list of jobs
     """
     Then the HTTP status code should be "400"
 
-  Scenario: Three jobs exist and a get request with offset greater than three returns an error
-
-    Given I have generated three jobs in the Job Store
-    When I GET "/jobs?offset=4"
-    """
-    """
-    Then the HTTP status code should be "400"
-
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
     Given I have generated three jobs in the Job Store

--- a/features/getting_tasks.feature
+++ b/features/getting_tasks.feature
@@ -90,26 +90,6 @@ Feature: Getting a list of tasks
     When I call GET /jobs/{id}/tasks?offset="-2"&limit="20"
     Then the HTTP status code should be "400"
 
-  Scenario: Three tasks exist and a get request with offset greater than three returns an error
-
-    Given I use a service auth token "validServiceAuthToken"
-    And zebedee recognises the service auth token as valid
-    And I have generated a job in the Job Store
-    And I call POST /jobs/{id}/tasks using the generated id
-    """
-    { "task_name": "zebedee", "number_of_documents": 4 }
-    """
-    And I call POST /jobs/{id}/tasks using the same id again
-    """
-    { "task_name": "dataset-api", "number_of_documents": 4 }
-    """
-    And I call POST /jobs/{id}/tasks using the same id again
-    """
-    { "task_name": "another-task-name3", "number_of_documents": 4 }
-    """
-    When I call GET /jobs/{id}/tasks?offset="4"&limit="20"
-    Then the HTTP status code should be "400"
-
   Scenario: Three tasks exist and a get request with negative limit returns an error
 
     Given I use a service auth token "validServiceAuthToken"

--- a/mongo/data_store.go
+++ b/mongo/data_store.go
@@ -167,7 +167,7 @@ func (m *JobStore) GetTask(ctx context.Context, jobID string, taskName string) (
 }
 
 // GetTasks retrieves all the tasks, from the collection, and lists them in order of last_updated
-func (m *JobStore) GetTasks(ctx context.Context, offsetParam string, limitParam string, jobID string) (models.Tasks, error) {
+func (m *JobStore) GetTasks(ctx context.Context, offset int, limit int, jobID string) (models.Tasks, error) {
 	s := m.Session.Copy()
 	defer s.Close()
 	log.Info(ctx, "getting list of tasks")
@@ -198,12 +198,6 @@ func (m *JobStore) GetTasks(ctx context.Context, offsetParam string, limitParam 
 		log.Info(ctx, "there are no tasks in the data store - so the list is empty")
 		results.TaskList = make([]models.Task, 0)
 		return results, nil
-	}
-
-	paginator := pagination.NewPaginator(m.cfg.DefaultLimit, m.cfg.DefaultOffset, m.cfg.DefaultMaxLimit)
-	offset, limit, err := paginator.ValidatePaginationParameters(offsetParam, limitParam, numTasks)
-	if err != nil {
-		return results, err
 	}
 
 	//Get the requested tasks from the tasks collection, using the given job_id, offset, and limit, and order them by last_updated
@@ -302,7 +296,7 @@ func (m *JobStore) GetJobs(ctx context.Context, offsetParam string, limitParam s
 	}
 
 	paginator := pagination.NewPaginator(m.cfg.DefaultLimit, m.cfg.DefaultOffset, m.cfg.DefaultMaxLimit)
-	offset, limit, err := paginator.ValidatePaginationParameters(offsetParam, limitParam, numJobs)
+	offset, limit, err := paginator.ValidatePaginationParameters(offsetParam, limitParam)
 	if err != nil {
 		return results, err
 	}

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -9,9 +9,6 @@ var (
 	// ErrInvalidOffsetParameter represents an error case where an invalid offset value is provided
 	ErrInvalidOffsetParameter = errors.New("invalid offset query parameter")
 
-	// ErrOffsetOverTotalCount represents an error case where the given offset value is larger than the total count
-	ErrOffsetOverTotalCount = errors.New("offset query parameter is larger than the total count of jobs")
-
 	// ErrInvalidLimitParameter represents an error case where an invalid limit value is provided
 	ErrInvalidLimitParameter = errors.New("invalid limit query parameter")
 
@@ -44,7 +41,7 @@ func NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit int) *Paginator {
 }
 
 // ValidatePaginationParameters returns pagination related values based on the given request
-func (p *Paginator) ValidatePaginationParameters(offsetParameter string, limitParameter string, totalCount int) (offset int, limit int, err error) {
+func (p *Paginator) ValidatePaginationParameters(offsetParameter string, limitParameter string) (offset int, limit int, err error) {
 
 	offset = p.DefaultOffset
 	limit = p.DefaultLimit
@@ -54,10 +51,6 @@ func (p *Paginator) ValidatePaginationParameters(offsetParameter string, limitPa
 		if err != nil || offset < 0 {
 			return 0, 0, ErrInvalidOffsetParameter
 		}
-	}
-
-	if offset > totalCount {
-		return 0, 0, ErrOffsetOverTotalCount
 	}
 
 	if limitParameter != "" {

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -20,12 +20,11 @@ func TestValidatePaginationParametersReturnsErrorWhenOffsetIsNegative(t *testing
 
 		offset := "-1"
 		limit := ""
-		totalCount := 20
 
 		Convey("When ValidatePaginationValues is called", func() {
 
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
 
 			Convey("Then the expected error is returned", func() {
 
@@ -43,12 +42,11 @@ func TestValidatePaginationParametersReturnsErrorWhenLimitIsNegative(t *testing.
 
 		offset := ""
 		limit := "-1"
-		totalCount := 20
 
 		Convey("When ValidatePaginationValues is called", func() {
 
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldEqual, pagination.ErrInvalidLimitParameter)
@@ -65,12 +63,11 @@ func TestValidatePaginationParametersReturnsErrorWhenLimitIsGreaterThanMaxLimit(
 
 		offset := ""
 		limit := "1001"
-		totalCount := 20
 
 		Convey("When ValidatePaginationValues is called", func() {
 
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldEqual, pagination.ErrLimitOverMax)
@@ -87,12 +84,11 @@ func TestValidatePaginationParametersReturnsLimitAndOffsetProvidedFromQuery(t *t
 
 		offset := "5"
 		limit := "10"
-		totalCount := 20
 
 		Convey("When ValidatePaginationValues is called", func() {
 
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
 
 			Convey("Then the expected values are returned", func() {
 				So(err, ShouldBeNil)
@@ -109,13 +105,12 @@ func TestValidatePaginationParametersReturnsDefaultValuesWhenNotProvided(t *test
 
 		offset := ""
 		limit := ""
-		totalCount := 20
 
 		Convey("When ValidatePaginationValues is called", func() {
 			expectedLimit := 15
 			expectedOffset := 1
 			paginator := pagination.NewPaginator(expectedLimit, expectedOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit, totalCount)
+			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
 
 			Convey("Then the configured default values are returned", func() {
 				So(err, ShouldBeNil)

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -45,7 +45,7 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 // 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
 // 				panic("mock out the GetTask method")
 // 			},
-// 			GetTasksFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Tasks, error) {
+// 			GetTasksFunc: func(ctx context.Context, offset int, limit int, jobID string) (models.Tasks, error) {
 // 				panic("mock out the GetTasks method")
 // 			},
 // 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
@@ -86,7 +86,7 @@ type MongoDataStorerMock struct {
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
 
 	// GetTasksFunc mocks the GetTasks method.
-	GetTasksFunc func(ctx context.Context, offsetParam string, limitParam string, jobID string) (models.Tasks, error)
+	GetTasksFunc func(ctx context.Context, offset int, limit int, jobID string) (models.Tasks, error)
 
 	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
 	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
@@ -162,10 +162,10 @@ type MongoDataStorerMock struct {
 		GetTasks []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// OffsetParam is the offsetParam argument value.
-			OffsetParam string
-			// LimitParam is the limitParam argument value.
-			LimitParam string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 			// JobID is the jobID argument value.
 			JobID string
 		}
@@ -490,41 +490,41 @@ func (mock *MongoDataStorerMock) GetTaskCalls() []struct {
 }
 
 // GetTasks calls GetTasksFunc.
-func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, offsetParam string, limitParam string, jobID string) (models.Tasks, error) {
+func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, offset int, limit int, jobID string) (models.Tasks, error) {
 	if mock.GetTasksFunc == nil {
 		panic("MongoDataStorerMock.GetTasksFunc: method is nil but MongoDataStorer.GetTasks was just called")
 	}
 	callInfo := struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
-		JobID       string
+		Ctx    context.Context
+		Offset int
+		Limit  int
+		JobID  string
 	}{
-		Ctx:         ctx,
-		OffsetParam: offsetParam,
-		LimitParam:  limitParam,
-		JobID:       jobID,
+		Ctx:    ctx,
+		Offset: offset,
+		Limit:  limit,
+		JobID:  jobID,
 	}
 	mock.lockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
 	mock.lockGetTasks.Unlock()
-	return mock.GetTasksFunc(ctx, offsetParam, limitParam, jobID)
+	return mock.GetTasksFunc(ctx, offset, limit, jobID)
 }
 
 // GetTasksCalls gets all the calls that were made to GetTasks.
 // Check the length with:
 //     len(mockedMongoDataStorer.GetTasksCalls())
 func (mock *MongoDataStorerMock) GetTasksCalls() []struct {
-	Ctx         context.Context
-	OffsetParam string
-	LimitParam  string
-	JobID       string
+	Ctx    context.Context
+	Offset int
+	Limit  int
+	JobID  string
 } {
 	var calls []struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
-		JobID       string
+		Ctx    context.Context
+		Offset int
+		Limit  int
+		JobID  string
 	}
 	mock.lockGetTasks.RLock()
 	calls = mock.calls.GetTasks

--- a/service/service.go
+++ b/service/service.go
@@ -47,7 +47,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	permissions := serviceList.GetAuthorisationHandlers(ctx, cfg)
 
 	// Setup the API
-	api.Setup(ctx, r, mongoDB, permissions, taskNames)
+	api.Setup(ctx, r, mongoDB, permissions, taskNames, cfg)
 
 	// Get HealthCheck
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -128,7 +128,6 @@ paths:
         - $ref: '#/parameters/id'
         - $ref: "#/parameters/limit"
         - $ref: "#/parameters/offset"
-        - $ref: "#/parameters/sort"
       produces:
         - application/json
       responses:
@@ -475,10 +474,6 @@ definitions:
         type: integer
         description: "How many total Task resources, for the given job, there may be (so the full list size, maybe thousands)."
         example: 100
-      sort:
-        type: string
-        description: "The sort order of the list."
-        example: number_of_documents
 
 parameters:
 


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Some improvements have been made to the new endpoint, which allows a GET request to be made, to list all the tasks for a particular search reindex job currently held in the data store. The endpoint is GET /jobs/{id}/tasks

The improvements are:
1. The sort field has been removed from the swagger spec. This is because we are not allowing API users to set sort in the query to affect the order of results.

2. When the requested tasks are counted there is potential for an error to occur if the connection to mongo is lost. That error was not previously being handled but now it is.

3. The pagination validation now occurs before the tasks are retrieved from mongo. This means that if the validation fails (because of bad offset or limit values) then it will return, and not make any database requests, which is more efficient.

4. The mongo dB querying language is now being used to better effect. Instead of retrieving all the tasks for a particular job, and iterating through them, it now uses the offset and limit parameters passed in and only returns the data that has been requested. It does not use an iterator but instead returns all the required data straight away.

5. Due to the improved use of the mongo dB querying language there is no need to use the modifyTasks function. So that has been removed.

# How to review
<!--- Describe in detail how you tested your changes. -->
If testing this locally then set up dependencies (see following steps).

In dp-compose run MongoDB on port 27017 as follows:

 docker-compose up -d

In any directory run Vault as follows:

 vault server -dev

In the zebedee directory run Zebedee as follows:

 ./run.sh

Then in the dp-search-reindex-api run:

 make debug

Then hit this POST endpoint to create a job. Take note of the job id that it generates:
http://localhost:25700/jobs

Then hit this POST URL (using the job id noted above) e.g for a job with id 1b9a6881-8bf3-4729-8c59-62901c4688b8: 
http://localhost:25700/jobs/1b9a6881-8bf3-4729-8c59-62901c4688b8/tasks

NB. Add 'Bearer Token' as the authorisation type and enter the value of your local $SERVICE_AUTH_TOKEN. Also add a request body e.g.
{
  "task_name": "dataset-api",
  "number_of_documents": 18
}

Hit the same POST URL again to create a second task. But this time change the task_name value to zebedee (in the request body).

Finally the new GET endpoint can now be tested. It should list the 2 tasks:
http://localhost:25700/jobs/1b9a6881-8bf3-4729-8c59-62901c4688b8/tasks

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
