### PR TITLE
Rename functions

### DIFF
--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -34,7 +34,7 @@ type DataStorer interface {
 
 // Paginator defines the required methods from the paginator package
 type Paginator interface {
-	ValidatePaginationParameters(offsetParam string, limitParam string, totalCount int) (offset int, limit int, err error)
+	ValidateParameters(offsetParam string, limitParam string, totalCount int) (offset int, limit int, err error)
 }
 
 // AuthHandler provides authorisation checks on requests

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -180,7 +180,7 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	offsetParam := req.URL.Query().Get("offset")
 	limitParam := req.URL.Query().Get("limit")
 
-	offset, limit, err := api.setUpPagination(offsetParam, limitParam)
+	offset, limit, err := api.initialisePagination(offsetParam, limitParam)
 	if err != nil {
 		log.Error(ctx, "pagination validation failed", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -220,7 +220,7 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (api *API) setUpPagination(offsetParam, limitParam string) (offset, limit int, err error) {
+func (api *API) initialisePagination(offsetParam, limitParam string) (offset, limit int, err error) {
 	paginator := pagination.NewPaginator(api.cfg.DefaultLimit, api.cfg.DefaultOffset, api.cfg.DefaultMaxLimit)
 	return paginator.ValidatePaginationParameters(offsetParam, limitParam)
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -222,7 +222,7 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 
 func (api *API) initialisePagination(offsetParam, limitParam string) (offset, limit int, err error) {
 	paginator := pagination.NewPaginator(api.cfg.DefaultLimit, api.cfg.DefaultOffset, api.cfg.DefaultMaxLimit)
-	return paginator.ValidatePaginationParameters(offsetParam, limitParam)
+	return paginator.ValidateParameters(offsetParam, limitParam)
 }
 
 // unlockJob unlocks the provided job lockID

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -180,7 +180,7 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	offsetParam := req.URL.Query().Get("offset")
 	limitParam := req.URL.Query().Get("limit")
 
-	offset, limit, err := api.initialisePagination(offsetParam, limitParam)
+	offset, limit, err := pagination.InitialisePagination(api.cfg, offsetParam, limitParam)
 	if err != nil {
 		log.Error(ctx, "pagination validation failed", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -218,11 +218,6 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 		return
 	}
-}
-
-func (api *API) initialisePagination(offsetParam, limitParam string) (offset, limit int, err error) {
-	paginator := pagination.NewPaginator(api.cfg.DefaultLimit, api.cfg.DefaultOffset, api.cfg.DefaultMaxLimit)
-	return paginator.ValidateParameters(offsetParam, limitParam)
 }
 
 // unlockJob unlocks the provided job lockID

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -123,7 +123,7 @@ func (api *API) GetTasksHandler(w http.ResponseWriter, req *http.Request) {
 	id := vars["id"]
 	logData := log.Data{"job_id": id}
 
-	offset, limit, err := api.setUpPagination(offsetParam, limitParam)
+	offset, limit, err := api.initialisePagination(offsetParam, limitParam)
 	if err != nil {
 		log.Error(ctx, "pagination validation failed", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
+	"github.com/ONSdigital/dp-search-reindex-api/pagination"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
-
-	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 )
 
 var invalidBodyErrorMessage = "invalid request body"
@@ -123,7 +123,7 @@ func (api *API) GetTasksHandler(w http.ResponseWriter, req *http.Request) {
 	id := vars["id"]
 	logData := log.Data{"job_id": id}
 
-	offset, limit, err := api.initialisePagination(offsetParam, limitParam)
+	offset, limit, err := pagination.InitialisePagination(api.cfg, offsetParam, limitParam)
 	if err != nil {
 		log.Error(ctx, "pagination validation failed", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -40,8 +40,8 @@ func NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit int) *Paginator {
 	}
 }
 
-// ValidatePaginationParameters returns pagination related values based on the given request
-func (p *Paginator) ValidatePaginationParameters(offsetParameter, limitParameter string) (offset, limit int, err error) {
+// ValidateParameters returns pagination related values based on the given request
+func (p *Paginator) ValidateParameters(offsetParameter, limitParameter string) (offset, limit int, err error) {
 	offset = p.DefaultOffset
 	limit = p.DefaultLimit
 

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -3,6 +3,8 @@ package pagination
 import (
 	"errors"
 	"strconv"
+
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 )
 
 var (
@@ -40,7 +42,7 @@ func NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit int) *Paginator {
 	}
 }
 
-// ValidateParameters returns pagination related values based on the given request
+// ValidateParameters returns pagination related values based on the given request.
 func (p *Paginator) ValidateParameters(offsetParameter, limitParameter string) (offset, limit int, err error) {
 	offset = p.DefaultOffset
 	limit = p.DefaultLimit
@@ -64,4 +66,10 @@ func (p *Paginator) ValidateParameters(offsetParameter, limitParameter string) (
 	}
 
 	return
+}
+
+// InitialisePagination creates a Paginator and uses it to validate, and set, the offset and limit parameters.
+func InitialisePagination(cfg *config.Config, offsetParam, limitParam string) (offset, limit int, err error) {
+	paginator := NewPaginator(cfg.DefaultLimit, cfg.DefaultOffset, cfg.DefaultMaxLimit)
+	return paginator.ValidateParameters(offsetParam, limitParam)
 }

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -14,13 +14,13 @@ const (
 	defaultMaxLimit = 1000
 )
 
-func TestValidatePaginationParametersReturnsErrorWhenOffsetIsNegative(t *testing.T) {
+func TestValidateParametersReturnsErrorWhenOffsetIsNegative(t *testing.T) {
 	Convey("Given a minus offset value and a JobStore containing 20 jobs", t, func() {
 		offset := "-1"
 		limit := ""
 		Convey("When ValidatePaginationValues is called", func() {
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
+			offset, limit, err := paginator.ValidateParameters(offset, limit)
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldEqual, pagination.ErrInvalidOffsetParameter)
 				So(offset, ShouldBeZeroValue)
@@ -30,14 +30,14 @@ func TestValidatePaginationParametersReturnsErrorWhenOffsetIsNegative(t *testing
 	})
 }
 
-func TestValidatePaginationParametersReturnsErrorWhenLimitIsNegative(t *testing.T) {
+func TestValidateParametersReturnsErrorWhenLimitIsNegative(t *testing.T) {
 	Convey("Given a minus limit value and a JobStore containing 20 jobs", t, func() {
 		offset := ""
 		limit := "-1"
 
 		Convey("When ValidatePaginationValues is called", func() {
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
+			offset, limit, err := paginator.ValidateParameters(offset, limit)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldEqual, pagination.ErrInvalidLimitParameter)
@@ -48,13 +48,13 @@ func TestValidatePaginationParametersReturnsErrorWhenLimitIsNegative(t *testing.
 	})
 }
 
-func TestValidatePaginationParametersReturnsErrorWhenLimitIsGreaterThanMaxLimit(t *testing.T) {
+func TestValidateParametersReturnsErrorWhenLimitIsGreaterThanMaxLimit(t *testing.T) {
 	Convey("Given a request with a limit value over the maximum", t, func() {
 		offset := ""
 		limit := "1001"
 		Convey("When ValidatePaginationValues is called", func() {
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
+			offset, limit, err := paginator.ValidateParameters(offset, limit)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldEqual, pagination.ErrLimitOverMax)
@@ -65,14 +65,14 @@ func TestValidatePaginationParametersReturnsErrorWhenLimitIsGreaterThanMaxLimit(
 	})
 }
 
-func TestValidatePaginationParametersReturnsLimitAndOffsetProvidedFromQuery(t *testing.T) {
+func TestValidateParametersReturnsLimitAndOffsetProvidedFromQuery(t *testing.T) {
 	Convey("Given a request with a valid limit and offset", t, func() {
 		offset := "5"
 		limit := "10"
 
 		Convey("When ValidatePaginationValues is called", func() {
 			paginator := pagination.NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
+			offset, limit, err := paginator.ValidateParameters(offset, limit)
 
 			Convey("Then the expected values are returned", func() {
 				So(err, ShouldBeNil)
@@ -83,7 +83,7 @@ func TestValidatePaginationParametersReturnsLimitAndOffsetProvidedFromQuery(t *t
 	})
 }
 
-func TestValidatePaginationParametersReturnsDefaultValuesWhenNotProvided(t *testing.T) {
+func TestValidateParametersReturnsDefaultValuesWhenNotProvided(t *testing.T) {
 	Convey("Given a request without pagination parameters", t, func() {
 		offset := ""
 		limit := ""
@@ -92,7 +92,7 @@ func TestValidatePaginationParametersReturnsDefaultValuesWhenNotProvided(t *test
 			expectedLimit := 15
 			expectedOffset := 1
 			paginator := pagination.NewPaginator(expectedLimit, expectedOffset, defaultMaxLimit)
-			offset, limit, err := paginator.ValidatePaginationParameters(offset, limit)
+			offset, limit, err := paginator.ValidateParameters(offset, limit)
 
 			Convey("Then the configured default values are returned", func() {
 				So(err, ShouldBeNil)


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Renaming methods
1. setUpPagination has been renamed to initialisePagination
2. the paginator method ValidatePaginationParameters has been renamed ValidateParameters to prevent stutter (this way it will read `paginator.ValidateParameters`)

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct. Also call the GetJobs endpoint using offset and limit parameters:
Need to run:
- docker-compose up -d (for Mongo, ES, and kafka)
- vault server -dev
- zebedee (./run.sh)
- search api (with ES port 11200)
- search reindex api

Then run the following curl commands:
To create a new job
curl -X POST http://localhost:25700/jobs | jq

To get a list of jobs:
curl -s 'http://localhost:25700/jobs?offset=2&limit=9' | jq

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
