### PR TITLE
Extend client to call patch jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ONSdigital/dp-search-reindex-api
 
 go 1.17
 
+	//replace github.com/ONSdigital/dp-api-clients-go/v2 => /Users/cookel/EllasFiles/DpCodeRepos/dp-api-clients-go
+
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.105.0
 	github.com/ONSdigital/dp-authorisation v0.2.0

--- a/models/job_test.go
+++ b/models/job_test.go
@@ -11,7 +11,7 @@ func TestNewJob(t *testing.T) {
 	Convey("Given an id for a new job", t, func() {
 		id := "test1234"
 
-		currentTime := time.Now()
+		currentTime := time.Now().UTC()
 		zeroTime := time.Time{}.UTC()
 
 		Convey("When NewJob is called", func() {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -45,13 +45,13 @@ func (h *Headers) Add(req *http.Request) {
 	}
 	fmt.Println("the ETag value is: " + h.ETag)
 	fmt.Println("the auth value is: " + h.ServiceAuthToken)
+	fmt.Println("the IfMatch value is: " + h.IfMatch)
 	if h.ETag != "" {
 		dpclients.SetETag(req, h.ETag)
 	}
 
 	if h.IfMatch != "" {
-		// TODO Set IfMatch header
-		fmt.Println("currently not handling IfMatch header")
+		dpclients.SetIfMatch(req, h.IfMatch)
 	}
 
 	if h.ServiceAuthToken != "" {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -17,7 +17,7 @@ type Client interface {
 	Checker(ctx context.Context, check *health.CheckState) error
 	Health() *healthcheck.Client
 	PostJob(ctx context.Context, headers Headers) (models.Job, error)
-	PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) error
+	PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) (string, error)
 	URL() string
 }
 

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -13,7 +13,7 @@ import (
 
 type Client interface {
 	PostJob(ctx context.Context, headers Headers) (models.Job, error)
-	PatchJob(ctx context.Context, headers Headers, jobID string, body PatchOpsList) error
+	PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) error
 }
 
 type Headers struct {
@@ -33,10 +33,6 @@ type PatchOperation struct {
 	Op    string
 	Path  string
 	Value interface{}
-}
-
-type PatchOpsList struct {
-	PatchList []PatchOperation
 }
 
 func (h *Headers) Add(req *http.Request) error {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	dpclients "github.com/ONSdigital/dp-api-clients-go/v2/headers"
@@ -31,9 +30,8 @@ type Options struct {
 }
 
 type PatchOperation struct {
-	Op   string
-	Path string
-	// 	From      string
+	Op    string
+	Path  string
 	Value interface{}
 }
 
@@ -45,9 +43,7 @@ func (h *Headers) Add(req *http.Request) {
 	if h == nil {
 		return
 	}
-	fmt.Println("the ETag value is: " + h.ETag)
-	fmt.Println("the auth value is: " + h.ServiceAuthToken)
-	fmt.Println("the IfMatch value is: " + h.IfMatch)
+
 	if h.ETag != "" {
 		dpclients.SetETag(req, h.ETag)
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	dpclients "github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 )
@@ -28,14 +29,24 @@ type Options struct {
 	Sort   string
 }
 
+type PatchOperation struct {
+	Operation string
+	Path      string
+	Value     string
+}
+
+type PatchOpsList struct {
+	PatchList []PatchOperation
+}
+
 func (h *Headers) Add(req *http.Request) {
 	if h == nil {
 		return
 	}
-
+	fmt.Println("the ETag value is: " + h.ETag)
+	fmt.Println("the auth value is: " + h.ServiceAuthToken)
 	if h.ETag != "" {
-		// TODO Set ETag header
-		fmt.Println("currently not handling ETag header")
+		dpclients.SetETag(req, h.ETag)
 	}
 
 	if h.IfMatch != "" {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -39,17 +39,23 @@ type PatchOpsList struct {
 	PatchList []PatchOperation
 }
 
-func (h *Headers) Add(req *http.Request) {
+func (h *Headers) Add(req *http.Request) error {
 	if h == nil {
-		return
+		return nil
 	}
 
 	if h.ETag != "" {
-		dpclients.SetETag(req, h.ETag)
+		err := dpclients.SetETag(req, h.ETag)
+		if err != nil {
+			return err
+		}
 	}
 
 	if h.IfMatch != "" {
-		dpclients.SetIfMatch(req, h.IfMatch)
+		err := dpclients.SetIfMatch(req, h.IfMatch)
+		if err != nil {
+			return err
+		}
 	}
 
 	if h.ServiceAuthToken != "" {
@@ -59,4 +65,6 @@ func (h *Headers) Add(req *http.Request) {
 	if h.UserAuthToken != "" {
 		dprequest.AddFlorenceHeader(req, h.UserAuthToken)
 	}
+
+	return nil
 }

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -14,6 +14,7 @@ import (
 
 type Client interface {
 	PostJob(ctx context.Context, headers Headers) (models.Job, error)
+	PatchJob(ctx context.Context, headers Headers, jobID string, body PatchOpsList) error
 }
 
 type Headers struct {
@@ -30,9 +31,10 @@ type Options struct {
 }
 
 type PatchOperation struct {
-	Operation string
-	Path      string
-	Value     string
+	Op   string
+	Path string
+	// 	From      string
+	Value interface{}
 }
 
 type PatchOpsList struct {

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	authHeader = "Authorization"
-	authPrefix = "Bearer "
-	eTagHeader = "ETag"
+	authHeader    = "Authorization"
+	authPrefix    = "Bearer "
+	eTagHeader    = "ETag"
+	ifMatchHeader = "If-Match"
 )
 
 func TestHeaders_Add(t *testing.T) {
@@ -21,20 +22,23 @@ func TestHeaders_Add(t *testing.T) {
 			Header: http.Header{},
 		}
 		headers := &Headers{
-			ETag:             "dsalfhjsadf",
+			ETag: "dsalfhjsadf",
 		}
 
 		Convey("When calling the Add method on Headers", func() {
 			headers.Add(req)
 
 			Convey("Then an ETag header is set on the request", func() {
+				So(req.Header, ShouldNotBeEmpty)
 				So(req.Header.Get(eTagHeader), ShouldEqual, headers.ETag)
 			})
 		})
 	})
 
 	Convey("Given the sdk Headers struct contains avalue for If-Match", t, func() {
-		req := &http.Request{}
+		req := &http.Request{
+			Header: http.Header{},
+		}
 		headers := &Headers{
 			IfMatch: "*",
 		}
@@ -43,7 +47,8 @@ func TestHeaders_Add(t *testing.T) {
 			headers.Add(req)
 
 			Convey("Then an If-Match header is set on the request", func() {
-				So(req.Header, ShouldBeEmpty)
+				So(req.Header, ShouldNotBeEmpty)
+				So(req.Header.Get(ifMatchHeader), ShouldEqual, headers.IfMatch)
 			})
 		})
 	})

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -10,22 +10,25 @@ import (
 const (
 	authHeader = "Authorization"
 	authPrefix = "Bearer "
+	eTagHeader = "ETag"
 )
 
 func TestHeaders_Add(t *testing.T) {
 	t.Parallel()
 
 	Convey("Given the sdk Headers struct contains a value for ETag", t, func() {
-		req := &http.Request{}
+		req := &http.Request{
+			Header: http.Header{},
+		}
 		headers := &Headers{
-			ETag: "dsalfhjsadf",
+			ETag:             "dsalfhjsadf",
 		}
 
 		Convey("When calling the Add method on Headers", func() {
 			headers.Add(req)
 
 			Convey("Then an ETag header is set on the request", func() {
-				So(req.Header, ShouldBeEmpty)
+				So(req.Header.Get(eTagHeader), ShouldEqual, headers.ETag)
 			})
 		})
 	})

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -10,35 +10,48 @@ import (
 	"sync"
 )
 
-var (
-	lockClientMockPostJob sync.RWMutex
-)
-
 // Ensure, that ClientMock does implement sdk.Client.
 // If this is not the case, regenerate this file with moq.
 var _ sdk.Client = &ClientMock{}
 
 // ClientMock is a mock implementation of sdk.Client.
 //
-//     func TestSomethingThatUsesClient(t *testing.T) {
+// 	func TestSomethingThatUsesClient(t *testing.T) {
 //
-//         // make and configure a mocked sdk.Client
-//         mockedClient := &ClientMock{
-//             PostJobFunc: func(ctx context.Context, headers sdk.Headers) (models.Job, error) {
-// 	               panic("mock out the PostJob method")
-//             },
-//         }
+// 		// make and configure a mocked sdk.Client
+// 		mockedClient := &ClientMock{
+// 			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body sdk.PatchOpsList) error {
+// 				panic("mock out the PatchJob method")
+// 			},
+// 			PostJobFunc: func(ctx context.Context, headers sdk.Headers) (models.Job, error) {
+// 				panic("mock out the PostJob method")
+// 			},
+// 		}
 //
-//         // use mockedClient in code that requires sdk.Client
-//         // and then make assertions.
+// 		// use mockedClient in code that requires sdk.Client
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type ClientMock struct {
+	// PatchJobFunc mocks the PatchJob method.
+	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body sdk.PatchOpsList) error
+
 	// PostJobFunc mocks the PostJob method.
 	PostJobFunc func(ctx context.Context, headers sdk.Headers) (models.Job, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// PatchJob holds details about calls to the PatchJob method.
+		PatchJob []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Headers is the headers argument value.
+			Headers sdk.Headers
+			// JobID is the jobID argument value.
+			JobID string
+			// Body is the body argument value.
+			Body sdk.PatchOpsList
+		}
 		// PostJob holds details about calls to the PostJob method.
 		PostJob []struct {
 			// Ctx is the ctx argument value.
@@ -47,6 +60,51 @@ type ClientMock struct {
 			Headers sdk.Headers
 		}
 	}
+	lockPatchJob sync.RWMutex
+	lockPostJob  sync.RWMutex
+}
+
+// PatchJob calls PatchJobFunc.
+func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body sdk.PatchOpsList) error {
+	if mock.PatchJobFunc == nil {
+		panic("ClientMock.PatchJobFunc: method is nil but Client.PatchJob was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Headers sdk.Headers
+		JobID   string
+		Body    sdk.PatchOpsList
+	}{
+		Ctx:     ctx,
+		Headers: headers,
+		JobID:   jobID,
+		Body:    body,
+	}
+	mock.lockPatchJob.Lock()
+	mock.calls.PatchJob = append(mock.calls.PatchJob, callInfo)
+	mock.lockPatchJob.Unlock()
+	return mock.PatchJobFunc(ctx, headers, jobID, body)
+}
+
+// PatchJobCalls gets all the calls that were made to PatchJob.
+// Check the length with:
+//     len(mockedClient.PatchJobCalls())
+func (mock *ClientMock) PatchJobCalls() []struct {
+	Ctx     context.Context
+	Headers sdk.Headers
+	JobID   string
+	Body    sdk.PatchOpsList
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Headers sdk.Headers
+		JobID   string
+		Body    sdk.PatchOpsList
+	}
+	mock.lockPatchJob.RLock()
+	calls = mock.calls.PatchJob
+	mock.lockPatchJob.RUnlock()
+	return calls
 }
 
 // PostJob calls PostJobFunc.
@@ -61,9 +119,9 @@ func (mock *ClientMock) PostJob(ctx context.Context, headers sdk.Headers) (model
 		Ctx:     ctx,
 		Headers: headers,
 	}
-	lockClientMockPostJob.Lock()
+	mock.lockPostJob.Lock()
 	mock.calls.PostJob = append(mock.calls.PostJob, callInfo)
-	lockClientMockPostJob.Unlock()
+	mock.lockPostJob.Unlock()
 	return mock.PostJobFunc(ctx, headers)
 }
 
@@ -78,8 +136,8 @@ func (mock *ClientMock) PostJobCalls() []struct {
 		Ctx     context.Context
 		Headers sdk.Headers
 	}
-	lockClientMockPostJob.RLock()
+	mock.lockPostJob.RLock()
 	calls = mock.calls.PostJob
-	lockClientMockPostJob.RUnlock()
+	mock.lockPostJob.RUnlock()
 	return calls
 }

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -28,7 +28,7 @@ var _ sdk.Client = &ClientMock{}
 // 			HealthFunc: func() *healthcheck.Client {
 // 				panic("mock out the Health method")
 // 			},
-// 			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) error {
+// 			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (string, error) {
 // 				panic("mock out the PatchJob method")
 // 			},
 // 			PostJobFunc: func(ctx context.Context, headers sdk.Headers) (models.Job, error) {
@@ -51,7 +51,7 @@ type ClientMock struct {
 	HealthFunc func() *healthcheck.Client
 
 	// PatchJobFunc mocks the PatchJob method.
-	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) error
+	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (string, error)
 
 	// PostJobFunc mocks the PostJob method.
 	PostJobFunc func(ctx context.Context, headers sdk.Headers) (models.Job, error)
@@ -162,7 +162,7 @@ func (mock *ClientMock) HealthCalls() []struct {
 }
 
 // PatchJob calls PatchJobFunc.
-func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) error {
+func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (string, error) {
 	if mock.PatchJobFunc == nil {
 		panic("ClientMock.PatchJobFunc: method is nil but Client.PatchJob was just called")
 	}

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -20,7 +20,7 @@ var _ sdk.Client = &ClientMock{}
 //
 // 		// make and configure a mocked sdk.Client
 // 		mockedClient := &ClientMock{
-// 			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body sdk.PatchOpsList) error {
+// 			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) error {
 // 				panic("mock out the PatchJob method")
 // 			},
 // 			PostJobFunc: func(ctx context.Context, headers sdk.Headers) (models.Job, error) {
@@ -34,7 +34,7 @@ var _ sdk.Client = &ClientMock{}
 // 	}
 type ClientMock struct {
 	// PatchJobFunc mocks the PatchJob method.
-	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body sdk.PatchOpsList) error
+	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) error
 
 	// PostJobFunc mocks the PostJob method.
 	PostJobFunc func(ctx context.Context, headers sdk.Headers) (models.Job, error)
@@ -50,7 +50,7 @@ type ClientMock struct {
 			// JobID is the jobID argument value.
 			JobID string
 			// Body is the body argument value.
-			Body sdk.PatchOpsList
+			Body []sdk.PatchOperation
 		}
 		// PostJob holds details about calls to the PostJob method.
 		PostJob []struct {
@@ -65,7 +65,7 @@ type ClientMock struct {
 }
 
 // PatchJob calls PatchJobFunc.
-func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body sdk.PatchOpsList) error {
+func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) error {
 	if mock.PatchJobFunc == nil {
 		panic("ClientMock.PatchJobFunc: method is nil but Client.PatchJob was just called")
 	}
@@ -73,7 +73,7 @@ func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID
 		Ctx     context.Context
 		Headers sdk.Headers
 		JobID   string
-		Body    sdk.PatchOpsList
+		Body    []sdk.PatchOperation
 	}{
 		Ctx:     ctx,
 		Headers: headers,
@@ -93,13 +93,13 @@ func (mock *ClientMock) PatchJobCalls() []struct {
 	Ctx     context.Context
 	Headers sdk.Headers
 	JobID   string
-	Body    sdk.PatchOpsList
+	Body    []sdk.PatchOperation
 } {
 	var calls []struct {
 		Ctx     context.Context
 		Headers sdk.Headers
 		JobID   string
-		Body    sdk.PatchOpsList
+		Body    []sdk.PatchOperation
 	}
 	mock.lockPatchJob.RLock()
 	calls = mock.calls.PatchJob

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -63,7 +63,7 @@ func (cli *Client) PostJob(ctx context.Context, headers client.Headers) (models.
 		headers.ServiceAuthToken = cli.serviceToken
 	}
 
-    path := cli.hcCli.URL + jobsEndpoint
+	path := cli.hcCli.URL + jobsEndpoint
 	b, err := cli.callReindexAPI(ctx, path, http.MethodPost, headers, nil)
 	if err != nil {
 		return job, err
@@ -78,6 +78,9 @@ func (cli *Client) PostJob(ctx context.Context, headers client.Headers) (models.
 
 	return job, nil
 }
+
+// func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID string, body client.PatchOpsList) error {
+// }
 
 func (cli *Client) callReindexAPI(ctx context.Context, path, method string, headers client.Headers, payload []byte) ([]byte, error) {
 	URL, err := url.Parse(path)

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -125,7 +125,13 @@ func (cli *Client) callReindexAPI(ctx context.Context, path, method string, head
 		}
 	}
 
-	headers.Add(req)
+	err = headers.Add(req)
+	if err != nil {
+		return nil, apiError.StatusError{
+			Err:  fmt.Errorf("failed to add headers to request, error is: %v", err),
+			Code: http.StatusInternalServerError,
+		}
+	}
 
 	resp, err := cli.hcCli.Client.Do(ctx, req)
 	if err != nil {

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -79,9 +79,24 @@ func (cli *Client) PostJob(ctx context.Context, headers client.Headers) (models.
 	return job, nil
 }
 
-// func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID string, body client.PatchOpsList) error {
-// }
+// PatchJob applies the patch operations, provided in the body, to the job with id = jobID
+func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID string, body client.PatchOpsList) error {
+    if headers.ServiceAuthToken == "" {
+        headers.ServiceAuthToken = cli.serviceToken
+    }
 
+    path := cli.hcCli.URL + jobsEndpoint + "/" + jobID
+    payload, _ := json.Marshal(body)
+    _, err := cli.callReindexAPI(ctx, path, http.MethodPatch, headers, payload)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}
+
+// callReindexAPI calls the Search Reindex endpoint given by path for the provided REST method, request headers, and body payload.
+// It returns the response body and any error that occurred.
 func (cli *Client) callReindexAPI(ctx context.Context, path, method string, headers client.Headers, payload []byte) ([]byte, error) {
 	URL, err := url.Parse(path)
 	if err != nil {

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	service    = "dp-search-reindex-api"
-	apiVersion = "v1"
-
+	service      = "dp-search-reindex-api"
+	apiVersion   = "v1"
 	jobsEndpoint = "/jobs"
 )
 
@@ -138,10 +137,6 @@ func (cli *Client) callReindexAPI(ctx context.Context, path, method string, head
 	defer func() {
 		err = closeResponseBody(ctx, resp)
 	}()
-
-	fmt.Println("the Request method is: " + req.Method)
-	fmt.Println("the Request URL is: " + req.URL.String())
-	fmt.Println("the Header contains value: " + req.Header["Authorization"][0])
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= 400 {
 		return nil, apiError.StatusError{

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -151,6 +151,10 @@ func (cli *Client) callReindexAPI(ctx context.Context, path, method string, head
 		}
 	}
 
+	if resp.Body == nil {
+		return nil, nil
+	}
+
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, apiError.StatusError{

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -21,7 +21,7 @@ const (
 	service      = "dp-search-reindex-api"
 	apiVersion   = "v1"
 	jobsEndpoint = "/jobs"
-	eTagHeader   = "ETag"
+	ETagHeader   = "ETag"
 )
 
 type Client struct {
@@ -94,7 +94,7 @@ func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID s
 		return "", err
 	}
 
-	respETag := respHeader.Get(eTagHeader)
+	respETag := respHeader.Get(ETagHeader)
 
 	return respETag, nil
 }

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -63,13 +63,11 @@ func (cli *Client) PostJob(ctx context.Context, headers client.Headers) (models.
 		headers.ServiceAuthToken = cli.serviceToken
 	}
 
-	path := cli.apiVersion + jobsEndpoint
+    path := cli.hcCli.URL + jobsEndpoint
 	b, err := cli.callReindexAPI(ctx, path, http.MethodPost, headers, nil)
 	if err != nil {
 		return job, err
 	}
-
-	fmt.Printf("got here, error is: %v", err)
 
 	if err = json.Unmarshal(b, &job); err != nil {
 		return job, apiError.StatusError{

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -80,19 +80,20 @@ func (cli *Client) PostJob(ctx context.Context, headers client.Headers) (models.
 }
 
 // PatchJob applies the patch operations, provided in the body, to the job with id = jobID
-func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID string, body client.PatchOpsList) error {
-    if headers.ServiceAuthToken == "" {
-        headers.ServiceAuthToken = cli.serviceToken
-    }
+func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID string, patchOpsList client.PatchOpsList) error {
+	if headers.ServiceAuthToken == "" {
+		headers.ServiceAuthToken = cli.serviceToken
+	}
 
-    path := cli.hcCli.URL + jobsEndpoint + "/" + jobID
-    payload, _ := json.Marshal(body)
-    _, err := cli.callReindexAPI(ctx, path, http.MethodPatch, headers, payload)
-    if err != nil {
-        return err
-    }
+	path := cli.hcCli.URL + jobsEndpoint + "/" + jobID
+	payload, _ := json.Marshal(patchOpsList.PatchList)
 
-    return nil
+	_, err := cli.callReindexAPI(ctx, path, http.MethodPatch, headers, payload)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // callReindexAPI calls the Search Reindex endpoint given by path for the provided REST method, request headers, and body payload.
@@ -137,6 +138,10 @@ func (cli *Client) callReindexAPI(ctx context.Context, path, method string, head
 	defer func() {
 		err = closeResponseBody(ctx, resp)
 	}()
+
+	fmt.Println("the Request method is: " + req.Method)
+	fmt.Println("the Request URL is: " + req.URL.String())
+	fmt.Println("the Header contains value: " + req.Header["Authorization"][0])
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= 400 {
 		return nil, apiError.StatusError{

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -21,6 +21,7 @@ const (
 	service      = "dp-search-reindex-api"
 	apiVersion   = "v1"
 	jobsEndpoint = "/jobs"
+	eTagHeader   = "ETag"
 )
 
 type Client struct {

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -312,4 +312,39 @@ func TestClient_PatchJob(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Given a 409 response", t, func() {
+		httpClient := newMockHTTPClient(
+			&http.Response{
+				StatusCode: http.StatusConflict,
+				Body:       nil,
+				Header:     nil},
+			fmt.Errorf("failed as unexpected code from search reindex api: %v", http.StatusConflict))
+
+		searchReindexClient := newSearchReindexClient(t, httpClient)
+
+		Convey("When search-reindexClient.PatchJob is called", func() {
+			respETag, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "failed to call search reindex api, error is: failed as unexpected code from search reindex api: 409")
+			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusInternalServerError)
+
+			Convey("Then an empty ETag is returned", func() {
+				So(respETag, ShouldNotBeNil)
+				So(respETag, ShouldResemble, "")
+			})
+
+			Convey("And client.Do should be called once with the expected parameters", func() {
+				doCalls := httpClient.DoCalls()
+				So(doCalls, ShouldHaveLength, 1)
+				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
+				expectedIfMatchHeader := make([]string, 1)
+				expectedIfMatchHeader[0] = "*"
+				So(doCalls[0].Req.Header[ifMatchHeader], ShouldResemble, expectedIfMatchHeader)
+				body, _ := json.Marshal(patchList)
+				expectedBody := io.NopCloser(bytes.NewReader(body))
+				So(doCalls[0].Req.Body, ShouldResemble, expectedBody)
+			})
+		})
+	})
 }

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -25,7 +25,6 @@ const (
 	serviceName   = "test-app"
 	serviceToken  = "test-token"
 	testHost      = "http://localhost:25700"
-	eTagHeader    = "ETag"
 	testJobID     = "123"
 	ifMatchHeader = "If-Match"
 )

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -27,6 +27,7 @@ const (
 	testHost      = "http://localhost:25700"
 	testJobID     = "123"
 	ifMatchHeader = "If-Match"
+	testETag      = `"56b6890f1321590998d5fd8d293b620581ff3531"`
 )
 
 var (
@@ -222,11 +223,8 @@ func TestClient_PatchJob(t *testing.T) {
 	path := "/jobs/" + testJobID
 
 	Convey("Given clienter.Do doesn't return an error", t, func() {
-        header := http.Header{}
-        testETagList := make([]string, 1)
-        testETagList[0] = `"56b6890f1321590998d5fd8d293b620581ff3531"`
-        header[ETagHeader] = testETagList
-
+		header := http.Header{}
+		header.Add(ETagHeader, testETag)
 		httpClient := newMockHTTPClient(
 			&http.Response{
 				StatusCode: 204,
@@ -235,7 +233,7 @@ func TestClient_PatchJob(t *testing.T) {
 			},
 			nil)
 
-		searchReindexClient := newSearchReindexClient(httpClient)
+		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PatchJob is called", func() {
 			headers := client.Headers{
@@ -262,8 +260,7 @@ func TestClient_PatchJob(t *testing.T) {
 
 			Convey("Then an ETag is returned", func() {
 				So(respETag, ShouldNotBeNil)
-				//TODO fix the error shown in the line below
-// 				So(respETag, ShouldResemble, testETagList)
+				So(respETag, ShouldResemble, testETag)
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -280,25 +277,25 @@ func TestClient_PatchJob(t *testing.T) {
 		})
 	})
 
-// 	Convey("Given a 500 response", t, func() {
-// 		httpClient := newMockHTTPClient(&http.Response{StatusCode: http.StatusInternalServerError}, nil)
-// 		searchReindexClient := newSearchReindexClient(httpClient)
-//
-// 		Convey("When search-reindexClient.PatchJob is called", func() {
-// 			job, err := searchReindexClient.PostJob(ctx, client.Headers{})
-// 			So(err, ShouldNotBeNil)
-// 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 500")
-// 			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusInternalServerError)
-//
-// 			Convey("Then an empty ETag is returned", func() {
-// 				So(job, ShouldResemble, models.Job{})
-// 			})
-//
-// 			Convey("And client.Do should be called once with the expected parameters", func() {
-// 				doCalls := httpClient.DoCalls()
-// 				So(doCalls, ShouldHaveLength, 1)
-// 				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
-// 			})
-// 		})
-// 	})
+	// 	Convey("Given a 500 response", t, func() {
+	// 		httpClient := newMockHTTPClient(&http.Response{StatusCode: http.StatusInternalServerError}, nil)
+	// 		searchReindexClient := newSearchReindexClient(httpClient)
+	//
+	// 		Convey("When search-reindexClient.PatchJob is called", func() {
+	// 			job, err := searchReindexClient.PostJob(ctx, client.Headers{})
+	// 			So(err, ShouldNotBeNil)
+	// 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 500")
+	// 			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusInternalServerError)
+	//
+	// 			Convey("Then an empty ETag is returned", func() {
+	// 				So(job, ShouldResemble, models.Job{})
+	// 			})
+	//
+	// 			Convey("And client.Do should be called once with the expected parameters", func() {
+	// 				doCalls := httpClient.DoCalls()
+	// 				So(doCalls, ShouldHaveLength, 1)
+	// 				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
+	// 			})
+	// 		})
+	// 	})
 }

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -218,10 +218,16 @@ func TestClient_PatchJob(t *testing.T) {
 	path := "/jobs/" + testJobID
 
 	Convey("Given clienter.Do doesn't return an error", t, func() {
+        header := http.Header{}
+        testETagList := make([]string, 1)
+        testETagList[0] = `"56b6890f1321590998d5fd8d293b620581ff3531"`
+        header[ETagHeader] = testETagList
+
 		httpClient := newMockHTTPClient(
 			&http.Response{
 				StatusCode: 204,
 				Body:       nil,
+				Header:     header,
 			},
 			nil)
 
@@ -252,6 +258,8 @@ func TestClient_PatchJob(t *testing.T) {
 
 			Convey("Then an ETag is returned", func() {
 				So(respETag, ShouldNotBeNil)
+				//TODO fix the error shown in the line below
+// 				So(respETag, ShouldResemble, testETagList)
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -267,4 +275,26 @@ func TestClient_PatchJob(t *testing.T) {
 			})
 		})
 	})
+
+// 	Convey("Given a 500 response", t, func() {
+// 		httpClient := newMockHTTPClient(&http.Response{StatusCode: http.StatusInternalServerError}, nil)
+// 		searchReindexClient := newSearchReindexClient(httpClient)
+//
+// 		Convey("When search-reindexClient.PatchJob is called", func() {
+// 			job, err := searchReindexClient.PostJob(ctx, client.Headers{})
+// 			So(err, ShouldNotBeNil)
+// 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 500")
+// 			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusInternalServerError)
+//
+// 			Convey("Then an empty ETag is returned", func() {
+// 				So(job, ShouldResemble, models.Job{})
+// 			})
+//
+// 			Convey("And client.Do should be called once with the expected parameters", func() {
+// 				doCalls := httpClient.DoCalls()
+// 				So(doCalls, ShouldHaveLength, 1)
+// 				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
+// 			})
+// 		})
+// 	})
 }

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -116,7 +116,7 @@ func TestClient_PostJob(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	path := "v1/jobs"
+	path := "/jobs"
 
 	Convey("Given clienter.Do doesn't return an error", t, func() {
 		expectedJob := models.Job{


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The Search Reindex Client has been extended to include the following method:

PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) (string, error)

And unit tests have been added to test the following:
- The Search Reindex Client returns 204 and an ETag (the success scenario)
- The Search Reindex Client returns a 400 response (bad patch request)
- The Search Reindex Client returns a 500 response (search reindex error)
- The Search Reindex Client returns a 409 response (conflict with other reindex job)
- The Search Reindex Client returns a 404 response (reindex job not found)

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct.

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: makee lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
