### PR TITLE
Refactor GetJob and GetJobs handlers

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -175,7 +175,7 @@ func (api *API) GetJobHandler(w http.ResponseWriter, req *http.Request) {
 // last_updated time (ascending).
 func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	log.Info(ctx, "Entering handler function, which calls GetJobs and returns a list of existing Job resources held in the JobStore.")
+	log.Info(ctx, "GetJobsHandler: returns a list of Job resources")
 	host := req.Host
 	offsetParam := req.URL.Query().Get("offset")
 	limitParam := req.URL.Query().Get("limit")

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -155,21 +155,20 @@ func (api *API) GetJobHandler(w http.ResponseWriter, req *http.Request) {
 	job.Links.Self = fmt.Sprintf("%s/%s%s", host, v1, job.Links.Self)
 	job.Links.Tasks = fmt.Sprintf("%s/%s%s", host, v1, job.Links.Tasks)
 
-	w.Header().Set("Content-Type", "application/json")
 	jsonResponse, err := json.Marshal(job)
 	if err != nil {
 		log.Error(ctx, "marshalling response failed", err, logData)
 		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 		return
 	}
-
-	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(jsonResponse)
 	if err != nil {
 		log.Error(ctx, "writing response failed", err, logData)
 		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // GetJobsHandler gets a list of existing Job resources, from the Job Store, sorted by their values of

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -141,7 +141,7 @@ func (api *API) GetJobHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	defer api.unlockJob(ctx, lockID)
 
-	job, err := api.dataStore.GetJob(req.Context(), id)
+	job, err := api.dataStore.GetJob(ctx, id)
 	if err != nil {
 		log.Error(ctx, "getting job failed", err, logData)
 		if err == mongo.ErrJobNotFound {


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
GetJobHandler
- Pass existing context into line 144 (reuse variable ctx created when handler is first called)
- Do error handling before setting the content-type header and status header (otherwise if this fails then we will return an error message instead of json in the response body which will be of content-type: plain/text)

GetsJobsHandler
- A long log.Info line on line 179 in api/jobs.go is now reduced to be more concise: "GetJobsHandler: returns a list of Job resources"

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct. Also call the GetJob and GetJobs endpoints:
Need to run:
- docker-compose up -d (for Mongo, ES, and kafka)
- vault server -dev
- zebedee (./run.sh)
- search api (with ES port 11200)
- search reindex api

Then run the following curl commands:
To create a new job
curl -X POST http://localhost:25700/jobs | jq

To get a particular job:
curl -s http://localhost:25700/jobs/<job id from created job> | jq

To get a list of jobs:
curl -s http://localhost:25700/jobs | jq
curl -s 'http://localhost:25700/jobs?offset=2&limit=9' | jq

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
