### PR TITLE
New client method created to call the PUT num tasks endpoint

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -17,11 +17,12 @@ import (
 type Client interface {
 	Checker(ctx context.Context, check *health.CheckState) error
 	Health() *healthcheck.Client
-	PostJob(ctx context.Context, headers Headers) (*models.Job, error)
-	PatchJob(ctx context.Context, headers Headers, jobID string, body []PatchOperation) (*RespHeaders, error)
-	PostTask(ctx context.Context, headers Headers, jobID string, taskToCreate models.TaskToCreate) (*RespHeaders, *models.Task, error)
-	GetTask(ctx context.Context, headers Headers, jobID, taskName string) (*RespHeaders, *models.Task, error)
-	GetTasks(ctx context.Context, reqheader Headers, jobID string) (*RespHeaders, *models.Tasks, error)
+	PostJob(ctx context.Context, reqHeaders Headers) (*RespHeaders, *models.Job, error)
+	PatchJob(ctx context.Context, reqHeaders Headers, jobID string, body []PatchOperation) (*RespHeaders, error)
+	PostTask(ctx context.Context, reqHeaders Headers, jobID string, taskToCreate models.TaskToCreate) (*RespHeaders, *models.Task, error)
+	GetTask(ctx context.Context, reqHeaders Headers, jobID, taskName string) (*RespHeaders, *models.Task, error)
+	GetTasks(ctx context.Context, reqHeaders Headers, jobID string) (*RespHeaders, *models.Tasks, error)
+	PutJobNumberOfTasks(ctx context.Context, reqHeaders Headers, jobID, numTasks string) (*RespHeaders, error)
 	URL() string
 }
 

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -5,85 +5,80 @@ package mocks
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-api-clients-go/v2/health"
-	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/sdk"
 	"sync"
 )
 
-var (
-	lockClientMockChecker  sync.RWMutex
-	lockClientMockGetTask  sync.RWMutex
-	lockClientMockGetTasks sync.RWMutex
-	lockClientMockHealth   sync.RWMutex
-	lockClientMockPatchJob sync.RWMutex
-	lockClientMockPostJob  sync.RWMutex
-	lockClientMockPostTask sync.RWMutex
-	lockClientMockURL      sync.RWMutex
-)
-
-// Ensure, that ClientMock does implement Client.
+// Ensure, that ClientMock does implement sdk.Client.
 // If this is not the case, regenerate this file with moq.
 var _ sdk.Client = &ClientMock{}
 
 // ClientMock is a mock implementation of sdk.Client.
 //
-//     func TestSomethingThatUsesClient(t *testing.T) {
+// 	func TestSomethingThatUsesClient(t *testing.T) {
 //
-//         // make and configure a mocked sdk.Client
-//         mockedClient := &ClientMock{
-//             CheckerFunc: func(ctx context.Context, check *healthcheck.CheckState) error {
-// 	               panic("mock out the Checker method")
-//             },
-//             GetTaskFunc: func(ctx context.Context, headers sdk.Headers, jobID string, taskName string) (*sdk.RespHeaders, *models.Task, error) {
-// 	               panic("mock out the GetTask method")
-//             },
-//             GetTasksFunc: func(ctx context.Context, reqheader sdk.Headers, jobID string) (*sdk.RespHeaders, *models.Tasks, error) {
-// 	               panic("mock out the GetTasks method")
-//             },
-//             HealthFunc: func() *health.Client {
-// 	               panic("mock out the Health method")
-//             },
-//             PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error) {
-// 	               panic("mock out the PatchJob method")
-//             },
-//             PostJobFunc: func(ctx context.Context, headers sdk.Headers) (*models.Job, error) {
-// 	               panic("mock out the PostJob method")
-//             },
-//             PostTaskFunc: func(ctx context.Context, headers sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error) {
-// 	               panic("mock out the PostTask method")
-//             },
-//             URLFunc: func() string {
-// 	               panic("mock out the URL method")
-//             },
-//         }
+// 		// make and configure a mocked sdk.Client
+// 		mockedClient := &ClientMock{
+// 			CheckerFunc: func(ctx context.Context, check *health.CheckState) error {
+// 				panic("mock out the Checker method")
+// 			},
+// 			GetTaskFunc: func(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskName string) (*sdk.RespHeaders, *models.Task, error) {
+// 				panic("mock out the GetTask method")
+// 			},
+// 			GetTasksFunc: func(ctx context.Context, reqHeaders sdk.Headers, jobID string) (*sdk.RespHeaders, *models.Tasks, error) {
+// 				panic("mock out the GetTasks method")
+// 			},
+// 			HealthFunc: func() *healthcheck.Client {
+// 				panic("mock out the Health method")
+// 			},
+// 			PatchJobFunc: func(ctx context.Context, reqHeaders sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error) {
+// 				panic("mock out the PatchJob method")
+// 			},
+// 			PostJobFunc: func(ctx context.Context, reqHeaders sdk.Headers) (*sdk.RespHeaders, *models.Job, error) {
+// 				panic("mock out the PostJob method")
+// 			},
+// 			PostTaskFunc: func(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error) {
+// 				panic("mock out the PostTask method")
+// 			},
+// 			PutJobNumberOfTasksFunc: func(ctx context.Context, reqHeaders sdk.Headers, jobID string, numTasks string) (*sdk.RespHeaders, error) {
+// 				panic("mock out the PutJobNumberOfTasks method")
+// 			},
+// 			URLFunc: func() string {
+// 				panic("mock out the URL method")
+// 			},
+// 		}
 //
-//         // use mockedClient in code that requires sdk.Client
-//         // and then make assertions.
+// 		// use mockedClient in code that requires sdk.Client
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type ClientMock struct {
 	// CheckerFunc mocks the Checker method.
-	CheckerFunc func(ctx context.Context, check *healthcheck.CheckState) error
+	CheckerFunc func(ctx context.Context, check *health.CheckState) error
 
 	// GetTaskFunc mocks the GetTask method.
-	GetTaskFunc func(ctx context.Context, headers sdk.Headers, jobID string, taskName string) (*sdk.RespHeaders, *models.Task, error)
+	GetTaskFunc func(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskName string) (*sdk.RespHeaders, *models.Task, error)
 
 	// GetTasksFunc mocks the GetTasks method.
-	GetTasksFunc func(ctx context.Context, reqheader sdk.Headers, jobID string) (*sdk.RespHeaders, *models.Tasks, error)
+	GetTasksFunc func(ctx context.Context, reqHeaders sdk.Headers, jobID string) (*sdk.RespHeaders, *models.Tasks, error)
 
 	// HealthFunc mocks the Health method.
-	HealthFunc func() *health.Client
+	HealthFunc func() *healthcheck.Client
 
 	// PatchJobFunc mocks the PatchJob method.
-	PatchJobFunc func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error)
+	PatchJobFunc func(ctx context.Context, reqHeaders sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error)
 
 	// PostJobFunc mocks the PostJob method.
-	PostJobFunc func(ctx context.Context, headers sdk.Headers) (*models.Job, error)
+	PostJobFunc func(ctx context.Context, reqHeaders sdk.Headers) (*sdk.RespHeaders, *models.Job, error)
 
 	// PostTaskFunc mocks the PostTask method.
-	PostTaskFunc func(ctx context.Context, headers sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error)
+	PostTaskFunc func(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error)
+
+	// PutJobNumberOfTasksFunc mocks the PutJobNumberOfTasks method.
+	PutJobNumberOfTasksFunc func(ctx context.Context, reqHeaders sdk.Headers, jobID string, numTasks string) (*sdk.RespHeaders, error)
 
 	// URLFunc mocks the URL method.
 	URLFunc func() string
@@ -95,14 +90,14 @@ type ClientMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Check is the check argument value.
-			Check *healthcheck.CheckState
+			Check *health.CheckState
 		}
 		// GetTask holds details about calls to the GetTask method.
 		GetTask []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Headers is the headers argument value.
-			Headers sdk.Headers
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
 			// JobID is the jobID argument value.
 			JobID string
 			// TaskName is the taskName argument value.
@@ -112,8 +107,8 @@ type ClientMock struct {
 		GetTasks []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Reqheader is the reqheader argument value.
-			Reqheader sdk.Headers
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
 			// JobID is the jobID argument value.
 			JobID string
 		}
@@ -124,8 +119,8 @@ type ClientMock struct {
 		PatchJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Headers is the headers argument value.
-			Headers sdk.Headers
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
 			// JobID is the jobID argument value.
 			JobID string
 			// Body is the body argument value.
@@ -135,41 +130,61 @@ type ClientMock struct {
 		PostJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Headers is the headers argument value.
-			Headers sdk.Headers
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
 		}
 		// PostTask holds details about calls to the PostTask method.
 		PostTask []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Headers is the headers argument value.
-			Headers sdk.Headers
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
 			// JobID is the jobID argument value.
 			JobID string
 			// TaskToCreate is the taskToCreate argument value.
 			TaskToCreate models.TaskToCreate
 		}
+		// PutJobNumberOfTasks holds details about calls to the PutJobNumberOfTasks method.
+		PutJobNumberOfTasks []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
+			// JobID is the jobID argument value.
+			JobID string
+			// NumTasks is the numTasks argument value.
+			NumTasks string
+		}
 		// URL holds details about calls to the URL method.
 		URL []struct {
 		}
 	}
+	lockChecker             sync.RWMutex
+	lockGetTask             sync.RWMutex
+	lockGetTasks            sync.RWMutex
+	lockHealth              sync.RWMutex
+	lockPatchJob            sync.RWMutex
+	lockPostJob             sync.RWMutex
+	lockPostTask            sync.RWMutex
+	lockPutJobNumberOfTasks sync.RWMutex
+	lockURL                 sync.RWMutex
 }
 
 // Checker calls CheckerFunc.
-func (mock *ClientMock) Checker(ctx context.Context, check *healthcheck.CheckState) error {
+func (mock *ClientMock) Checker(ctx context.Context, check *health.CheckState) error {
 	if mock.CheckerFunc == nil {
 		panic("ClientMock.CheckerFunc: method is nil but Client.Checker was just called")
 	}
 	callInfo := struct {
 		Ctx   context.Context
-		Check *healthcheck.CheckState
+		Check *health.CheckState
 	}{
 		Ctx:   ctx,
 		Check: check,
 	}
-	lockClientMockChecker.Lock()
+	mock.lockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	lockClientMockChecker.Unlock()
+	mock.lockChecker.Unlock()
 	return mock.CheckerFunc(ctx, check)
 }
 
@@ -178,110 +193,110 @@ func (mock *ClientMock) Checker(ctx context.Context, check *healthcheck.CheckSta
 //     len(mockedClient.CheckerCalls())
 func (mock *ClientMock) CheckerCalls() []struct {
 	Ctx   context.Context
-	Check *healthcheck.CheckState
+	Check *health.CheckState
 } {
 	var calls []struct {
 		Ctx   context.Context
-		Check *healthcheck.CheckState
+		Check *health.CheckState
 	}
-	lockClientMockChecker.RLock()
+	mock.lockChecker.RLock()
 	calls = mock.calls.Checker
-	lockClientMockChecker.RUnlock()
+	mock.lockChecker.RUnlock()
 	return calls
 }
 
 // GetTask calls GetTaskFunc.
-func (mock *ClientMock) GetTask(ctx context.Context, headers sdk.Headers, jobID string, taskName string) (*sdk.RespHeaders, *models.Task, error) {
+func (mock *ClientMock) GetTask(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskName string) (*sdk.RespHeaders, *models.Task, error) {
 	if mock.GetTaskFunc == nil {
 		panic("ClientMock.GetTaskFunc: method is nil but Client.GetTask was just called")
 	}
 	callInfo := struct {
-		Ctx      context.Context
-		Headers  sdk.Headers
-		JobID    string
-		TaskName string
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
+		TaskName   string
 	}{
-		Ctx:      ctx,
-		Headers:  headers,
-		JobID:    jobID,
-		TaskName: taskName,
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		JobID:      jobID,
+		TaskName:   taskName,
 	}
-	lockClientMockGetTask.Lock()
+	mock.lockGetTask.Lock()
 	mock.calls.GetTask = append(mock.calls.GetTask, callInfo)
-	lockClientMockGetTask.Unlock()
-	return mock.GetTaskFunc(ctx, headers, jobID, taskName)
+	mock.lockGetTask.Unlock()
+	return mock.GetTaskFunc(ctx, reqHeaders, jobID, taskName)
 }
 
 // GetTaskCalls gets all the calls that were made to GetTask.
 // Check the length with:
 //     len(mockedClient.GetTaskCalls())
 func (mock *ClientMock) GetTaskCalls() []struct {
-	Ctx      context.Context
-	Headers  sdk.Headers
-	JobID    string
-	TaskName string
+	Ctx        context.Context
+	ReqHeaders sdk.Headers
+	JobID      string
+	TaskName   string
 } {
 	var calls []struct {
-		Ctx      context.Context
-		Headers  sdk.Headers
-		JobID    string
-		TaskName string
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
+		TaskName   string
 	}
-	lockClientMockGetTask.RLock()
+	mock.lockGetTask.RLock()
 	calls = mock.calls.GetTask
-	lockClientMockGetTask.RUnlock()
+	mock.lockGetTask.RUnlock()
 	return calls
 }
 
 // GetTasks calls GetTasksFunc.
-func (mock *ClientMock) GetTasks(ctx context.Context, reqheader sdk.Headers, jobID string) (*sdk.RespHeaders, *models.Tasks, error) {
+func (mock *ClientMock) GetTasks(ctx context.Context, reqHeaders sdk.Headers, jobID string) (*sdk.RespHeaders, *models.Tasks, error) {
 	if mock.GetTasksFunc == nil {
 		panic("ClientMock.GetTasksFunc: method is nil but Client.GetTasks was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
-		Reqheader sdk.Headers
-		JobID     string
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
 	}{
-		Ctx:       ctx,
-		Reqheader: reqheader,
-		JobID:     jobID,
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		JobID:      jobID,
 	}
-	lockClientMockGetTasks.Lock()
+	mock.lockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
-	lockClientMockGetTasks.Unlock()
-	return mock.GetTasksFunc(ctx, reqheader, jobID)
+	mock.lockGetTasks.Unlock()
+	return mock.GetTasksFunc(ctx, reqHeaders, jobID)
 }
 
 // GetTasksCalls gets all the calls that were made to GetTasks.
 // Check the length with:
 //     len(mockedClient.GetTasksCalls())
 func (mock *ClientMock) GetTasksCalls() []struct {
-	Ctx       context.Context
-	Reqheader sdk.Headers
-	JobID     string
+	Ctx        context.Context
+	ReqHeaders sdk.Headers
+	JobID      string
 } {
 	var calls []struct {
-		Ctx       context.Context
-		Reqheader sdk.Headers
-		JobID     string
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
 	}
-	lockClientMockGetTasks.RLock()
+	mock.lockGetTasks.RLock()
 	calls = mock.calls.GetTasks
-	lockClientMockGetTasks.RUnlock()
+	mock.lockGetTasks.RUnlock()
 	return calls
 }
 
 // Health calls HealthFunc.
-func (mock *ClientMock) Health() *health.Client {
+func (mock *ClientMock) Health() *healthcheck.Client {
 	if mock.HealthFunc == nil {
 		panic("ClientMock.HealthFunc: method is nil but Client.Health was just called")
 	}
 	callInfo := struct {
 	}{}
-	lockClientMockHealth.Lock()
+	mock.lockHealth.Lock()
 	mock.calls.Health = append(mock.calls.Health, callInfo)
-	lockClientMockHealth.Unlock()
+	mock.lockHealth.Unlock()
 	return mock.HealthFunc()
 }
 
@@ -292,110 +307,110 @@ func (mock *ClientMock) HealthCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockClientMockHealth.RLock()
+	mock.lockHealth.RLock()
 	calls = mock.calls.Health
-	lockClientMockHealth.RUnlock()
+	mock.lockHealth.RUnlock()
 	return calls
 }
 
 // PatchJob calls PatchJobFunc.
-func (mock *ClientMock) PatchJob(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error) {
+func (mock *ClientMock) PatchJob(ctx context.Context, reqHeaders sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error) {
 	if mock.PatchJobFunc == nil {
 		panic("ClientMock.PatchJobFunc: method is nil but Client.PatchJob was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		Headers sdk.Headers
-		JobID   string
-		Body    []sdk.PatchOperation
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
+		Body       []sdk.PatchOperation
 	}{
-		Ctx:     ctx,
-		Headers: headers,
-		JobID:   jobID,
-		Body:    body,
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		JobID:      jobID,
+		Body:       body,
 	}
-	lockClientMockPatchJob.Lock()
+	mock.lockPatchJob.Lock()
 	mock.calls.PatchJob = append(mock.calls.PatchJob, callInfo)
-	lockClientMockPatchJob.Unlock()
-	return mock.PatchJobFunc(ctx, headers, jobID, body)
+	mock.lockPatchJob.Unlock()
+	return mock.PatchJobFunc(ctx, reqHeaders, jobID, body)
 }
 
 // PatchJobCalls gets all the calls that were made to PatchJob.
 // Check the length with:
 //     len(mockedClient.PatchJobCalls())
 func (mock *ClientMock) PatchJobCalls() []struct {
-	Ctx     context.Context
-	Headers sdk.Headers
-	JobID   string
-	Body    []sdk.PatchOperation
+	Ctx        context.Context
+	ReqHeaders sdk.Headers
+	JobID      string
+	Body       []sdk.PatchOperation
 } {
 	var calls []struct {
-		Ctx     context.Context
-		Headers sdk.Headers
-		JobID   string
-		Body    []sdk.PatchOperation
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
+		Body       []sdk.PatchOperation
 	}
-	lockClientMockPatchJob.RLock()
+	mock.lockPatchJob.RLock()
 	calls = mock.calls.PatchJob
-	lockClientMockPatchJob.RUnlock()
+	mock.lockPatchJob.RUnlock()
 	return calls
 }
 
 // PostJob calls PostJobFunc.
-func (mock *ClientMock) PostJob(ctx context.Context, headers sdk.Headers) (*models.Job, error) {
+func (mock *ClientMock) PostJob(ctx context.Context, reqHeaders sdk.Headers) (*sdk.RespHeaders, *models.Job, error) {
 	if mock.PostJobFunc == nil {
 		panic("ClientMock.PostJobFunc: method is nil but Client.PostJob was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		Headers sdk.Headers
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
 	}{
-		Ctx:     ctx,
-		Headers: headers,
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
 	}
-	lockClientMockPostJob.Lock()
+	mock.lockPostJob.Lock()
 	mock.calls.PostJob = append(mock.calls.PostJob, callInfo)
-	lockClientMockPostJob.Unlock()
-	return mock.PostJobFunc(ctx, headers)
+	mock.lockPostJob.Unlock()
+	return mock.PostJobFunc(ctx, reqHeaders)
 }
 
 // PostJobCalls gets all the calls that were made to PostJob.
 // Check the length with:
 //     len(mockedClient.PostJobCalls())
 func (mock *ClientMock) PostJobCalls() []struct {
-	Ctx     context.Context
-	Headers sdk.Headers
+	Ctx        context.Context
+	ReqHeaders sdk.Headers
 } {
 	var calls []struct {
-		Ctx     context.Context
-		Headers sdk.Headers
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
 	}
-	lockClientMockPostJob.RLock()
+	mock.lockPostJob.RLock()
 	calls = mock.calls.PostJob
-	lockClientMockPostJob.RUnlock()
+	mock.lockPostJob.RUnlock()
 	return calls
 }
 
 // PostTask calls PostTaskFunc.
-func (mock *ClientMock) PostTask(ctx context.Context, headers sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error) {
+func (mock *ClientMock) PostTask(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskToCreate models.TaskToCreate) (*sdk.RespHeaders, *models.Task, error) {
 	if mock.PostTaskFunc == nil {
 		panic("ClientMock.PostTaskFunc: method is nil but Client.PostTask was just called")
 	}
 	callInfo := struct {
 		Ctx          context.Context
-		Headers      sdk.Headers
+		ReqHeaders   sdk.Headers
 		JobID        string
 		TaskToCreate models.TaskToCreate
 	}{
 		Ctx:          ctx,
-		Headers:      headers,
+		ReqHeaders:   reqHeaders,
 		JobID:        jobID,
 		TaskToCreate: taskToCreate,
 	}
-	lockClientMockPostTask.Lock()
+	mock.lockPostTask.Lock()
 	mock.calls.PostTask = append(mock.calls.PostTask, callInfo)
-	lockClientMockPostTask.Unlock()
-	return mock.PostTaskFunc(ctx, headers, jobID, taskToCreate)
+	mock.lockPostTask.Unlock()
+	return mock.PostTaskFunc(ctx, reqHeaders, jobID, taskToCreate)
 }
 
 // PostTaskCalls gets all the calls that were made to PostTask.
@@ -403,19 +418,62 @@ func (mock *ClientMock) PostTask(ctx context.Context, headers sdk.Headers, jobID
 //     len(mockedClient.PostTaskCalls())
 func (mock *ClientMock) PostTaskCalls() []struct {
 	Ctx          context.Context
-	Headers      sdk.Headers
+	ReqHeaders   sdk.Headers
 	JobID        string
 	TaskToCreate models.TaskToCreate
 } {
 	var calls []struct {
 		Ctx          context.Context
-		Headers      sdk.Headers
+		ReqHeaders   sdk.Headers
 		JobID        string
 		TaskToCreate models.TaskToCreate
 	}
-	lockClientMockPostTask.RLock()
+	mock.lockPostTask.RLock()
 	calls = mock.calls.PostTask
-	lockClientMockPostTask.RUnlock()
+	mock.lockPostTask.RUnlock()
+	return calls
+}
+
+// PutJobNumberOfTasks calls PutJobNumberOfTasksFunc.
+func (mock *ClientMock) PutJobNumberOfTasks(ctx context.Context, reqHeaders sdk.Headers, jobID string, numTasks string) (*sdk.RespHeaders, error) {
+	if mock.PutJobNumberOfTasksFunc == nil {
+		panic("ClientMock.PutJobNumberOfTasksFunc: method is nil but Client.PutJobNumberOfTasks was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
+		NumTasks   string
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		JobID:      jobID,
+		NumTasks:   numTasks,
+	}
+	mock.lockPutJobNumberOfTasks.Lock()
+	mock.calls.PutJobNumberOfTasks = append(mock.calls.PutJobNumberOfTasks, callInfo)
+	mock.lockPutJobNumberOfTasks.Unlock()
+	return mock.PutJobNumberOfTasksFunc(ctx, reqHeaders, jobID, numTasks)
+}
+
+// PutJobNumberOfTasksCalls gets all the calls that were made to PutJobNumberOfTasks.
+// Check the length with:
+//     len(mockedClient.PutJobNumberOfTasksCalls())
+func (mock *ClientMock) PutJobNumberOfTasksCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders sdk.Headers
+	JobID      string
+	NumTasks   string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		JobID      string
+		NumTasks   string
+	}
+	mock.lockPutJobNumberOfTasks.RLock()
+	calls = mock.calls.PutJobNumberOfTasks
+	mock.lockPutJobNumberOfTasks.RUnlock()
 	return calls
 }
 
@@ -426,9 +484,9 @@ func (mock *ClientMock) URL() string {
 	}
 	callInfo := struct {
 	}{}
-	lockClientMockURL.Lock()
+	mock.lockURL.Lock()
 	mock.calls.URL = append(mock.calls.URL, callInfo)
-	lockClientMockURL.Unlock()
+	mock.lockURL.Unlock()
 	return mock.URLFunc()
 }
 
@@ -439,8 +497,8 @@ func (mock *ClientMock) URLCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockClientMockURL.RLock()
+	mock.lockURL.RLock()
 	calls = mock.calls.URL
-	lockClientMockURL.RUnlock()
+	mock.lockURL.RUnlock()
 	return calls
 }

--- a/sdk/v1/client_test.go
+++ b/sdk/v1/client_test.go
@@ -182,17 +182,25 @@ func TestClient_PostJob(t *testing.T) {
 			&http.Response{
 				StatusCode: http.StatusCreated,
 				Body:       io.NopCloser(bytes.NewReader(body)),
+				Header: http.Header{
+					"Etag": []string{testETag},
+				},
 			},
 			nil)
 
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostJob is called", func() {
-			job, err := searchReindexClient.PostJob(ctx, client.Headers{})
+			respHeaders, job, err := searchReindexClient.PostJob(ctx, client.Headers{})
 			So(err, ShouldBeNil)
 
 			Convey("Then the expected jobid is returned", func() {
 				So(job.ID, ShouldEqual, expectedJob.ID)
+			})
+
+			Convey("And an ETag is returned", func() {
+				So(respHeaders, ShouldNotBeNil)
+				So(respHeaders, ShouldResemble, &client.RespHeaders{ETag: testETag})
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -208,13 +216,17 @@ func TestClient_PostJob(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostJob is called", func() {
-			job, err := searchReindexClient.PostJob(ctx, client.Headers{})
+			respHeaders, job, err := searchReindexClient.PostJob(ctx, client.Headers{})
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 500")
 			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusInternalServerError)
 
 			Convey("Then the expected empty job is returned", func() {
 				So(job, ShouldResemble, &models.Job{})
+			})
+
+			Convey("And no headers are returned", func() {
+				So(respHeaders, ShouldBeNil)
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {
@@ -230,13 +242,17 @@ func TestClient_PostJob(t *testing.T) {
 		searchReindexClient := newSearchReindexClient(t, httpClient)
 
 		Convey("When search-reindexClient.PostJob is called", func() {
-			job, err := searchReindexClient.PostJob(ctx, client.Headers{})
+			respHeaders, job, err := searchReindexClient.PostJob(ctx, client.Headers{})
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "failed as unexpected code from search reindex api: 409")
 			So(apiError.ErrorStatus(err), ShouldEqual, http.StatusConflict)
 
 			Convey("Then the expected empty job is returned", func() {
 				So(job, ShouldResemble, &models.Job{})
+			})
+
+			Convey("And no headers are returned", func() {
+				So(respHeaders, ShouldBeNil)
 			})
 
 			Convey("And client.Do should be called once with the expected parameters", func() {


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The Search Reindex Client has been extended to include the following method:

PutJobNumberOfTasks(ctx context.Context, reqHeaders Headers, jobID, numTasks string) (*RespHeaders, error)

Also the following method has been updated to return *RespHeaders:

PostJob(ctx context.Context, reqHeaders Headers) (*RespHeaders, *models.Job, error)

And unit tests have been added to test the following for PutJobNumberOfTasks:
- The Search Reindex Client returns 200 and an ETag (the success scenario)
- The Search Reindex Client returns a 400 response (bad request due to invalid job id)
- The Search Reindex Client returns a 500 response (search reindex error)
- The Search Reindex Client returns a 404 response (reindex job not found)

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct.

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
