### PR TITLE
Fix path and refactor post tasks count

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -19,7 +19,7 @@ type Client interface {
 	Health() *healthcheck.Client
 	PostJob(ctx context.Context, headers Headers) (*models.Job, error)
 	PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) (*RespHeaders, error)
-	PostTasksCount(ctx context.Context, headers Headers, jobID string, payload []byte) (*RespHeaders, *models.Task, error)
+	PostTask(ctx context.Context, headers Headers, jobID string, taskToCreate models.TaskToCreate) (*RespHeaders, *models.Task, error)
 	GetTask(ctx context.Context, headers Headers, jobID, taskName string) (*RespHeaders, *models.Task, error)
 	URL() string
 }

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -37,8 +37,8 @@ var _ sdk.Client = &ClientMock{}
 // 			PostJobFunc: func(ctx context.Context, headers sdk.Headers) (*models.Job, error) {
 // 				panic("mock out the PostJob method")
 // 			},
-// 			PostTasksCountFunc: func(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (*sdk.RespHeaders, *models.Task, error) {
-// 				panic("mock out the PostTasksCount method")
+// 			PostTaskFunc: func(ctx context.Context, headers sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error) {
+// 				panic("mock out the PostTask method")
 // 			},
 // 			URLFunc: func() string {
 // 				panic("mock out the URL method")
@@ -65,8 +65,8 @@ type ClientMock struct {
 	// PostJobFunc mocks the PostJob method.
 	PostJobFunc func(ctx context.Context, headers sdk.Headers) (*models.Job, error)
 
-	// PostTasksCountFunc mocks the PostTasksCount method.
-	PostTasksCountFunc func(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (*sdk.RespHeaders, *models.Task, error)
+	// PostTaskFunc mocks the PostTask method.
+	PostTaskFunc func(ctx context.Context, headers sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error)
 
 	// URLFunc mocks the URL method.
 	URLFunc func() string
@@ -112,28 +112,28 @@ type ClientMock struct {
 			// Headers is the headers argument value.
 			Headers sdk.Headers
 		}
-		// PostTasksCount holds details about calls to the PostTasksCount method.
-		PostTasksCount []struct {
+		// PostTask holds details about calls to the PostTask method.
+		PostTask []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Headers is the headers argument value.
 			Headers sdk.Headers
 			// JobID is the jobID argument value.
 			JobID string
-			// Payload is the payload argument value.
-			Payload []byte
+			// TaskToCreate is the taskToCreate argument value.
+			TaskToCreate models.TaskToCreate
 		}
 		// URL holds details about calls to the URL method.
 		URL []struct {
 		}
 	}
-	lockChecker        sync.RWMutex
-	lockGetTask        sync.RWMutex
-	lockHealth         sync.RWMutex
-	lockPatchJob       sync.RWMutex
-	lockPostJob        sync.RWMutex
-	lockPostTasksCount sync.RWMutex
-	lockURL            sync.RWMutex
+	lockChecker  sync.RWMutex
+	lockGetTask  sync.RWMutex
+	lockHealth   sync.RWMutex
+	lockPatchJob sync.RWMutex
+	lockPostJob  sync.RWMutex
+	lockPostTask sync.RWMutex
+	lockURL      sync.RWMutex
 }
 
 // Checker calls CheckerFunc.
@@ -318,46 +318,46 @@ func (mock *ClientMock) PostJobCalls() []struct {
 	return calls
 }
 
-// PostTasksCount calls PostTasksCountFunc.
-func (mock *ClientMock) PostTasksCount(ctx context.Context, headers sdk.Headers, jobID string, payload []byte) (*sdk.RespHeaders, *models.Task, error) {
-	if mock.PostTasksCountFunc == nil {
-		panic("ClientMock.PostTasksCountFunc: method is nil but Client.PostTasksCount was just called")
+// PostTask calls PostTaskFunc.
+func (mock *ClientMock) PostTask(ctx context.Context, headers sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error) {
+	if mock.PostTaskFunc == nil {
+		panic("ClientMock.PostTaskFunc: method is nil but Client.PostTask was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		Headers sdk.Headers
-		JobID   string
-		Payload []byte
+		Ctx          context.Context
+		Headers      sdk.Headers
+		JobID        string
+		TaskToCreate models.TaskToCreate
 	}{
-		Ctx:     ctx,
-		Headers: headers,
-		JobID:   jobID,
-		Payload: payload,
+		Ctx:          ctx,
+		Headers:      headers,
+		JobID:        jobID,
+		TaskToCreate: taskToCreate,
 	}
-	mock.lockPostTasksCount.Lock()
-	mock.calls.PostTasksCount = append(mock.calls.PostTasksCount, callInfo)
-	mock.lockPostTasksCount.Unlock()
-	return mock.PostTasksCountFunc(ctx, headers, jobID, payload)
+	mock.lockPostTask.Lock()
+	mock.calls.PostTask = append(mock.calls.PostTask, callInfo)
+	mock.lockPostTask.Unlock()
+	return mock.PostTaskFunc(ctx, headers, jobID, taskToCreate)
 }
 
-// PostTasksCountCalls gets all the calls that were made to PostTasksCount.
+// PostTaskCalls gets all the calls that were made to PostTask.
 // Check the length with:
-//     len(mockedClient.PostTasksCountCalls())
-func (mock *ClientMock) PostTasksCountCalls() []struct {
-	Ctx     context.Context
-	Headers sdk.Headers
-	JobID   string
-	Payload []byte
+//     len(mockedClient.PostTaskCalls())
+func (mock *ClientMock) PostTaskCalls() []struct {
+	Ctx          context.Context
+	Headers      sdk.Headers
+	JobID        string
+	TaskToCreate models.TaskToCreate
 } {
 	var calls []struct {
-		Ctx     context.Context
-		Headers sdk.Headers
-		JobID   string
-		Payload []byte
+		Ctx          context.Context
+		Headers      sdk.Headers
+		JobID        string
+		TaskToCreate models.TaskToCreate
 	}
-	mock.lockPostTasksCount.RLock()
-	calls = mock.calls.PostTasksCount
-	mock.lockPostTasksCount.RUnlock()
+	mock.lockPostTask.RLock()
+	calls = mock.calls.PostTask
+	mock.lockPostTask.RUnlock()
 	return calls
 }
 

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -90,13 +90,15 @@ func (cli *Client) PostJob(ctx context.Context, headers client.Headers) (*models
 	return &job, nil
 }
 
-// PostTasksCount Updates tasks count for processing
-func (cli *Client) PostTasksCount(ctx context.Context, reqheaders client.Headers, jobID string, payload []byte) (*client.RespHeaders, *models.Task, error) {
+// PostTask creates or updates a task, for the job with id = jobID, containing the number of documents to be processed
+func (cli *Client) PostTask(ctx context.Context, reqheaders client.Headers, jobID string, taskToCreate models.TaskToCreate) (*client.RespHeaders, *models.Task, error) {
 	if reqheaders.ServiceAuthToken == "" {
 		reqheaders.ServiceAuthToken = cli.serviceToken
 	}
 
-	path := fmt.Sprintf("%s/jobs/%s/tasks", cli.apiVersion, jobID)
+// 	path := fmt.Sprintf("%s/jobs/%s/tasks", cli.apiVersion, jobID)
+	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID + "/tasks"
+	payload, _ := json.Marshal(taskToCreate)
 
 	respHeader, b, err := cli.callReindexAPI(ctx, path, http.MethodPost, reqheaders, payload)
 	if err != nil {

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -96,8 +96,8 @@ func (cli *Client) PostTask(ctx context.Context, reqheaders client.Headers, jobI
 		reqheaders.ServiceAuthToken = cli.serviceToken
 	}
 
-// 	path := fmt.Sprintf("%s/jobs/%s/tasks", cli.apiVersion, jobID)
-	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID + "/tasks"
+//     path := fmt.Sprintf("/%s/jobs/%s/tasks", cli.apiVersion, jobID)
+    path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID + "/tasks"    
 	payload, _ := json.Marshal(taskToCreate)
 
 	respHeader, b, err := cli.callReindexAPI(ctx, path, http.MethodPost, reqheaders, payload)

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -96,8 +96,7 @@ func (cli *Client) PostTask(ctx context.Context, reqheaders client.Headers, jobI
 		reqheaders.ServiceAuthToken = cli.serviceToken
 	}
 
-//     path := fmt.Sprintf("/%s/jobs/%s/tasks", cli.apiVersion, jobID)
-    path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID + "/tasks"    
+	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID + "/tasks"
 	payload, _ := json.Marshal(taskToCreate)
 
 	respHeader, b, err := cli.callReindexAPI(ctx, path, http.MethodPost, reqheaders, payload)

--- a/sdk/v1/client.go
+++ b/sdk/v1/client.go
@@ -97,7 +97,10 @@ func (cli *Client) PostTask(ctx context.Context, reqheaders client.Headers, jobI
 	}
 
 	path := cli.hcCli.URL + "/" + cli.apiVersion + jobsEndpoint + "/" + jobID + "/tasks"
-	payload, _ := json.Marshal(taskToCreate)
+	payload, errMarshal := json.Marshal(taskToCreate)
+	if errMarshal != nil {
+		return nil, nil, errMarshal
+	}
 
 	respHeader, b, err := cli.callReindexAPI(ctx, path, http.MethodPost, reqheaders, payload)
 	if err != nil {

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -229,13 +229,18 @@ func TestClient_PostJob(t *testing.T) {
 	})
 }
 
-func TestClient_PostTasksCount(t *testing.T) {
+func TestClient_PostTask(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	pathToCheck := "v1/jobs/883c81fd-726d-4ea3-9db8-7e7c781a01cc/tasks"
+	pathToCheck := "/v1/jobs/883c81fd-726d-4ea3-9db8-7e7c781a01cc/tasks"
 
-	mockTaskToCreate := `{"task_name":"zebedee","number_of_documents": "10"}`
-	testPayload := []byte(mockTaskToCreate)
+// 	mockTaskToCreate := `{"task_name":"zebedee","number_of_documents": "10"}`
+// 	testPayload := []byte(mockTaskToCreate)
+
+	testPayload := models.TaskToCreate{
+        TaskName:          "zebedee",
+        NumberOfDocuments: 10,
+    }
 
 	headers := client.Headers{
 		IfMatch:          "*",
@@ -261,7 +266,7 @@ func TestClient_PostTasksCount(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostTasksCount is called", func() {
-			respHeaders, task, err := searchReindexClient.PostTasksCount(ctx, headers, testJobID, testPayload)
+			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, testPayload)
 			So(err, ShouldBeNil)
 
 			Convey("Then the expected jobid, task name, and number of documents, are returned", func() {
@@ -279,7 +284,7 @@ func TestClient_PostTasksCount(t *testing.T) {
 				doCalls := httpClient.DoCalls()
 				So(doCalls, ShouldHaveLength, 1)
 				So(doCalls[0].Req.URL.Path, ShouldEqual, pathToCheck)
-				So(doCalls[0].Req.Body, ShouldResemble, io.NopCloser(bytes.NewReader(testPayload)))
+				So(doCalls[0].Req.Body, ShouldResemble, testPayload)
 				expectedIfMatchHeader := make([]string, 1)
 				expectedIfMatchHeader[0] = "*"
 				So(doCalls[0].Req.Header[ifMatchHeader], ShouldResemble, expectedIfMatchHeader)
@@ -291,7 +296,7 @@ func TestClient_PostTasksCount(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostTaskCount is called", func() {
-			respHeaders, task, err := searchReindexClient.PostTasksCount(ctx, headers, testJobID, testPayload)
+			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, testPayload)
 			So(err, ShouldNotBeNil)
 			So(task, ShouldBeNil)
 
@@ -321,7 +326,7 @@ func TestClient_PostTasksCount(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostTasksCount is called", func() {
-			respHeaders, task, err := searchReindexClient.PostTasksCount(ctx, headers, testJobID, testPayload)
+			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, testPayload)
 			So(err, ShouldNotBeNil)
 			So(task, ShouldBeNil)
 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 404")

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -234,13 +234,15 @@ func TestClient_PostTask(t *testing.T) {
 	ctx := context.Background()
 	pathToCheck := "/v1/jobs/883c81fd-726d-4ea3-9db8-7e7c781a01cc/tasks"
 
-// 	mockTaskToCreate := `{"task_name":"zebedee","number_of_documents": "10"}`
-// 	testPayload := []byte(mockTaskToCreate)
+	taskToCreate := models.TaskToCreate{
+		TaskName:          "zebedee",
+		NumberOfDocuments: 10,
+	}
 
-	testPayload := models.TaskToCreate{
-        TaskName:          "zebedee",
-        NumberOfDocuments: 10,
-    }
+	testPayload, _ := json.Marshal(taskToCreate)
+	reqBody := bytes.NewReader(testPayload)
+	req, _ := http.NewRequest("POST", pathToCheck, reqBody)
+	reqBodyToCheck := req.Body
 
 	headers := client.Headers{
 		IfMatch:          "*",
@@ -266,7 +268,7 @@ func TestClient_PostTask(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostTasksCount is called", func() {
-			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, testPayload)
+			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, taskToCreate)
 			So(err, ShouldBeNil)
 
 			Convey("Then the expected jobid, task name, and number of documents, are returned", func() {
@@ -284,7 +286,7 @@ func TestClient_PostTask(t *testing.T) {
 				doCalls := httpClient.DoCalls()
 				So(doCalls, ShouldHaveLength, 1)
 				So(doCalls[0].Req.URL.Path, ShouldEqual, pathToCheck)
-				So(doCalls[0].Req.Body, ShouldResemble, testPayload)
+				So(doCalls[0].Req.Body, ShouldResemble, reqBodyToCheck)
 				expectedIfMatchHeader := make([]string, 1)
 				expectedIfMatchHeader[0] = "*"
 				So(doCalls[0].Req.Header[ifMatchHeader], ShouldResemble, expectedIfMatchHeader)
@@ -296,7 +298,7 @@ func TestClient_PostTask(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostTaskCount is called", func() {
-			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, testPayload)
+			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, taskToCreate)
 			So(err, ShouldNotBeNil)
 			So(task, ShouldBeNil)
 
@@ -326,7 +328,7 @@ func TestClient_PostTask(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostTasksCount is called", func() {
-			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, testPayload)
+			respHeaders, task, err := searchReindexClient.PostTask(ctx, headers, testJobID, taskToCreate)
 			So(err, ShouldNotBeNil)
 			So(task, ShouldBeNil)
 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 404")

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -239,9 +239,15 @@ func TestClient_PostTask(t *testing.T) {
 		NumberOfDocuments: 10,
 	}
 
-	testPayload, _ := json.Marshal(taskToCreate)
+	testPayload, errMarshal := json.Marshal(taskToCreate)
+	if errMarshal != nil {
+		t.Errorf("failed to setup test data, marshal error: %v", errMarshal)
+	}
 	reqBody := bytes.NewReader(testPayload)
-	req, _ := http.NewRequest("POST", pathToCheck, reqBody)
+	req, errNewReq := http.NewRequest("POST", pathToCheck, reqBody)
+	if errNewReq != nil {
+		t.Errorf("failed to setup test data, new request error: %v", errNewReq)
+	}
 	reqBodyToCheck := req.Body
 
 	headers := client.Headers{
@@ -252,7 +258,7 @@ func TestClient_PostTask(t *testing.T) {
 	Convey("Given clienter.Do doesn't return an error", t, func() {
 		body, err := json.Marshal(expectedTask)
 		if err != nil {
-			t.Errorf("failed to setup test data, error: %v", err)
+			t.Errorf("failed to setup test data, response body error: %v", err)
 		}
 
 		header := http.Header{}


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The PostTasksCount method was giving the following error when used:

unsupported protocol scheme \“\”

These changes fix the problem, which was with the path, and also refactor the PostTasksCount method and rename it PostTask.

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct and that the following tests pass:

make test

go test -component

make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
