### PR TITLE
Release/0.13.0

### DIFF
--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -14,7 +14,7 @@ import (
 type DataStorer interface {
 	CreateJob(ctx context.Context, id string) (job models.Job, err error)
 	GetJob(ctx context.Context, id string) (job models.Job, err error)
-	GetJobs(ctx context.Context, offsetParam string, limitParam string) (job models.Jobs, err error)
+	GetJobs(ctx context.Context, offset int, limit int) (job models.Jobs, err error)
 	AcquireJobLock(ctx context.Context, id string) (lockID string, err error)
 	UnlockJob(lockID string) error
 	PutNumberOfTasks(ctx context.Context, id string, count int) error

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -113,9 +113,9 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	offsetParam := req.URL.Query().Get("offset")
 	limitParam := req.URL.Query().Get("limit")
 
-	offset, limit, err := api.setUpPagination(w, offsetParam, limitParam, ctx)
+	offset, limit, err := api.setUpPagination(offsetParam, limitParam)
 	if err != nil {
-		log.Error(ctx, "setting up pagination failed", err)
+		log.Error(ctx, "pagination validation failed", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -144,10 +144,9 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (api *API) setUpPagination(w http.ResponseWriter, offsetParam string, limitParam string, ctx context.Context) (int, int, error) {
+func (api *API) setUpPagination(offsetParam string, limitParam string) (int, int, error) {
 	paginator := pagination.NewPaginator(api.cfg.DefaultLimit, api.cfg.DefaultOffset, api.cfg.DefaultMaxLimit)
-	offset, limit, err := paginator.ValidatePaginationParameters(offsetParam, limitParam)
-	return offset, limit, err
+	return paginator.ValidatePaginationParameters(offsetParam, limitParam)
 }
 
 // unlockJob unlocks the provided job lockID and logs any error with WARN state

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -115,6 +115,7 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 
 	offset, limit, err := api.setUpPagination(w, offsetParam, limitParam, ctx)
 	if err != nil {
+		log.Error(ctx, "setting up pagination failed", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -146,10 +147,6 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 func (api *API) setUpPagination(w http.ResponseWriter, offsetParam string, limitParam string, ctx context.Context) (int, int, error) {
 	paginator := pagination.NewPaginator(api.cfg.DefaultLimit, api.cfg.DefaultOffset, api.cfg.DefaultMaxLimit)
 	offset, limit, err := paginator.ValidatePaginationParameters(offsetParam, limitParam)
-	if err != nil {
-		log.Error(ctx, "pagination validation failed", err)
-		return 0, 0, err
-	}
 	return offset, limit, err
 }
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -22,13 +22,6 @@ var (
 	}
 
 	serverErrorMessage = "internal server error"
-
-	// errors that should return a 400 status
-	badRequest = map[error]bool{
-		pagination.ErrInvalidLimitParameter:  true,
-		pagination.ErrInvalidOffsetParameter: true,
-		pagination.ErrLimitOverMax:           true,
-	}
 )
 
 // CreateJobHandler returns a function that generates a new Job resource containing default values in its fields.

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -242,7 +242,7 @@ func TestGetJobHandler(t *testing.T) {
 func TestGetJobsHandler(t *testing.T) {
 	Convey("Given a Search Reindex Job API that returns a list of jobs", t, func() {
 		dataStorerMock := &apiMock.DataStorerMock{
-			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 				jobs := models.Jobs{}
 				jobsList := make([]models.Job, 2)
 
@@ -318,7 +318,7 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 	Convey("Given a Search Reindex Job API that returns an empty list of jobs", t, func() {
 
 		dataStorerMock := &apiMock.DataStorerMock{
-			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 				jobs := models.Jobs{}
 
 				return jobs, nil
@@ -356,7 +356,7 @@ func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 
 	Convey("Given a Search Reindex Job API that that failed to connect to the Job Store", t, func() {
 		dataStorerMock := &apiMock.DataStorerMock{
-			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 				jobs := models.Jobs{}
 
 				return jobs, errors.New("something went wrong in the server")

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -393,6 +393,32 @@ func TestGetJobsHandler(t *testing.T) {
 			})
 		})
 
+		Convey("When a request is made to get a list of jobs with an offset that is negative", func() {
+			req := httptest.NewRequest("GET", "http://localhost:25700/jobs?offset=-3&limit=20", nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then a bad request error is returned with status code 400", func() {
+				So(resp.Code, ShouldEqual, http.StatusBadRequest)
+				errMsg := strings.TrimSpace(resp.Body.String())
+				So(errMsg, ShouldEqual, expectedOffsetErrorMsg)
+			})
+		})
+
+		Convey("When a request is made to get a list of jobs with a limit that is not numeric", func() {
+			req := httptest.NewRequest("GET", "http://localhost:25700/jobs?offset=0&limit=sky", nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then a bad request error is returned with status code 400", func() {
+				So(resp.Code, ShouldEqual, http.StatusBadRequest)
+				errMsg := strings.TrimSpace(resp.Body.String())
+				So(errMsg, ShouldEqual, expectedLimitErrorMsg)
+			})
+		})
+
 		Convey("When a request is made to get a list of jobs with a limit that is negative", func() {
 			req := httptest.NewRequest("GET", "http://localhost:25700/jobs?offset=0&limit=-1", nil)
 			resp := httptest.NewRecorder()

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -54,7 +54,7 @@ func TestCreateJobHandler(t *testing.T) {
 		},
 	}
 
-	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a Job Store", t, func() {
+	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a Data Store", t, func() {
 		api.NewID = func() string { return validJobID1 }
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
@@ -93,7 +93,7 @@ func TestCreateJobHandler(t *testing.T) {
 		})
 	})
 
-	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a Job Store", t, func() {
+	Convey("Given a Search Reindex Job API that can create valid search reindex jobs and store their details in a Data Store", t, func() {
 		api.NewID = func() string { return validJobID2 }
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
@@ -165,7 +165,7 @@ func TestGetJobHandler(t *testing.T) {
 		So(err, ShouldBeNil)
 		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
-		Convey("When a request is made to get a specific job that exists in the Job Store", func() {
+		Convey("When a request is made to get a specific job that exists in the Data Store", func() {
 			req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:25700/jobs/%s", validJobID2), nil)
 			resp := httptest.NewRecorder()
 
@@ -198,7 +198,7 @@ func TestGetJobHandler(t *testing.T) {
 
 		})
 
-		Convey("When a request is made to get a specific job that does not exist in the Job Store", func() {
+		Convey("When a request is made to get a specific job that does not exist in the Data Store", func() {
 			req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:25700/jobs/%s", notFoundJobID), nil)
 			resp := httptest.NewRecorder()
 
@@ -211,7 +211,7 @@ func TestGetJobHandler(t *testing.T) {
 			})
 		})
 
-		Convey("When a request is made to get a specific job but the Job Store is unable to lock the id", func() {
+		Convey("When a request is made to get a specific job but the Data Store is unable to lock the id", func() {
 			req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:25700/jobs/%s", unLockableJobID), nil)
 			resp := httptest.NewRecorder()
 
@@ -224,7 +224,7 @@ func TestGetJobHandler(t *testing.T) {
 			})
 		})
 
-		Convey("When a request is made to get a specific job but an unexpected error occurs in the Job Store", func() {
+		Convey("When a request is made to get a specific job but an unexpected error occurs in the Data Store", func() {
 			req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:25700/jobs/%s", validJobID3), nil)
 			resp := httptest.NewRecorder()
 
@@ -273,7 +273,7 @@ func TestGetJobsHandler(t *testing.T) {
 		So(err, ShouldBeNil)
 		apiInstance := api.Setup(ctx, mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
-		Convey("When a request is made to get a list of all the jobs that exist in the Job Store", func() {
+		Convey("When a request is made to get a list of all the jobs that exist in the Data Store", func() {
 			req := httptest.NewRequest("GET", "http://localhost:25700/jobs", nil)
 			resp := httptest.NewRecorder()
 
@@ -355,6 +355,27 @@ func TestGetJobsHandler(t *testing.T) {
 				})
 			})
 		})
+
+		Convey("When a request is made to get a list of jobs with an offset greater than the total number of jobs in the Data Store", func() {
+			req := httptest.NewRequest("GET", "http://localhost:25700/jobs?offset=10&limit=20", nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then a list of jobs is returned with status code 200", func() {
+				So(resp.Code, ShouldEqual, http.StatusOK)
+				payload, err := ioutil.ReadAll(resp.Body)
+				So(err, ShouldBeNil)
+				jobsReturned := models.Jobs{}
+				err = json.Unmarshal(payload, &jobsReturned)
+				So(err, ShouldBeNil)
+
+				Convey("And the returned list should be empty", func() {
+					returnedJobList := jobsReturned.JobList
+					So(returnedJobList, ShouldHaveLength, 0)
+				})
+			})
+		})
 	})
 }
 
@@ -398,7 +419,7 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 	t.Parallel()
 
-	Convey("Given a Search Reindex Job API that that failed to connect to the Job Store", t, func() {
+	Convey("Given a Search Reindex Job API that that failed to connect to the Data Store", t, func() {
 		dataStorerMock := &apiMock.DataStorerMock{
 			GetJobsFunc: func(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 				jobs := models.Jobs{}
@@ -492,7 +513,7 @@ func TestPutNumTasksHandler(t *testing.T) {
 		So(err, ShouldBeNil)
 		apiInstance := api.Setup(ctx, mux.NewRouter(), jobStoreMock, &apiMock.AuthHandlerMock{}, taskNames, cfg)
 
-		Convey("When a request is made to update the number of tasks of a specific job that exists in the Job Store", func() {
+		Convey("When a request is made to update the number of tasks of a specific job that exists in the Data Store", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", validJobID2, validCount), nil)
 			resp := httptest.NewRecorder()
 
@@ -503,7 +524,7 @@ func TestPutNumTasksHandler(t *testing.T) {
 			})
 		})
 
-		Convey("When a request is made to update the number of tasks of a specific job that does not exist in the Job Store", func() {
+		Convey("When a request is made to update the number of tasks of a specific job that does not exist in the Data Store", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", notFoundJobID, validCount), nil)
 			resp := httptest.NewRecorder()
 
@@ -555,7 +576,7 @@ func TestPutNumTasksHandler(t *testing.T) {
 			})
 		})
 
-		Convey("When a request is made to update the number of tasks but the Job Store is unable to lock the id", func() {
+		Convey("When a request is made to update the number of tasks but the Data Store is unable to lock the id", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", unLockableJobID, validCount), nil)
 			resp := httptest.NewRecorder()
 

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -34,7 +34,7 @@ var _ api.DataStorer = &DataStorerMock{}
 // 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
 // 				panic("mock out the GetJob method")
 // 			},
-// 			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
+// 			GetJobsFunc: func(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 // 				panic("mock out the GetJobs method")
 // 			},
 // 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
@@ -69,7 +69,7 @@ type DataStorerMock struct {
 	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
-	GetJobsFunc func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error)
+	GetJobsFunc func(ctx context.Context, offset int, limit int) (models.Jobs, error)
 
 	// GetTaskFunc mocks the GetTask method.
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
@@ -121,10 +121,10 @@ type DataStorerMock struct {
 		GetJobs []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// OffsetParam is the offsetParam argument value.
-			OffsetParam string
-			// LimitParam is the limitParam argument value.
-			LimitParam string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetTask holds details about calls to the GetTask method.
 		GetTask []struct {
@@ -341,7 +341,7 @@ func (mock *DataStorerMock) GetJobCalls() []struct {
 }
 
 // GetJobs calls GetJobsFunc.
-func (mock *DataStorerMock) GetJobs(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
+func (mock *DataStorerMock) GetJobs(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 	if mock.GetJobsFunc == nil {
 		results := models.Jobs{}
 		jobs := make([]models.Job, 2)
@@ -353,32 +353,32 @@ func (mock *DataStorerMock) GetJobs(ctx context.Context, offsetParam string, lim
 		return results, err
 	}
 	callInfo := struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
+		Ctx    context.Context
+		Offset int
+		Limit  int
 	}{
-		Ctx:         ctx,
-		OffsetParam: offsetParam,
-		LimitParam:  limitParam,
+		Ctx:    ctx,
+		Offset: offset,
+		Limit:  limit,
 	}
 	mock.lockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
 	mock.lockGetJobs.Unlock()
-	return mock.GetJobsFunc(ctx, offsetParam, limitParam)
+	return mock.GetJobsFunc(ctx, offset, limit)
 }
 
 // GetJobsCalls gets all the calls that were made to GetJobs.
 // Check the length with:
 //     len(mockedDataStorer.GetJobsCalls())
 func (mock *DataStorerMock) GetJobsCalls() []struct {
-	Ctx         context.Context
-	OffsetParam string
-	LimitParam  string
+	Ctx    context.Context
+	Offset int
+	Limit  int
 } {
 	var calls []struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
+		Ctx    context.Context
+		Offset int
+		Limit  int
 	}
 	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
-	"github.com/ONSdigital/dp-search-reindex-api/pagination"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 	"net/http"
@@ -108,11 +107,8 @@ func (api *API) GetTasksHandler(w http.ResponseWriter, req *http.Request) {
 	id := vars["id"]
 	logData := log.Data{"job_id": id}
 
-	paginator := pagination.NewPaginator(api.cfg.DefaultLimit, api.cfg.DefaultOffset, api.cfg.DefaultMaxLimit)
-	offset, limit, err := paginator.ValidatePaginationParameters(offsetParam, limitParam)
-	if err != nil {
-		log.Error(ctx, "pagination validation failed", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	offset, limit, setUpPaginationFailed := api.setUpPagination(w, offsetParam, limitParam, ctx)
+	if setUpPaginationFailed {
 		return
 	}
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -107,8 +107,9 @@ func (api *API) GetTasksHandler(w http.ResponseWriter, req *http.Request) {
 	id := vars["id"]
 	logData := log.Data{"job_id": id}
 
-	offset, limit, setUpPaginationFailed := api.setUpPagination(w, offsetParam, limitParam, ctx)
-	if setUpPaginationFailed {
+	offset, limit, err := api.setUpPagination(w, offsetParam, limitParam, ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -107,8 +107,9 @@ func (api *API) GetTasksHandler(w http.ResponseWriter, req *http.Request) {
 	id := vars["id"]
 	logData := log.Data{"job_id": id}
 
-	offset, limit, err := api.setUpPagination(w, offsetParam, limitParam, ctx)
+	offset, limit, err := api.setUpPagination(offsetParam, limitParam)
 	if err != nil {
+		log.Error(ctx, "pagination validation failed", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -39,7 +39,7 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 // 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
 // 				panic("mock out the GetJob method")
 // 			},
-// 			GetJobsFunc: func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
+// 			GetJobsFunc: func(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 // 				panic("mock out the GetJobs method")
 // 			},
 // 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
@@ -80,7 +80,7 @@ type MongoDataStorerMock struct {
 	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
-	GetJobsFunc func(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error)
+	GetJobsFunc func(ctx context.Context, offset int, limit int) (models.Jobs, error)
 
 	// GetTaskFunc mocks the GetTask method.
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
@@ -144,10 +144,10 @@ type MongoDataStorerMock struct {
 		GetJobs []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// OffsetParam is the offsetParam argument value.
-			OffsetParam string
-			// LimitParam is the limitParam argument value.
-			LimitParam string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetTask holds details about calls to the GetTask method.
 		GetTask []struct {
@@ -412,37 +412,37 @@ func (mock *MongoDataStorerMock) GetJobCalls() []struct {
 }
 
 // GetJobs calls GetJobsFunc.
-func (mock *MongoDataStorerMock) GetJobs(ctx context.Context, offsetParam string, limitParam string) (models.Jobs, error) {
+func (mock *MongoDataStorerMock) GetJobs(ctx context.Context, offset int, limit int) (models.Jobs, error) {
 	if mock.GetJobsFunc == nil {
 		panic("MongoDataStorerMock.GetJobsFunc: method is nil but MongoDataStorer.GetJobs was just called")
 	}
 	callInfo := struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
+		Ctx    context.Context
+		Offset int
+		Limit  int
 	}{
-		Ctx:         ctx,
-		OffsetParam: offsetParam,
-		LimitParam:  limitParam,
+		Ctx:    ctx,
+		Offset: offset,
+		Limit:  limit,
 	}
 	mock.lockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
 	mock.lockGetJobs.Unlock()
-	return mock.GetJobsFunc(ctx, offsetParam, limitParam)
+	return mock.GetJobsFunc(ctx, offset, limit)
 }
 
 // GetJobsCalls gets all the calls that were made to GetJobs.
 // Check the length with:
 //     len(mockedMongoDataStorer.GetJobsCalls())
 func (mock *MongoDataStorerMock) GetJobsCalls() []struct {
-	Ctx         context.Context
-	OffsetParam string
-	LimitParam  string
+	Ctx    context.Context
+	Offset int
+	Limit  int
 } {
 	var calls []struct {
-		Ctx         context.Context
-		OffsetParam string
-		LimitParam  string
+		Ctx    context.Context
+		Offset int
+		Limit  int
 	}
 	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
These are the changes in this release:

The following amendments have been made to the GET /jobs endpoint, which allows a GET request to be made, to list all the search reindex jobs currently held in the data store:

1. When the requested jobs are counted there is potential for an error to occur if the connection to mongo is lost. That error was not previously being handled but now it is.

2. If an offset parameter is passed in, which has a value greater than the total count of jobs in the database, instead of returning an error it will now return an empty list and a status of 200. This is to prevent unnecessary failures.

3. The pagination validation now occurs before the jobs are retrieved from mongo. This means that if the validation fails (because of bad offset or limit values) then it will return, and not make any database requests, which is more efficient.

4. The mongo dB querying language is now being used to better effect. Instead of retrieving all the jobs in the database, and iterating through them, it now uses the offset and limit parameters passed in and only returns the data that has been requested. It does not use an iterator but instead returns all the required data straight away.

5. Due to the improved use of the mongo dB querying language there is no need to use the modifyTasks function. So that has been removed.

# How to review
<!--- Describe in detail how you tested your changes. -->
Check only expected commits present

NB. The new functionality can be tested locally as follows:

In dp-compose run MongoDB on port 27017 as follows:

 docker-compose up -d

In any directory run Vault as follows:

 vault server -dev

In the zebedee directory run Zebedee as follows:

 ./run.sh

Then in the dp-search-reindex-api run:

 make debug

Then hit the POST endpoint a few times to create some jobs:
http://localhost:25700/jobs

The changes can then be tested locally using this GET URL or similar: 
http://localhost:25700/jobs?offset=3&limit=100


The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
