### PR TITLE
Remove unnecessary conversions

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -220,10 +219,7 @@ func (api *API) PutNumTasksHandler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, apierrors.ErrInvalidNumTasks.Error(), http.StatusBadRequest)
 		return
 	}
-
-	floatNumTasks := float64(numTasks)
-	isNegative := math.Signbit(floatNumTasks)
-	if isNegative {
+	if numTasks < 0 {
 		err = errors.New("the count is negative")
 	}
 	if err != nil {


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
PutNumTasksHandler
- Instead of converting numTasks to float and using math.Signbit, it now uses `if numTasks <0 {`

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct. Also call the PUT `jobs/<job id from created job>/number_of_tasks/<numTasks>` endpoint:
Need to run:
- docker-compose up -d (for Mongo, ES, and kafka)
- vault server -dev
- zebedee (./run.sh)
- search api (with ES port 11200)
- search reindex api

Then run the following curl commands:
To create a new job
`curl -X POST http://localhost:25700/jobs | jq`

To get that particular job and see that number_of_tasks is currently zero:
`curl -s http://localhost:25700/jobs/<job id from created job> | jq`

To change the number of tasks to 3 using the amended PutNumTasksHandler function:
`curl -X PUT http://localhost:25700/jobs/<job id from created job>/number_of_tasks/3`

To get that particular job and see that number_of_tasks is now 3:
`curl -s http://localhost:25700/jobs/<job id from created job> | jq`

To check what happens if you try to set the number of tasks to a negative value:
`curl -X PUT http://localhost:25700/jobs/<job id from created job>/number_of_tasks/-3`

You should see the following message is returned:
"number of tasks must be a positive integer"

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
