### PR TITLE
Fix patch job return value

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -18,8 +18,8 @@ type Client interface {
 	Checker(ctx context.Context, check *health.CheckState) error
 	Health() *healthcheck.Client
 	PostJob(ctx context.Context, headers Headers) (models.Job, error)
-	PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) (string, error)
-	PostTasksCount(ctx context.Context, headers Headers, jobID string, payload []byte) (models.Task, error)
+	PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) (RespHeaders, error)
+	PostTasksCount(ctx context.Context, headers Headers, jobID string, payload []byte) (string, models.Task, error)
 	URL() string
 }
 
@@ -28,6 +28,10 @@ type Headers struct {
 	IfMatch          string
 	ServiceAuthToken string
 	UserAuthToken    string
+}
+
+type RespHeaders struct {
+	ETag             string
 }
 
 type Options struct {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -31,7 +31,7 @@ type Headers struct {
 }
 
 type RespHeaders struct {
-	ETag             string
+	ETag string
 }
 
 type Options struct {

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -28,13 +28,13 @@ var _ sdk.Client = &ClientMock{}
 // 			HealthFunc: func() *healthcheck.Client {
 // 				panic("mock out the Health method")
 // 			},
-// 			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (string, error) {
+// 			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (sdk.RespHeaders, error) {
 // 				panic("mock out the PatchJob method")
 // 			},
 // 			PostJobFunc: func(ctx context.Context, headers sdk.Headers) (models.Job, error) {
 // 				panic("mock out the PostJob method")
 // 			},
-// 			PostTasksCountFunc: func(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (models.Task, error) {
+// 			PostTasksCountFunc: func(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (string, models.Task, error) {
 // 				panic("mock out the PostTasksCount method")
 // 			},
 // 			URLFunc: func() string {
@@ -54,13 +54,13 @@ type ClientMock struct {
 	HealthFunc func() *healthcheck.Client
 
 	// PatchJobFunc mocks the PatchJob method.
-	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (string, error)
+	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (sdk.RespHeaders, error)
 
 	// PostJobFunc mocks the PostJob method.
 	PostJobFunc func(ctx context.Context, headers sdk.Headers) (models.Job, error)
 
 	// PostTasksCountFunc mocks the PostTasksCount method.
-	PostTasksCountFunc func(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (models.Task, error)
+	PostTasksCountFunc func(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (string, models.Task, error)
 
 	// URLFunc mocks the URL method.
 	URLFunc func() string
@@ -180,7 +180,7 @@ func (mock *ClientMock) HealthCalls() []struct {
 }
 
 // PatchJob calls PatchJobFunc.
-func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (string, error) {
+func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (sdk.RespHeaders, error) {
 	if mock.PatchJobFunc == nil {
 		panic("ClientMock.PatchJobFunc: method is nil but Client.PatchJob was just called")
 	}
@@ -258,7 +258,7 @@ func (mock *ClientMock) PostJobCalls() []struct {
 }
 
 // PostTasksCount calls PostTasksCountFunc.
-func (mock *ClientMock) PostTasksCount(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (models.Task, error) {
+func (mock *ClientMock) PostTasksCount(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (string, models.Task, error) {
 	if mock.PostTasksCountFunc == nil {
 		panic("ClientMock.PostTasksCountFunc: method is nil but Client.PostTasksCount was just called")
 	}

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -119,7 +119,7 @@ func (cli *Client) PostTasksCount(ctx context.Context, headers client.Headers, j
 
 // PatchJob applies the patch operations, provided in the body, to the job with id = jobID
 // It returns the ETag from the response header
-func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID string, patchList []client.PatchOperation) (string, error) {
+func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID string, patchList []client.PatchOperation) (client.RespHeaders, error) {
 	if headers.ServiceAuthToken == "" {
 		headers.ServiceAuthToken = cli.serviceToken
 	}
@@ -130,12 +130,16 @@ func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID s
 
 	respHeader, _, err := cli.callReindexAPI(ctx, path, http.MethodPatch, headers, payload)
 	if err != nil {
-		return "", err
+		return client.RespHeaders{}, err
 	}
 
 	respETag := respHeader.Get(ETagHeader)
 
-	return respETag, nil
+	respHeaders := client.RespHeaders{
+        ETag: respETag,
+    }
+
+	return respHeaders, nil
 }
 
 // callReindexAPI calls the Search Reindex endpoint given by path for the provided REST method, request headers, and body payload.

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -124,7 +124,8 @@ func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID s
 		headers.ServiceAuthToken = cli.serviceToken
 	}
 
-	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID
+// 	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID
+    path := cli.hcCli.URL + jobsEndpoint + "/" + jobID
 	payload, _ := json.Marshal(patchList)
 
 	respHeader, _, err := cli.callReindexAPI(ctx, path, http.MethodPatch, headers, payload)

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -124,8 +124,7 @@ func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID s
 		headers.ServiceAuthToken = cli.serviceToken
 	}
 
-// 	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID
-    path := cli.hcCli.URL + jobsEndpoint + "/" + jobID
+	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID
 	payload, _ := json.Marshal(patchList)
 
 	respHeader, _, err := cli.callReindexAPI(ctx, path, http.MethodPatch, headers, payload)
@@ -136,8 +135,8 @@ func (cli *Client) PatchJob(ctx context.Context, headers client.Headers, jobID s
 	respETag := respHeader.Get(ETagHeader)
 
 	respHeaders := client.RespHeaders{
-        ETag: respETag,
-    }
+		ETag: respETag,
+	}
 
 	return respHeaders, nil
 }

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -385,12 +385,12 @@ func TestClient_PatchJob(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PatchJob is called", func() {
-			respETag, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
+			respHeaders, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
 			So(err, ShouldBeNil)
 
 			Convey("Then an ETag is returned", func() {
-				So(respETag, ShouldNotBeNil)
-				So(respETag, ShouldResemble, testETag)
+				So(respHeaders, ShouldNotBeNil)
+				So(respHeaders, ShouldResemble, client.RespHeaders{ETag: testETag})
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -418,14 +418,14 @@ func TestClient_PatchJob(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PatchJob is called with an invalid request body", func() {
-			respETag, err := searchReindexClient.PatchJob(ctx, headers, testJobID, invalidPatchList)
+			respHeaders, err := searchReindexClient.PatchJob(ctx, headers, testJobID, invalidPatchList)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 400")
 			So(apiError.ErrorStatus(err), ShouldEqual, 400)
 
 			Convey("Then an empty ETag is returned", func() {
-				So(respETag, ShouldNotBeNil)
-				So(respETag, ShouldResemble, "")
+				So(respHeaders, ShouldNotBeNil)
+				So(respHeaders, ShouldResemble, client.RespHeaders{ETag: ""})
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -453,14 +453,14 @@ func TestClient_PatchJob(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PatchJob is called", func() {
-			respETag, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
+			respHeaders, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "failed to call search reindex api, error is: something went wrong in the search reindex api service")
 			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusInternalServerError)
 
 			Convey("Then an empty ETag is returned", func() {
-				So(respETag, ShouldNotBeNil)
-				So(respETag, ShouldResemble, "")
+				So(respHeaders, ShouldNotBeNil)
+				So(respHeaders, ShouldResemble, client.RespHeaders{ETag: ""})
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -488,14 +488,14 @@ func TestClient_PatchJob(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PatchJob is called", func() {
-			respETag, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
+			respHeaders, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 409")
 			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusConflict)
 
 			Convey("Then an empty ETag is returned", func() {
-				So(respETag, ShouldNotBeNil)
-				So(respETag, ShouldResemble, "")
+				So(respHeaders, ShouldNotBeNil)
+				So(respHeaders, ShouldResemble, client.RespHeaders{ETag: ""})
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -523,14 +523,14 @@ func TestClient_PatchJob(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PatchJob is called", func() {
-			respETag, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
+			respHeaders, err := searchReindexClient.PatchJob(ctx, headers, testJobID, patchList)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 404")
 			So(apiError.ErrorStatus(err), ShouldEqual, 404)
 
 			Convey("Then an empty ETag is returned", func() {
-				So(respETag, ShouldNotBeNil)
-				So(respETag, ShouldResemble, "")
+				So(respHeaders, ShouldNotBeNil)
+				So(respHeaders, ShouldResemble, client.RespHeaders{ETag: ""})
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The signature of the PatchJobs method was incorrect. Instead of returning the ETag as a string it needed to return it in a ResponseHeaders object, which it now does as required.

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct and that the following tests pass:

make test

go test -component

make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
