### PR TITLE
simplify component tests

### DIFF
--- a/features/latest_version_features/getting_a_job.feature
+++ b/features/latest_version_features/getting_a_job.feature
@@ -2,7 +2,7 @@ Feature: Getting a job
 
   Scenario: Job exists in the Job Store and a get request returns it successfully
 
-    Given set the api version to undefined for incoming requests
+    Given the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
@@ -23,13 +23,13 @@ Feature: Getting a job
   Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: The connection to mongo DB is lost and a get request returns an internal server error
 
     Given the search reindex api loses its connection to mongo DB
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "500"

--- a/features/latest_version_features/getting_a_job.feature
+++ b/features/latest_version_features/getting_a_job.feature
@@ -2,8 +2,7 @@ Feature: Getting a job
 
   Scenario: Job exists in the Job Store and a get request returns it successfully
 
-    Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    Given set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures

--- a/features/latest_version_features/getting_a_job.feature
+++ b/features/latest_version_features/getting_a_job.feature
@@ -3,7 +3,7 @@ Feature: Getting a job
   Scenario: Job exists in the Job Store and a get request returns it successfully
 
     Given the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
       | id                | UUID                                    |
@@ -22,7 +22,7 @@ Feature: Getting a job
 
   Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "404"

--- a/features/latest_version_features/getting_a_task.feature
+++ b/features/latest_version_features/getting_a_task.feature
@@ -5,7 +5,7 @@ Feature: Getting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I have created a task for the generated job
     """
     { "task_name": "dataset-api", "number_of_documents": 30 }
@@ -22,7 +22,7 @@ Feature: Getting a task
 
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/tasks/{"dataset-api"} using a valid UUID
     Then the HTTP status code should be "404"
@@ -31,7 +31,7 @@ Feature: Getting a task
 
     Given no tasks have been created in the tasks collection
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "404"
 

--- a/features/latest_version_features/getting_a_task.feature
+++ b/features/latest_version_features/getting_a_task.feature
@@ -4,7 +4,7 @@ Feature: Getting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I have created a task for the generated job
     """
@@ -23,14 +23,14 @@ Feature: Getting a task
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/tasks/{"dataset-api"} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: Task does not exist in the tasks collection and a get task for job id request returns StatusNotFound
 
     Given no tasks have been created in the tasks collection
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "404"
@@ -38,6 +38,6 @@ Feature: Getting a task
   Scenario: The connection to mongo DB is lost and a get request returns an internal server error
 
     Given the search reindex api loses its connection to mongo DB
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/tasks/{"dataset-api"} using a valid UUID
     Then the HTTP status code should be "500"

--- a/features/latest_version_features/getting_a_task.feature
+++ b/features/latest_version_features/getting_a_task.feature
@@ -3,9 +3,8 @@ Feature: Getting a task
   Scenario: Task exists in the tasks collection and a get request returns it successfully
 
     Given I use a service auth token "validServiceAuthToken"
-    And set the api version to undefined for incoming requests
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
+    And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I have created a task for the generated job
     """
@@ -31,7 +30,6 @@ Feature: Getting a task
   Scenario: Task does not exist in the tasks collection and a get task for job id request returns StatusNotFound
 
     Given no tasks have been created in the tasks collection
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id}/tasks/{"dataset-api"}

--- a/features/latest_version_features/getting_jobs.feature
+++ b/features/latest_version_features/getting_jobs.feature
@@ -2,8 +2,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
-    Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    Given set the api version to undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs"
     """
@@ -37,8 +36,7 @@ Feature: Getting a list of jobs
 
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
-    Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    Given set the api version to undefined for incoming requests
     And I have generated 6 jobs in the Job Store
     When I GET "/jobs?offset=1&limit=4"
     """
@@ -62,8 +60,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
-    Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    Given set the api version to undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?offset=-2"
     """
@@ -72,8 +69,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
-    Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    Given set the api version to undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=-3"
     """
@@ -82,8 +78,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
-    Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    Given set the api version to undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=1001"
     """

--- a/features/latest_version_features/getting_jobs.feature
+++ b/features/latest_version_features/getting_jobs.feature
@@ -3,7 +3,7 @@ Feature: Getting a list of jobs
   Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
     Given the api version is undefined for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs"
     """
     """
@@ -26,7 +26,7 @@ Feature: Getting a list of jobs
 
   Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is undefined for incoming requests
     When I GET "/jobs"
     """
@@ -37,7 +37,7 @@ Feature: Getting a list of jobs
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
     Given the api version is undefined for incoming requests
-    And I have generated 6 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 6
     When I GET "/jobs?offset=1&limit=4"
     """
     """
@@ -61,7 +61,7 @@ Feature: Getting a list of jobs
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
     Given the api version is undefined for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs?offset=-2"
     """
     """
@@ -70,7 +70,7 @@ Feature: Getting a list of jobs
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
     Given the api version is undefined for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs?limit=-3"
     """
     """
@@ -79,7 +79,7 @@ Feature: Getting a list of jobs
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
     Given the api version is undefined for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs?limit=1001"
     """
     """

--- a/features/latest_version_features/getting_jobs.feature
+++ b/features/latest_version_features/getting_jobs.feature
@@ -2,7 +2,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
-    Given set the api version to undefined for incoming requests
+    Given the api version is undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs"
     """
@@ -27,7 +27,7 @@ Feature: Getting a list of jobs
   Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I GET "/jobs"
     """
     """
@@ -36,7 +36,7 @@ Feature: Getting a list of jobs
 
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
-    Given set the api version to undefined for incoming requests
+    Given the api version is undefined for incoming requests
     And I have generated 6 jobs in the Job Store
     When I GET "/jobs?offset=1&limit=4"
     """
@@ -60,7 +60,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
-    Given set the api version to undefined for incoming requests
+    Given the api version is undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?offset=-2"
     """
@@ -69,7 +69,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
-    Given set the api version to undefined for incoming requests
+    Given the api version is undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=-3"
     """
@@ -78,7 +78,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
-    Given set the api version to undefined for incoming requests
+    Given the api version is undefined for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=1001"
     """

--- a/features/latest_version_features/getting_tasks.feature
+++ b/features/latest_version_features/getting_tasks.feature
@@ -4,7 +4,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -33,7 +33,7 @@ Feature: Getting a list of tasks
   Scenario: No Tasks exist in the Data Store and a get request returns an empty list
 
     Given no tasks have been created in the tasks collection
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I GET /jobs/{id}/tasks using the generated id
     Then I would expect the response to be an empty list of tasks
@@ -43,7 +43,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -77,7 +77,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -98,7 +98,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -119,7 +119,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -139,6 +139,6 @@ Feature: Getting a list of tasks
   Scenario: Job does not exist and a get request returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I GET "/jobs/a219584a-454a-4add-92c6-170359b0ee77/tasks"
     Then the HTTP status code should be "404"

--- a/features/latest_version_features/getting_tasks.feature
+++ b/features/latest_version_features/getting_tasks.feature
@@ -4,7 +4,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -34,7 +33,6 @@ Feature: Getting a list of tasks
   Scenario: No Tasks exist in the Data Store and a get request returns an empty list
 
     Given no tasks have been created in the tasks collection
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I GET /jobs/{id}/tasks using the generated id
@@ -45,7 +43,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -80,7 +77,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -102,7 +98,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -124,7 +119,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id

--- a/features/latest_version_features/getting_tasks.feature
+++ b/features/latest_version_features/getting_tasks.feature
@@ -5,7 +5,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -34,7 +34,7 @@ Feature: Getting a list of tasks
 
     Given no tasks have been created in the tasks collection
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I GET /jobs/{id}/tasks using the generated id
     Then I would expect the response to be an empty list of tasks
     And the HTTP status code should be "200"
@@ -44,7 +44,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -78,7 +78,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -99,7 +99,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -120,7 +120,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -138,7 +138,7 @@ Feature: Getting a list of tasks
 
   Scenario: Job does not exist and a get request returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is undefined for incoming requests
     When I GET "/jobs/a219584a-454a-4add-92c6-170359b0ee77/tasks"
     Then the HTTP status code should be "404"

--- a/features/latest_version_features/patch_job_state_fail.feature
+++ b/features/latest_version_features/patch_job_state_fail.feature
@@ -4,7 +4,6 @@ Feature: Patch job state - Failure
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -27,7 +26,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid or outdated etag in If-Match header
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to "invalid"
@@ -50,7 +48,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with no modification to job resource
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to the old e-tag
@@ -73,7 +70,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid job ID
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -96,7 +92,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with empty patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -116,7 +111,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -139,7 +133,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -162,7 +155,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown path for the patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -185,7 +177,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid number of tasks which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -208,7 +199,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an unknown state
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -231,7 +221,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid state which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -254,7 +243,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid total search documents which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag

--- a/features/latest_version_features/patch_job_state_fail.feature
+++ b/features/latest_version_features/patch_job_state_fail.feature
@@ -5,7 +5,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -27,7 +27,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the "If-Match" header to "invalid"
     
     When I call PATCH /jobs/{id} using the generated id
@@ -49,7 +49,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the "If-Match" header to the old e-tag
 
     When I call PATCH /jobs/{id} using the generated id
@@ -71,7 +71,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I PATCH "/jobs/invalid"
@@ -93,7 +93,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -112,7 +112,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -134,7 +134,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -156,7 +156,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -178,7 +178,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -200,7 +200,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -222,7 +222,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -244,7 +244,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id

--- a/features/latest_version_features/patch_job_state_fail.feature
+++ b/features/latest_version_features/patch_job_state_fail.feature
@@ -4,7 +4,7 @@ Feature: Patch job state - Failure
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -26,7 +26,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid or outdated etag in If-Match header
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to "invalid"
     
@@ -48,7 +48,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with no modification to job resource
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to the old e-tag
 
@@ -70,7 +70,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid job ID
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -92,7 +92,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with empty patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -111,7 +111,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -133,7 +133,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -155,7 +155,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown path for the patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -177,7 +177,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid number of tasks which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -199,7 +199,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an unknown state
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -221,7 +221,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid state which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -243,7 +243,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid total search documents which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     

--- a/features/latest_version_features/patch_job_state_success.feature
+++ b/features/latest_version_features/patch_job_state_success.feature
@@ -4,7 +4,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -34,7 +34,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         
         When I call PATCH /jobs/{id} using the generated id
@@ -60,7 +60,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the "If-Match" header to ""
         
@@ -87,7 +87,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -114,7 +114,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -141,7 +141,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -168,7 +168,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -194,7 +194,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to undefined for incoming requests
+        And the api version is undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         

--- a/features/latest_version_features/patch_job_state_success.feature
+++ b/features/latest_version_features/patch_job_state_success.feature
@@ -5,7 +5,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -35,7 +35,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -61,7 +61,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the "If-Match" header to ""
         
         When I call PATCH /jobs/{id} using the generated id
@@ -88,7 +88,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -115,7 +115,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -142,7 +142,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -169,7 +169,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -195,7 +195,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id

--- a/features/latest_version_features/patch_job_state_success.feature
+++ b/features/latest_version_features/patch_job_state_success.feature
@@ -4,7 +4,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -21,6 +20,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -32,7 +34,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         
@@ -46,6 +47,9 @@ Feature: Patch job state - Success
         And the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag               |
             | last_updated           | now or earlier         |
@@ -56,7 +60,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the "If-Match" header to ""
@@ -71,6 +74,9 @@ Feature: Patch job state - Success
         And the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -81,7 +87,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -96,6 +101,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -106,7 +114,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -121,6 +128,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -131,7 +141,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -146,6 +155,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -156,7 +168,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -171,6 +182,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -180,7 +194,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to undefined for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -195,6 +208,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |

--- a/features/latest_version_features/posting_a_job.feature
+++ b/features/latest_version_features/posting_a_job.feature
@@ -3,7 +3,7 @@ Feature: Posting a job
   Scenario: Job is posted successfully
 
     Given the search api is working correctly
-    Given set the api version to undefined for incoming requests
+    Given the api version is undefined for incoming requests
     When I POST "/jobs"
     """
     """
@@ -28,7 +28,7 @@ Feature: Posting a job
   Scenario: An existing reindex job is in progress resulting in conflict error 
 
     Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And an existing reindex job is in progress
     When I POST "/jobs"
     """
@@ -44,7 +44,7 @@ Feature: Posting a job
 
     Given the search reindex api loses its connection to mongo DB
     And the search api is working correctly
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I POST "/jobs"
     """
     """
@@ -58,7 +58,7 @@ Feature: Posting a job
   Scenario: The connection to search API is lost and a post request returns an internal server error
 
     Given the search reindex api loses its connection to the search api
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I POST "/jobs"
     """
     """
@@ -73,7 +73,7 @@ Feature: Posting a job
   Scenario: The search API is failing with internal server error
 
     Given the search api is not working correctly
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I POST "/jobs"
     """
     """

--- a/features/latest_version_features/posting_a_job.feature
+++ b/features/latest_version_features/posting_a_job.feature
@@ -3,11 +3,12 @@ Feature: Posting a job
   Scenario: Job is posted successfully
 
     Given the search api is working correctly
-    And set the api version to undefined for incoming requests
+    Given set the api version to undefined for incoming requests
     When I POST "/jobs"
     """
     """
-    Then the response should contain values that have these structures
+    Then the HTTP status code should be "201"
+    And the response should contain values that have these structures
       | id                | UUID                                    |
       | last_updated      | Not in the future                       |
       | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
@@ -21,7 +22,6 @@ Feature: Posting a job
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
-    And the HTTP status code should be "201"
     And the response header "Content-Type" should be "application/json"
     And the reindex-requested event should contain the expected job ID and search index name
 

--- a/features/latest_version_features/posting_a_job.feature
+++ b/features/latest_version_features/posting_a_job.feature
@@ -3,7 +3,7 @@ Feature: Posting a job
   Scenario: Job is posted successfully
 
     Given the search api is working correctly
-    Given the api version is undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I POST "/jobs"
     """
     """

--- a/features/latest_version_features/posting_a_task.feature
+++ b/features/latest_version_features/posting_a_task.feature
@@ -5,7 +5,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
@@ -24,7 +24,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And the search reindex api loses its connection to mongo DB
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -37,7 +37,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
@@ -64,7 +64,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -75,7 +75,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 0 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 0
     And I POST "/jobs/any-job-id/tasks"
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
@@ -86,7 +86,7 @@ Feature: Posting a task
 
     Given I am not authorised
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -98,7 +98,7 @@ Feature: Posting a task
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -111,7 +111,7 @@ Feature: Posting a task
     And I am identified as "someone@somewhere.com"
     And zebedee recognises the user token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -124,7 +124,7 @@ Feature: Posting a task
     And I am not identified by zebedee
     And zebedee does not recognise the user token
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -136,7 +136,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "florence", "number_of_documents": 29 }

--- a/features/latest_version_features/posting_a_task.feature
+++ b/features/latest_version_features/posting_a_task.feature
@@ -4,7 +4,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -24,7 +23,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And the search reindex api loses its connection to mongo DB
@@ -38,7 +36,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -66,7 +63,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -78,7 +74,6 @@ Feature: Posting a task
   Scenario: Job does not exist and an attempt to create a task for it returns a not found error
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 0 jobs in the Job Store
     And I POST "/jobs/any-job-id/tasks"
@@ -90,7 +85,6 @@ Feature: Posting a task
   Scenario: No authorisation header set returns a bad request error
 
     Given I am not authorised
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -103,7 +97,6 @@ Feature: Posting a task
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -117,7 +110,6 @@ Feature: Posting a task
     Given I use an X Florence user token "validXFlorenceToken"
     And I am identified as "someone@somewhere.com"
     And zebedee recognises the user token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -131,7 +123,6 @@ Feature: Posting a task
     Given I use an X Florence user token "invalidXFlorenceToken"
     And I am not identified by zebedee
     And zebedee does not recognise the user token
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -144,7 +135,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id

--- a/features/latest_version_features/posting_a_task.feature
+++ b/features/latest_version_features/posting_a_task.feature
@@ -4,7 +4,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -23,7 +23,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And the search reindex api loses its connection to mongo DB
     When I call POST /jobs/{id}/tasks using the generated id
@@ -36,7 +36,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -63,7 +63,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -74,7 +74,7 @@ Feature: Posting a task
   Scenario: Job does not exist and an attempt to create a task for it returns a not found error
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 0 jobs in the Job Store
     And I POST "/jobs/any-job-id/tasks"
     """
@@ -85,7 +85,7 @@ Feature: Posting a task
   Scenario: No authorisation header set returns a bad request error
 
     Given I am not authorised
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -97,7 +97,7 @@ Feature: Posting a task
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -110,7 +110,7 @@ Feature: Posting a task
     Given I use an X Florence user token "validXFlorenceToken"
     And I am identified as "someone@somewhere.com"
     And zebedee recognises the user token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -123,7 +123,7 @@ Feature: Posting a task
     Given I use an X Florence user token "invalidXFlorenceToken"
     And I am not identified by zebedee
     And zebedee does not recognise the user token
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -135,7 +135,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """

--- a/features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/latest_version_features/putting_number_of_tasks.feature
@@ -3,7 +3,7 @@ Feature: Updating the number of tasks for a particular job
   Scenario: Job exists in the Job Store and a put request updates its number of tasks successfully
 
     Given I have generated 1 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
     Then the HTTP status code should be "200"
     Given I call GET /jobs/{id} using the generated id
@@ -13,27 +13,27 @@ Feature: Updating the number of tasks for a particular job
   Scenario: Job does not exist in the Job Store and a put request, to update its number of tasks, returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: A put request fails to update the number of tasks because it contains an invalid value of count
 
     Given I have generated 1 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"seven"} using the generated id with an invalid count
     Then the HTTP status code should be "400"
 
   Scenario: A put request fails to update the number of tasks because it contains a negative value of count
 
     Given I have generated 1 jobs in the Job Store
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"-7"} using the generated id with a negative count
     Then the HTTP status code should be "400"
 
   Scenario: The connection to mongo DB is lost and a put request returns an internal server error
 
     Given the search reindex api loses its connection to mongo DB
-    And set the api version to undefined for incoming requests
+    And the api version is undefined for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "500"

--- a/features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/latest_version_features/putting_number_of_tasks.feature
@@ -2,8 +2,7 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: Job exists in the Job Store and a put request updates its number of tasks successfully
 
-    Given the search api is working correctly
-    And I have generated 1 jobs in the Job Store
+    Given I have generated 1 jobs in the Job Store
     And set the api version to undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
     Then the HTTP status code should be "200"
@@ -20,16 +19,14 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: A put request fails to update the number of tasks because it contains an invalid value of count
 
-    Given the search api is working correctly
-    And I have generated 1 jobs in the Job Store
+    Given I have generated 1 jobs in the Job Store
     And set the api version to undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"seven"} using the generated id with an invalid count
     Then the HTTP status code should be "400"
 
   Scenario: A put request fails to update the number of tasks because it contains a negative value of count
 
-    Given the search api is working correctly
-    And I have generated 1 jobs in the Job Store
+    Given I have generated 1 jobs in the Job Store
     And set the api version to undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"-7"} using the generated id with a negative count
     Then the HTTP status code should be "400"

--- a/features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/latest_version_features/putting_number_of_tasks.feature
@@ -2,7 +2,7 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: Job exists in the Job Store and a put request updates its number of tasks successfully
 
-    Given I have generated 1 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 1
     And the api version is undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
     Then the HTTP status code should be "200"
@@ -12,21 +12,21 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: Job does not exist in the Job Store and a put request, to update its number of tasks, returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is undefined for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: A put request fails to update the number of tasks because it contains an invalid value of count
 
-    Given I have generated 1 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 1
     And the api version is undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"seven"} using the generated id with an invalid count
     Then the HTTP status code should be "400"
 
   Scenario: A put request fails to update the number of tasks because it contains a negative value of count
 
-    Given I have generated 1 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 1
     And the api version is undefined for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"-7"} using the generated id with a negative count
     Then the HTTP status code should be "400"

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -154,6 +154,7 @@ func (f *SearchReindexAPIFeature) Reset(mongoFail bool) error {
 	} else {
 		f.MongoClient.Database = utils.RandomDatabase()
 	}
+
 	if f.Config == nil {
 		cfg, err := config.Get()
 		if err != nil {

--- a/features/steps/helper.go
+++ b/features/steps/helper.go
@@ -21,20 +21,6 @@ import (
 
 const testHost = "foo"
 
-// callPostJobs can be called by a feature step in order to call the POST /jobs endpoint
-// Calling that endpoint results in the creation of a job, in the Job Store, containing a unique id and default values.
-func (f *SearchReindexAPIFeature) callPostJobs(version string) error {
-	path := getPath(version, "/jobs")
-
-	var emptyBody = godog.DocString{}
-	err := f.APIFeature.IPostToWithBody(path, &emptyBody)
-	if err != nil {
-		return fmt.Errorf("error occurred in IPostToWithBody: %w", err)
-	}
-
-	return nil
-}
-
 // CallGetJobByID can be called by a feature step in order to call the GET /jobs/{id} endpoint.
 func (f *SearchReindexAPIFeature) CallGetJobByID(version, id string) error {
 	path := getPath(version, fmt.Sprintf("/jobs/%s", id))
@@ -205,27 +191,27 @@ func (f *SearchReindexAPIFeature) checkForNoChangeInJobField(field string, oldJo
 
 // checkStructure can be called by a feature step to assert that a job contains the expected structure in its values of
 // id, last_updated, and links. It confirms that last_updated is a current or past time, and that the tasks and self links have the correct paths.
-func (f *SearchReindexAPIFeature) checkStructure(expectedResult map[string]string) error {
-	_, err := uuid.FromString(f.createdJob.ID)
+func (f *SearchReindexAPIFeature) checkStructure(responseJob *models.Job, expectedResult map[string]string) error {
+	_, err := uuid.FromString(responseJob.ID)
 	if err != nil {
 		return fmt.Errorf("the id should be a uuid: %w", err)
 	}
 
-	if f.createdJob.LastUpdated.After(time.Now()) {
-		return errors.New("expected LastUpdated to be now or earlier but it was: " + f.createdJob.LastUpdated.String())
+	if responseJob.LastUpdated.After(time.Now()) {
+		return errors.New("expected LastUpdated to be now or earlier but it was: " + responseJob.LastUpdated.String())
 	}
 
-	replacer := strings.NewReplacer("{host}", testHost, "{latest_version}", f.Config.LatestVersion, "{id}", f.createdJob.ID)
+	replacer := strings.NewReplacer("{host}", testHost, "{latest_version}", f.Config.LatestVersion, "{id}", responseJob.ID)
 
 	expectedLinksTasks := replacer.Replace(expectedResult["links: tasks"])
-	assert.Equal(&f.ErrorFeature, expectedLinksTasks, f.createdJob.Links.Tasks)
+	assert.Equal(&f.ErrorFeature, expectedLinksTasks, responseJob.Links.Tasks)
 
 	expectedLinksSelf := replacer.Replace(expectedResult["links: self"])
-	assert.Equal(&f.ErrorFeature, expectedLinksSelf, f.createdJob.Links.Self)
+	assert.Equal(&f.ErrorFeature, expectedLinksSelf, responseJob.Links.Self)
 
 	re := regexp.MustCompile(`(ons)(\d*)`)
-	wordWithExpectedPattern := re.FindString(f.createdJob.SearchIndexName)
-	assert.Equal(&f.ErrorFeature, wordWithExpectedPattern, f.createdJob.SearchIndexName)
+	wordWithExpectedPattern := re.FindString(responseJob.SearchIndexName)
+	assert.Equal(&f.ErrorFeature, wordWithExpectedPattern, responseJob.SearchIndexName)
 
 	return nil
 }
@@ -297,20 +283,6 @@ func readAndDeserializeKafkaProducerOutput(kafkaProducerOutputData <-chan []byte
 	}
 
 	return reindexRequestedData, err
-}
-
-// getAndSetCreatedJobFromResponse gets the previously generated job and sets it to f.createdJob so that the job resource is accessible in each step
-func (f *SearchReindexAPIFeature) getAndSetCreatedJobFromResponse() error {
-	if (f.createdJob == models.Job{}) {
-		response, err := f.getJobFromResponse()
-		if err != nil {
-			return fmt.Errorf("failed to get job from response: %w", err)
-		}
-
-		f.createdJob = *response
-	}
-
-	return nil
 }
 
 // getJobFromResponse reads the job JSON response from the SearchReindexAPIFeature's HTTP response body and unmarshals it to the form of Job

--- a/features/steps/job_steps.go
+++ b/features/steps/job_steps.go
@@ -28,7 +28,7 @@ func (f *SearchReindexAPIFeature) setAPIVersionForPath(apiVersion string) {
 
 // anExistingReindexJobIsInProgress is a feature step that generates a job where its state is in-progress
 func (f *SearchReindexAPIFeature) anExistingReindexJobIsInProgress() error {
-	err := f.iHaveGeneratedJobsInTheJobStore(1)
+	err := f.theNoOfExistingJobsInTheJobStore(1)
 	if err != nil {
 		return fmt.Errorf("failed to generate an existing reindex job - error: %w", err)
 	}
@@ -177,42 +177,6 @@ func (f *SearchReindexAPIFeature) iCallPATCHJobsIDUsingTheGeneratedID(patchReqBo
 
 // 	return f.ErrorFeature.StepError()
 // }
-
-// iHaveGeneratedJobsInTheJobStore is a feature step that can be defined for a specific SearchReindexAPIFeature.
-// It creates a job in mongo and assigns the created job to f.createdJob to be used in later feature steps
-func (f *SearchReindexAPIFeature) iHaveGeneratedJobsInTheJobStore(noOfJobs int) (err error) {
-	ctx := context.Background()
-
-	if noOfJobs < 0 {
-		return fmt.Errorf("invalid number of jobs given - noOfJobs = %d", noOfJobs)
-	}
-
-	if noOfJobs == 0 {
-		err = f.Reset(false)
-		if err != nil {
-			return fmt.Errorf("failed to reset the SearchReindexAPIFeature: %w", err)
-		}
-	}
-
-	if noOfJobs > 0 {
-		var job *models.Job
-		for i := 1; i <= noOfJobs; i++ {
-			// create a job in mongo
-			job, err = f.MongoClient.CreateJob(ctx, "")
-			if err != nil {
-				return fmt.Errorf("failed to create job in mongo: %w", err)
-			}
-
-			if i <= noOfJobs {
-				time.Sleep(5 * time.Millisecond)
-			}
-		}
-
-		f.createdJob = *job
-	}
-
-	return f.ErrorFeature.StepError()
-}
 
 // iSetIfMatchHeaderToTheGeneratedETag is a feature step that gets the eTag from the response body generated in the previous step
 // and then sets If-Match header to that eTag
@@ -381,6 +345,42 @@ func (f *SearchReindexAPIFeature) theJobsShouldBeOrderedByLastupdatedWithTheOlde
 			"The value of last_updated at job_list["+index+"] should be earlier than that at job_list["+nextIndex+"]")
 		timeToCheck = nextTime
 	}
+	return f.ErrorFeature.StepError()
+}
+
+// theNoOfExistingJobsInTheJobStore is a feature step that can be defined for a specific SearchReindexAPIFeature.
+// It creates a job in mongo and assigns the created job to f.createdJob to be used in later feature steps
+func (f *SearchReindexAPIFeature) theNoOfExistingJobsInTheJobStore(noOfJobs int) (err error) {
+	ctx := context.Background()
+
+	if noOfJobs < 0 {
+		return fmt.Errorf("invalid number of jobs given - noOfJobs = %d", noOfJobs)
+	}
+
+	if noOfJobs == 0 {
+		err = f.Reset(false)
+		if err != nil {
+			return fmt.Errorf("failed to reset the SearchReindexAPIFeature: %w", err)
+		}
+	}
+
+	if noOfJobs > 0 {
+		var job *models.Job
+		for i := 1; i <= noOfJobs; i++ {
+			// create a job in mongo
+			job, err = f.MongoClient.CreateJob(ctx, "")
+			if err != nil {
+				return fmt.Errorf("failed to create job in mongo: %w", err)
+			}
+
+			if i <= noOfJobs {
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+
+		f.createdJob = *job
+	}
+
 	return f.ErrorFeature.StepError()
 }
 

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -35,9 +35,9 @@ func (f *SearchReindexAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I call PATCH \/jobs\/{id} using the generated id$`, f.iCallPATCHJobsIDUsingTheGeneratedID)
 
 	ctx.Step(`^I have created a task for the generated job$`, f.iHaveCreatedATaskForTheGeneratedJob)
-	ctx.Step(`^I have generated (\d+) jobs in the Job Store$`, f.iHaveGeneratedJobsInTheJobStore)
 	ctx.Step(`^I set the If-Match header to the generated e-tag$`, f.iSetIfMatchHeaderToTheGeneratedETag)
 	ctx.Step(`^I set the "If-Match" header to the old e-tag$`, f.iSetIfMatchHeaderToTheOldGeneratedETag)
+	ctx.Step(`^the number of existing jobs in the Job Store is (\d+)$`, f.theNoOfExistingJobsInTheJobStore)
 
 	ctx.Step(`^I would expect the response to be an empty list$`, f.iWouldExpectTheResponseToBeAnEmptyList)
 	ctx.Step(`^I would expect the response to be an empty list of tasks$`, f.iWouldExpectTheResponseToBeAnEmptyListOfTasks)

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -4,7 +4,7 @@ import "github.com/cucumber/godog"
 
 // RegisterSteps defines the steps within a specific SearchReindexAPIFeature cucumber test.
 func (f *SearchReindexAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
-	ctx.Step(`^set the api version to ([^"]*) for incoming requests$`, f.setAPIVersionForPath)
+	ctx.Step(`^the api version is ([^"]*) for incoming requests$`, f.setAPIVersionForPath)
 	ctx.Step(`^a new task resource is created containing the following values:$`, f.aNewTaskResourceIsCreatedContainingTheFollowingValues)
 	ctx.Step(`^an existing reindex job is in progress$`, f.anExistingReindexJobIsInProgress)
 	ctx.Step(`^each job should also contain the following values:$`, f.eachJobShouldAlsoContainTheFollowingValues)

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -3,7 +3,7 @@ Feature: Getting a job
   Scenario: Job exists in the Job Store and a get request returns it successfully
 
     Given the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
       | id                | UUID                      |
@@ -22,7 +22,7 @@ Feature: Getting a job
 
   Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "404"

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -2,15 +2,14 @@ Feature: Getting a job
 
   Scenario: Job exists in the Job Store and a get request returns it successfully
 
-    Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    Given set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
       | search_index_name | ons{date_stamp}                         |
     And the response should also contain the following values:
       | number_of_tasks                 | 0                         |

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -6,11 +6,11 @@ Feature: Getting a job
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
+      | id                | UUID                      |
+      | last_updated      | Not in the future         |
+      | links: tasks      | {host}/v1/jobs/{id}/tasks |
+      | links: self       | {host}/v1/jobs/{id}       |
+      | search_index_name | ons{date_stamp}           |
     And the response should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -2,7 +2,7 @@ Feature: Getting a job
 
   Scenario: Job exists in the Job Store and a get request returns it successfully
 
-    Given set the api version to v1 for incoming requests
+    Given the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
@@ -23,13 +23,13 @@ Feature: Getting a job
   Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: The connection to mongo DB is lost and a get request returns an internal server error
 
     Given the search reindex api loses its connection to mongo DB
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "500"

--- a/features/v1_features/latest_version_features/getting_a_task.feature
+++ b/features/v1_features/latest_version_features/getting_a_task.feature
@@ -3,9 +3,8 @@ Feature: Getting a task
   Scenario: Task exists in the tasks collection and a get request returns it successfully
 
     Given I use a service auth token "validServiceAuthToken"
-    And set the api version to v1 for incoming requests
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
+    And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I have created a task for the generated job
     """
@@ -14,12 +13,12 @@ Feature: Getting a task
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "200"
     And the response for getting task to look like this
-      | job_id              | UUID                                  |
-      | last_updated        | Not in the future                     |
-      | links: self         | {host}/v1/jobs/{id}/tasks/dataset-api |
-      | links: job          | {host}/v1/jobs/{id}                   |
-      | number_of_documents | 30                                    |
-      | task_name           | dataset-api                           |
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
 
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 
@@ -31,7 +30,6 @@ Feature: Getting a task
   Scenario: Task does not exist in the tasks collection and a get task for job id request returns StatusNotFound
 
     Given no tasks have been created in the tasks collection
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id}/tasks/{"dataset-api"}

--- a/features/v1_features/latest_version_features/getting_a_task.feature
+++ b/features/v1_features/latest_version_features/getting_a_task.feature
@@ -13,12 +13,12 @@ Feature: Getting a task
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "200"
     And the response for getting task to look like this
-      | job_id              | UUID                                                |
-      | last_updated        | Not in the future                                   |
-      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
-      | links: job          | {host}/{latest_version}/jobs/{id}                   |
-      | number_of_documents | 30                                                  |
-      | task_name           | dataset-api                                         |
+      | job_id              | UUID                                  |
+      | last_updated        | Not in the future                     |
+      | links: self         | {host}/v1/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/v1/jobs/{id}                   |
+      | number_of_documents | 30                                    |
+      | task_name           | dataset-api                           |
 
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 

--- a/features/v1_features/latest_version_features/getting_a_task.feature
+++ b/features/v1_features/latest_version_features/getting_a_task.feature
@@ -4,7 +4,7 @@ Feature: Getting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I have created a task for the generated job
     """
@@ -23,14 +23,14 @@ Feature: Getting a task
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/tasks/{"dataset-api"} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: Task does not exist in the tasks collection and a get task for job id request returns StatusNotFound
 
     Given no tasks have been created in the tasks collection
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "404"
@@ -38,6 +38,6 @@ Feature: Getting a task
   Scenario: The connection to mongo DB is lost and a get request returns an internal server error
 
     Given the search reindex api loses its connection to mongo DB
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/tasks/{"dataset-api"} using a valid UUID
     Then the HTTP status code should be "500"

--- a/features/v1_features/latest_version_features/getting_a_task.feature
+++ b/features/v1_features/latest_version_features/getting_a_task.feature
@@ -5,7 +5,7 @@ Feature: Getting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I have created a task for the generated job
     """
     { "task_name": "dataset-api", "number_of_documents": 30 }
@@ -22,7 +22,7 @@ Feature: Getting a task
 
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/tasks/{"dataset-api"} using a valid UUID
     Then the HTTP status code should be "404"
@@ -31,7 +31,7 @@ Feature: Getting a task
 
     Given no tasks have been created in the tasks collection
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "404"
 

--- a/features/v1_features/latest_version_features/getting_jobs.feature
+++ b/features/v1_features/latest_version_features/getting_jobs.feature
@@ -3,7 +3,7 @@ Feature: Getting a list of jobs
   Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
     Given the api version is v1 for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs"
     """
     """
@@ -26,7 +26,7 @@ Feature: Getting a list of jobs
 
   Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
     When I GET "/jobs"
     """
@@ -37,7 +37,7 @@ Feature: Getting a list of jobs
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
     Given the api version is v1 for incoming requests
-    And I have generated 6 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 6
     When I GET "/jobs?offset=1&limit=4"
     """
     """
@@ -61,7 +61,7 @@ Feature: Getting a list of jobs
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
     Given the api version is v1 for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs?offset=-2"
     """
     """
@@ -70,7 +70,7 @@ Feature: Getting a list of jobs
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
     Given the api version is v1 for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs?limit=-3"
     """
     """
@@ -79,7 +79,7 @@ Feature: Getting a list of jobs
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
     Given the api version is v1 for incoming requests
-    And I have generated 3 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 3
     When I GET "/jobs?limit=1001"
     """
     """

--- a/features/v1_features/latest_version_features/getting_jobs.feature
+++ b/features/v1_features/latest_version_features/getting_jobs.feature
@@ -2,19 +2,18 @@ Feature: Getting a list of jobs
 
   Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
-    Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    Given set the api version to v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs"
     """
     """
     Then I would expect there to be three or more jobs returned in a list
     And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
-      | search_index_name | ons{date_stamp}           |
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
     And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
@@ -37,19 +36,18 @@ Feature: Getting a list of jobs
 
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
-    Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    Given set the api version to v1 for incoming requests
     And I have generated 6 jobs in the Job Store
     When I GET "/jobs?offset=1&limit=4"
     """
     """
     Then I would expect there to be four jobs returned in a list
     And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
-      | search_index_name | ons{date_stamp}           |
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
     And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
@@ -62,8 +60,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
-    Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    Given set the api version to v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?offset=-2"
     """
@@ -72,8 +69,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
-    Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    Given set the api version to v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=-3"
     """
@@ -82,8 +78,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
-    Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    Given set the api version to v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=1001"
     """

--- a/features/v1_features/latest_version_features/getting_jobs.feature
+++ b/features/v1_features/latest_version_features/getting_jobs.feature
@@ -2,7 +2,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
-    Given set the api version to v1 for incoming requests
+    Given the api version is v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs"
     """
@@ -27,7 +27,7 @@ Feature: Getting a list of jobs
   Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I GET "/jobs"
     """
     """
@@ -36,7 +36,7 @@ Feature: Getting a list of jobs
 
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
-    Given set the api version to v1 for incoming requests
+    Given the api version is v1 for incoming requests
     And I have generated 6 jobs in the Job Store
     When I GET "/jobs?offset=1&limit=4"
     """
@@ -60,7 +60,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
-    Given set the api version to v1 for incoming requests
+    Given the api version is v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?offset=-2"
     """
@@ -69,7 +69,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
-    Given set the api version to v1 for incoming requests
+    Given the api version is v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=-3"
     """
@@ -78,7 +78,7 @@ Feature: Getting a list of jobs
 
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
-    Given set the api version to v1 for incoming requests
+    Given the api version is v1 for incoming requests
     And I have generated 3 jobs in the Job Store
     When I GET "/jobs?limit=1001"
     """

--- a/features/v1_features/latest_version_features/getting_jobs.feature
+++ b/features/v1_features/latest_version_features/getting_jobs.feature
@@ -9,11 +9,11 @@ Feature: Getting a list of jobs
     """
     Then I would expect there to be three or more jobs returned in a list
     And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
+      | id                | UUID                      |
+      | last_updated      | Not in the future         |
+      | links: tasks      | {host}/v1/jobs/{id}/tasks |
+      | links: self       | {host}/v1/jobs/{id}       |
+      | search_index_name | ons{date_stamp}           |
     And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
@@ -43,11 +43,11 @@ Feature: Getting a list of jobs
     """
     Then I would expect there to be four jobs returned in a list
     And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
+      | id                | UUID                      |
+      | last_updated      | Not in the future         |
+      | links: tasks      | {host}/v1/jobs/{id}/tasks |
+      | links: self       | {host}/v1/jobs/{id}       |
+      | search_index_name | ons{date_stamp}           |
     And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |

--- a/features/v1_features/latest_version_features/getting_tasks.feature
+++ b/features/v1_features/latest_version_features/getting_tasks.feature
@@ -5,7 +5,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -34,7 +34,7 @@ Feature: Getting a list of tasks
 
     Given no tasks have been created in the tasks collection
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I GET /jobs/{id}/tasks using the generated id
     Then I would expect the response to be an empty list of tasks
     And the HTTP status code should be "200"
@@ -44,7 +44,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -78,7 +78,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -99,7 +99,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -120,7 +120,7 @@ Feature: Getting a list of tasks
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "zebedee", "number_of_documents": 4 }
@@ -138,7 +138,7 @@ Feature: Getting a list of tasks
 
   Scenario: Job does not exist and a get request returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
     When I GET "/jobs/a219584a-454a-4add-92c6-170359b0ee77/tasks"
     Then the HTTP status code should be "404"

--- a/features/v1_features/latest_version_features/getting_tasks.feature
+++ b/features/v1_features/latest_version_features/getting_tasks.feature
@@ -4,7 +4,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -33,7 +33,7 @@ Feature: Getting a list of tasks
   Scenario: No Tasks exist in the Data Store and a get request returns an empty list
 
     Given no tasks have been created in the tasks collection
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I GET /jobs/{id}/tasks using the generated id
     Then I would expect the response to be an empty list of tasks
@@ -43,7 +43,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -77,7 +77,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -98,7 +98,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -119,7 +119,7 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -139,6 +139,6 @@ Feature: Getting a list of tasks
   Scenario: Job does not exist and a get request returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I GET "/jobs/a219584a-454a-4add-92c6-170359b0ee77/tasks"
     Then the HTTP status code should be "404"

--- a/features/v1_features/latest_version_features/getting_tasks.feature
+++ b/features/v1_features/latest_version_features/getting_tasks.feature
@@ -21,13 +21,13 @@ Feature: Getting a list of tasks
     When I call GET /jobs/{id}/tasks using the same id again
     Then I would expect there to be 3 tasks returned in a list
     And the response for getting task to look like this
-      | job_id       | UUID                                                |
-      | last_updated | Not in the future                                   |
-      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
-      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+      | job_id       | UUID                                  |
+      | last_updated | Not in the future                     |
+      | links: self  | {host}/v1/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/v1/jobs/{id}                   |
     And each task should also contain the following values:
-      | number_of_documents | 4                                            |
-      | task_name           | {task_name}                                  |
+      | number_of_documents | 4                              |
+      | task_name           | {task_name}                    |
     And the tasks should be ordered, by last_updated, with the oldest first
 
   Scenario: No Tasks exist in the Data Store and a get request returns an empty list
@@ -64,13 +64,13 @@ Feature: Getting a list of tasks
     When I call GET /jobs/{id}/tasks?offset="1"&limit="2"
     Then I would expect there to be 2 tasks returned in a list
     And the response for getting task to look like this
-      | job_id       | UUID                                                |
-      | last_updated | Not in the future                                   |
-      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
-      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+      | job_id       | UUID                                  |
+      | last_updated | Not in the future                     |
+      | links: self  | {host}/v1/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/v1/jobs/{id}                   |
     And each task should also contain the following values:
-      | number_of_documents | 4                                            |
-      | task_name           | {task_name}                                  |
+      | number_of_documents | 4                              |
+      | task_name           | {task_name}                    |
     And the tasks should be ordered, by last_updated, with the oldest first
 
   Scenario: Three tasks exist and a get request with negative offset returns an error

--- a/features/v1_features/latest_version_features/getting_tasks.feature
+++ b/features/v1_features/latest_version_features/getting_tasks.feature
@@ -4,7 +4,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -22,19 +21,18 @@ Feature: Getting a list of tasks
     When I call GET /jobs/{id}/tasks using the same id again
     Then I would expect there to be 3 tasks returned in a list
     And the response for getting task to look like this
-      | job_id       | UUID                                  |
-      | last_updated | Not in the future                     |
-      | links: self  | {host}/v1/jobs/{id}/tasks/{task_name} |
-      | links: job   | {host}/v1/jobs/{id}                   |
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
     And each task should also contain the following values:
-      | number_of_documents | 4                              |
-      | task_name           | {task_name}                    |
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
     And the tasks should be ordered, by last_updated, with the oldest first
 
   Scenario: No Tasks exist in the Data Store and a get request returns an empty list
 
     Given no tasks have been created in the tasks collection
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I GET /jobs/{id}/tasks using the generated id
@@ -45,7 +43,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -67,20 +64,19 @@ Feature: Getting a list of tasks
     When I call GET /jobs/{id}/tasks?offset="1"&limit="2"
     Then I would expect there to be 2 tasks returned in a list
     And the response for getting task to look like this
-      | job_id       | UUID                                  |
-      | last_updated | Not in the future                     |
-      | links: self  | {host}/v1/jobs/{id}/tasks/{task_name} |
-      | links: job   | {host}/v1/jobs/{id}                   |
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
     And each task should also contain the following values:
-      | number_of_documents | 4                              |
-      | task_name           | {task_name}                    |
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
     And the tasks should be ordered, by last_updated, with the oldest first
 
   Scenario: Three tasks exist and a get request with negative offset returns an error
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -102,7 +98,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -124,7 +119,6 @@ Feature: Getting a list of tasks
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id

--- a/features/v1_features/latest_version_features/patch_job_state_fail.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_fail.feature
@@ -5,7 +5,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -27,7 +27,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the "If-Match" header to "invalid"
     
     When I call PATCH /jobs/{id} using the generated id
@@ -49,7 +49,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the "If-Match" header to the old e-tag
 
     When I call PATCH /jobs/{id} using the generated id
@@ -71,7 +71,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I PATCH "/jobs/invalid"
@@ -93,7 +93,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -112,7 +112,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -134,7 +134,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -156,7 +156,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -178,7 +178,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -200,7 +200,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -222,7 +222,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id
@@ -244,7 +244,7 @@ Feature: Patch job state - Failure
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I set the If-Match header to the generated e-tag
     
     When I call PATCH /jobs/{id} using the generated id

--- a/features/v1_features/latest_version_features/patch_job_state_fail.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_fail.feature
@@ -4,7 +4,7 @@ Feature: Patch job state - Failure
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -26,7 +26,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid or outdated etag in If-Match header
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to "invalid"
     
@@ -48,7 +48,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with no modification to job resource
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to the old e-tag
 
@@ -70,7 +70,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid job ID
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -92,7 +92,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with empty patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -111,7 +111,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -133,7 +133,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -155,7 +155,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown path for the patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -177,7 +177,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid number of tasks which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -199,7 +199,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an unknown state
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -221,7 +221,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid state which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     
@@ -243,7 +243,7 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid total search documents which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
     

--- a/features/v1_features/latest_version_features/patch_job_state_fail.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_fail.feature
@@ -4,7 +4,6 @@ Feature: Patch job state - Failure
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -27,7 +26,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid or outdated etag in If-Match header
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to "invalid"
@@ -50,11 +48,10 @@ Feature: Patch job state - Failure
   Scenario: Request is made with no modification to job resource
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the "If-Match" header to the old e-tag
-    
+
     When I call PATCH /jobs/{id} using the generated id
     """
     [
@@ -73,7 +70,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid job ID
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -96,7 +92,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with empty patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -116,7 +111,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with invalid patch body
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -139,7 +133,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -162,7 +155,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made with unknown path for the patch operation
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -185,7 +177,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid number of tasks which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -208,7 +199,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an unknown state
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -231,7 +221,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid state which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag
@@ -254,7 +243,6 @@ Feature: Patch job state - Failure
   Scenario: Request is made which updates an invalid total search documents which is the wrong type
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I set the If-Match header to the generated e-tag

--- a/features/v1_features/latest_version_features/patch_job_state_success.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_success.feature
@@ -5,7 +5,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -35,7 +35,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -61,7 +61,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the "If-Match" header to ""
         
         When I call PATCH /jobs/{id} using the generated id
@@ -88,7 +88,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -115,7 +115,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -142,7 +142,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -169,7 +169,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id
@@ -195,7 +195,7 @@ Feature: Patch job state - Success
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
-        And I have generated 1 jobs in the Job Store
+        And the number of existing jobs in the Job Store is 1
         And I set the If-Match header to the generated e-tag
         
         When I call PATCH /jobs/{id} using the generated id

--- a/features/v1_features/latest_version_features/patch_job_state_success.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_success.feature
@@ -4,7 +4,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -21,6 +20,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -32,7 +34,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         
@@ -46,17 +47,19 @@ Feature: Patch job state - Success
         And the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
-            | e_tag                  | new eTag                  |
-            | last_updated           | now or earlier            |
-            | reindex_started        | now or earlier            |
-            | state                  | in-progress               |
+            | e_tag                  | new eTag               |
+            | last_updated           | now or earlier         |
+            | reindex_started        | now or earlier         |
+            | state                  | in-progress            |
   
     Scenario: Request is made with empty If-Match header which then sets If-Match header to IfMatchAnyETag (`*`) to ask the API to ignore the ETag check
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the "If-Match" header to ""
@@ -71,6 +74,9 @@ Feature: Patch job state - Success
         And the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -81,7 +87,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -96,6 +101,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -106,7 +114,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -121,6 +128,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -131,7 +141,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -146,6 +155,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -156,7 +168,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -171,6 +182,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |
@@ -180,7 +194,6 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And the search api is working correctly
         And set the api version to v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
@@ -195,6 +208,9 @@ Feature: Patch job state - Success
         Then the HTTP status code should be "204"
         And the response header "Content-Type" should be ""
         And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
         And the job should only be updated with the following fields and values
             | e_tag                  | new eTag                  |
             | last_updated           | now or earlier            |

--- a/features/v1_features/latest_version_features/patch_job_state_success.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_success.feature
@@ -4,7 +4,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -34,7 +34,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         
         When I call PATCH /jobs/{id} using the generated id
@@ -60,7 +60,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the "If-Match" header to ""
         
@@ -87,7 +87,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -114,7 +114,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -141,7 +141,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -168,7 +168,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         
@@ -194,7 +194,7 @@ Feature: Patch job state - Success
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
-        And set the api version to v1 for incoming requests
+        And the api version is v1 for incoming requests
         And I have generated 1 jobs in the Job Store
         And I set the If-Match header to the generated e-tag
         

--- a/features/v1_features/latest_version_features/posting_a_job.feature
+++ b/features/v1_features/latest_version_features/posting_a_job.feature
@@ -3,7 +3,7 @@ Feature: Posting a job
   Scenario: Job is posted successfully
 
     Given the search api is working correctly
-    Given set the api version to v1 for incoming requests
+    Given the api version is v1 for incoming requests
     When I POST "/jobs"
     """
     """
@@ -28,7 +28,7 @@ Feature: Posting a job
   Scenario: An existing reindex job is in progress resulting in conflict error 
 
     Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And an existing reindex job is in progress
     When I POST "/jobs"
     """
@@ -44,7 +44,7 @@ Feature: Posting a job
 
     Given the search reindex api loses its connection to mongo DB
     And the search api is working correctly
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I POST "/jobs"
     """
     """
@@ -58,7 +58,7 @@ Feature: Posting a job
   Scenario: The connection to search API is lost and a post request returns an internal server error
 
     Given the search reindex api loses its connection to the search api
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I POST "/jobs"
     """
     """
@@ -73,7 +73,7 @@ Feature: Posting a job
   Scenario: The search API is failing with internal server error
 
     Given the search api is not working correctly
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I POST "/jobs"
     """
     """

--- a/features/v1_features/latest_version_features/posting_a_job.feature
+++ b/features/v1_features/latest_version_features/posting_a_job.feature
@@ -9,11 +9,11 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "201"
     And the response should contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
+      | id                | UUID                      |
+      | last_updated      | Not in the future         |
+      | links: tasks      | {host}/v1/jobs/{id}/tasks |
+      | links: self       | {host}/v1/jobs/{id}       |
+      | search_index_name | ons{date_stamp}           |
     And the response should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |

--- a/features/v1_features/latest_version_features/posting_a_job.feature
+++ b/features/v1_features/latest_version_features/posting_a_job.feature
@@ -3,25 +3,25 @@ Feature: Posting a job
   Scenario: Job is posted successfully
 
     Given the search api is working correctly
-    And set the api version to v1 for incoming requests
+    Given set the api version to v1 for incoming requests
     When I POST "/jobs"
     """
     """
-    Then the response should contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
-      | search_index_name | ons{date_stamp}           |
+    Then the HTTP status code should be "201"
+    And the response should contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
     And the response should also contain the following values:
-      | number_of_tasks                 | 0                    |
-      | reindex_completed               | 0001-01-01T00:00:00Z |
-      | reindex_failed                  | 0001-01-01T00:00:00Z |
-      | reindex_started                 | 0001-01-01T00:00:00Z |
-      | state                           | created              |
-      | total_search_documents          | 0                    |
-      | total_inserted_search_documents | 0                    |
-    And the HTTP status code should be "201"
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
     And the response header "Content-Type" should be "application/json"
     And the reindex-requested event should contain the expected job ID and search index name
 

--- a/features/v1_features/latest_version_features/posting_a_job.feature
+++ b/features/v1_features/latest_version_features/posting_a_job.feature
@@ -3,7 +3,7 @@ Feature: Posting a job
   Scenario: Job is posted successfully
 
     Given the search api is working correctly
-    Given the api version is v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I POST "/jobs"
     """
     """

--- a/features/v1_features/latest_version_features/posting_a_task.feature
+++ b/features/v1_features/latest_version_features/posting_a_task.feature
@@ -5,7 +5,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
@@ -24,7 +24,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And the search reindex api loses its connection to mongo DB
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -37,7 +37,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
@@ -64,7 +64,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -75,7 +75,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 0 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 0
     And I POST "/jobs/any-job-id/tasks"
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
@@ -86,7 +86,7 @@ Feature: Posting a task
 
     Given I am not authorised
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -98,7 +98,7 @@ Feature: Posting a task
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -111,7 +111,7 @@ Feature: Posting a task
     And I am identified as "someone@somewhere.com"
     And zebedee recognises the user token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -124,7 +124,7 @@ Feature: Posting a task
     And I am not identified by zebedee
     And zebedee does not recognise the user token
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29
@@ -136,7 +136,7 @@ Feature: Posting a task
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
-    And I have generated 1 jobs in the Job Store
+    And the number of existing jobs in the Job Store is 1
     And I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "florence", "number_of_documents": 29 }

--- a/features/v1_features/latest_version_features/posting_a_task.feature
+++ b/features/v1_features/latest_version_features/posting_a_task.feature
@@ -4,7 +4,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -23,7 +23,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And the search reindex api loses its connection to mongo DB
     When I call POST /jobs/{id}/tasks using the generated id
@@ -36,7 +36,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -63,7 +63,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -74,7 +74,7 @@ Feature: Posting a task
   Scenario: Job does not exist and an attempt to create a task for it returns a not found error
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 0 jobs in the Job Store
     And I POST "/jobs/any-job-id/tasks"
     """
@@ -85,7 +85,7 @@ Feature: Posting a task
   Scenario: No authorisation header set returns a bad request error
 
     Given I am not authorised
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """
@@ -97,7 +97,7 @@ Feature: Posting a task
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -110,7 +110,7 @@ Feature: Posting a task
     Given I use an X Florence user token "validXFlorenceToken"
     And I am identified as "someone@somewhere.com"
     And zebedee recognises the user token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -123,7 +123,7 @@ Feature: Posting a task
     Given I use an X Florence user token "invalidXFlorenceToken"
     And I am not identified by zebedee
     And zebedee does not recognise the user token
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
     """
@@ -135,7 +135,7 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
     """

--- a/features/v1_features/latest_version_features/posting_a_task.feature
+++ b/features/v1_features/latest_version_features/posting_a_task.feature
@@ -4,7 +4,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -24,7 +23,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And the search reindex api loses its connection to mongo DB
@@ -38,7 +36,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -66,7 +63,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -78,7 +74,6 @@ Feature: Posting a task
   Scenario: Job does not exist and an attempt to create a task for it returns a not found error
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 0 jobs in the Job Store
     And I POST "/jobs/any-job-id/tasks"
@@ -90,7 +85,6 @@ Feature: Posting a task
   Scenario: No authorisation header set returns a bad request error
 
     Given I am not authorised
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id
@@ -103,7 +97,6 @@ Feature: Posting a task
 
     Given I use a service auth token "invalidServiceAuthToken"
     And zebedee does not recognise the service auth token
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -117,7 +110,6 @@ Feature: Posting a task
     Given I use an X Florence user token "validXFlorenceToken"
     And I am identified as "someone@somewhere.com"
     And zebedee recognises the user token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -131,7 +123,6 @@ Feature: Posting a task
     Given I use an X Florence user token "invalidXFlorenceToken"
     And I am not identified by zebedee
     And zebedee does not recognise the user token
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     When I call POST /jobs/{id}/tasks using the generated id
@@ -144,7 +135,6 @@ Feature: Posting a task
 
     Given I use a service auth token "validServiceAuthToken"
     And zebedee recognises the service auth token as valid
-    And the search api is working correctly
     And set the api version to v1 for incoming requests
     And I have generated 1 jobs in the Job Store
     And I call POST /jobs/{id}/tasks using the generated id

--- a/features/v1_features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/v1_features/latest_version_features/putting_number_of_tasks.feature
@@ -2,7 +2,7 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: Job exists in the Job Store and a put request updates its number of tasks successfully
 
-    Given I have generated 1 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 1
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
     Then the HTTP status code should be "200"
@@ -12,21 +12,21 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: Job does not exist in the Job Store and a put request, to update its number of tasks, returns StatusNotFound
 
-    Given I have generated 0 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: A put request fails to update the number of tasks because it contains an invalid value of count
 
-    Given I have generated 1 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 1
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"seven"} using the generated id with an invalid count
     Then the HTTP status code should be "400"
 
   Scenario: A put request fails to update the number of tasks because it contains a negative value of count
 
-    Given I have generated 1 jobs in the Job Store
+    Given the number of existing jobs in the Job Store is 1
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"-7"} using the generated id with a negative count
     Then the HTTP status code should be "400"

--- a/features/v1_features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/v1_features/latest_version_features/putting_number_of_tasks.feature
@@ -3,7 +3,7 @@ Feature: Updating the number of tasks for a particular job
   Scenario: Job exists in the Job Store and a put request updates its number of tasks successfully
 
     Given I have generated 1 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
     Then the HTTP status code should be "200"
     Given I call GET /jobs/{id} using the generated id
@@ -13,27 +13,27 @@ Feature: Updating the number of tasks for a particular job
   Scenario: Job does not exist in the Job Store and a put request, to update its number of tasks, returns StatusNotFound
 
     Given I have generated 0 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "404"
 
   Scenario: A put request fails to update the number of tasks because it contains an invalid value of count
 
     Given I have generated 1 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"seven"} using the generated id with an invalid count
     Then the HTTP status code should be "400"
 
   Scenario: A put request fails to update the number of tasks because it contains a negative value of count
 
     Given I have generated 1 jobs in the Job Store
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"-7"} using the generated id with a negative count
     Then the HTTP status code should be "400"
 
   Scenario: The connection to mongo DB is lost and a put request returns an internal server error
 
     Given the search reindex api loses its connection to mongo DB
-    And set the api version to v1 for incoming requests
+    And the api version is v1 for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "500"

--- a/features/v1_features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/v1_features/latest_version_features/putting_number_of_tasks.feature
@@ -2,8 +2,7 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: Job exists in the Job Store and a put request updates its number of tasks successfully
 
-    Given the search api is working correctly
-    And I have generated 1 jobs in the Job Store
+    Given I have generated 1 jobs in the Job Store
     And set the api version to v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
     Then the HTTP status code should be "200"
@@ -20,16 +19,14 @@ Feature: Updating the number of tasks for a particular job
 
   Scenario: A put request fails to update the number of tasks because it contains an invalid value of count
 
-    Given the search api is working correctly
-    And I have generated 1 jobs in the Job Store
+    Given I have generated 1 jobs in the Job Store
     And set the api version to v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"seven"} using the generated id with an invalid count
     Then the HTTP status code should be "400"
 
   Scenario: A put request fails to update the number of tasks because it contains a negative value of count
 
-    Given the search api is working correctly
-    And I have generated 1 jobs in the Job Store
+    Given I have generated 1 jobs in the Job Store
     And set the api version to v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"-7"} using the generated id with a negative count
     Then the HTTP status code should be "400"


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Remove the step `the search api is working correctly` in all the other features except for the `posting_a_job.feature`
- This is because the Search API is only used in the `CreateJob` handler and not in any of the others
- This was achieved by using the mongo client within the component test rather than doing a `POST /jobs` request within the component test to generate jobs in the datastore (`mongo`). 
- This makes it more performant as it is now only doing the create job in `mongo` when asked whereas the component test would have previously done the `POST /jobs` which would do additional processes such as creating an index and getting the index name which was not needed
- This also simplifies and removes code that reads the HTTP response body from those calls which is no longer required 

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the tests pass

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone