### PR TITLE
refactor `CreateJob` data layer

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,15 +1,19 @@
-# The nancy command has found a vulnerability, which is an out of date version of GoGo Protobuf. However, this cannot be updated due to the project also having an indirect dependency of something called
-# scram; the latest version of scram has a new path in github, which also needs to be changed (instead of http://github.com/xdg/scram it is now http://github.com/xdg-go/scram I believe). The problem is 
-# that if I manually amend this path and version in the go.sum file then it reverts back when I try to commit and push the code (so it won't let me update GoGo Protobuf either). So I need to update the
-# dependency that is actually using scram directly. That dependency is actually mongo-driver, which itself is a dependency in dp-component-test, which is a dependency in this project. But on further
-# investigation it turns out that mongo-driver itself does not have the latest version of scram. So this build cannot be fixed until a new version of mongo-driver is released and then dp-component-test
-# is updated with it. Here's the issue: https://jira.mongodb.org/projects/GODRIVER/issues/GODRIVER-1935?filter=allissues
-CVE-2021-3121
-CVE-2020-26160 # No upgrade path for github.com/dgrijalva/jwt-go. See: https://ossindex.sonatype.org/vulnerability/c16fb56d-9de6-4065-9fca-d2b4cfb13020?component-type=golang&component-name=github.com%2Fdgrijalva%2Fjwt-go&utm_source=nancy-client&utm_medium=integration&utm_content=0.0.0-dev
+# Skip for indirect dependency github.com/gorilla/sessions@v1.2.1
+# Used by github.com/gorilla/mux v1.8.0
+# For more info: https://ossindex.sonatype.org/vulnerability/sonatype-2021-4899?component-type=golang&component-name=github.com%2Fgorilla%2Fsessions&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33
+sonatype-2021-4899
 
-# Skip for indirect dependency golang/github.com/coreos/etcd@3.3.13
-# Used by github.com/ONSdigital/dp-component-test v0.7.0
-# For more info: https://ossindex.sonatype.org/vulnerability/bba60acb-c7b5-4621-af69-f4085a8301d0?component-type=golang&component-name=github.com%2Fcoreos%2Fetcd&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.17
-CVE-2020-15114
-CVE-2020-15136
-CVE-2020-15115
+# Skip for indirect dependency github.com/hashicorp/consul/api@v1.1.0 and github.com/hashicorp/consul/sdk@v0.1.1
+# Used by github.com/cucumber/godog v0.12.5
+# For more info: https://ossindex.sonatype.org/vulnerability/CVE-2022-29153?component-type=golang&component-name=github.com%2Fhashicorp%2Fconsul%2Fapi&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33
+CVE-2022-29153
+
+# Skip for indirect dependency github.com/miekg/dns@v1.0.14
+# Used by github.com/cucumber/godog v0.12.5
+# For more info: https://ossindex.sonatype.org/vulnerability/sonatype-2021-1401?component-type=golang&component-name=github.com%2Fmiekg%2Fdns&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33
+sonatype-2021-1401
+
+# Skip for indirect dependency github.com/prometheus/client_golang@v0.9.3
+# Used by github.com/cucumber/godog v0.12.5
+# For more info: https://ossindex.sonatype.org/vulnerability/CVE-2022-21698?component-type=golang&component-name=github.com%2Fprometheus%2Fclient_golang&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33
+CVE-2022-21698

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -19,8 +19,8 @@ import (
 // DataStorer is an interface for a type that can store and retrieve jobs
 type DataStorer interface {
 	AcquireJobLock(ctx context.Context, id string) (lockID string, err error)
-	CheckNewReindexCanBeCreated(ctx context.Context) error
-	CreateJob(ctx context.Context, searchIndexName string) (job *models.Job, err error)
+	CheckInProgressJob(ctx context.Context) error
+	CreateJob(ctx context.Context, job models.Job) error
 	CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (task models.Task, err error)
 	GetJob(ctx context.Context, id string) (job models.Job, err error)
 	GetJobs(ctx context.Context, options mongo.Options) (job models.Jobs, err error)
@@ -29,6 +29,7 @@ type DataStorer interface {
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	UnlockJob(ctx context.Context, lockID string)
 	UpdateJob(ctx context.Context, id string, updates bson.M) error
+	ValidateJobIDUnique(ctx context.Context, id string) error
 }
 
 // Paginator defines the required methods from the paginator package

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -29,7 +29,6 @@ type DataStorer interface {
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	UnlockJob(ctx context.Context, lockID string)
 	UpdateJob(ctx context.Context, id string, updates bson.M) error
-	ValidateJobIDUnique(ctx context.Context, id string) error
 }
 
 // Paginator defines the required methods from the paginator package

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -36,7 +36,7 @@ func (api *API) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 	log.Info(ctx, "starting post operation of reindex job")
 
 	// check if a new reindex job can be created
-	err := api.dataStore.CheckNewReindexCanBeCreated(ctx)
+	err := api.dataStore.CheckInProgressJob(ctx)
 	if err != nil {
 		log.Error(ctx, "error occurred when checking to create a new reindex job", err)
 
@@ -72,10 +72,28 @@ func (api *API) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// create a reindex job in the datastore with the search index name
-	newJob, err := api.dataStore.CreateJob(ctx, indexName)
+	// create a new job
+	newJob, err := models.NewJob(ctx, indexName)
 	if err != nil {
-		logData["search_index_name"] = indexName
+		logData["index_name"] = indexName
+		log.Error(ctx, "failed to create new job", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	// checks if there exists a reindex job with the same id as the new job in the datastore
+	err = api.dataStore.ValidateJobIDUnique(ctx, newJob.ID)
+	if err != nil {
+		logData["jobID"] = newJob.ID
+		log.Error(ctx, "failed to validate job id is unique", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	// insert new job in the datastore
+	err = api.dataStore.CreateJob(ctx, *newJob)
+	if err != nil {
+		logData["new_job"] = newJob
 		log.Error(ctx, "failed to create reindex job", err, logData)
 		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 		return

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -81,15 +81,6 @@ func (api *API) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// checks if there exists a reindex job with the same id as the new job in the datastore
-	err = api.dataStore.ValidateJobIDUnique(ctx, newJob.ID)
-	if err != nil {
-		logData["jobID"] = newJob.ID
-		log.Error(ctx, "failed to validate job id is unique", err, logData)
-		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
-		return
-	}
-
 	// insert new job in the datastore
 	err = api.dataStore.CreateJob(ctx, *newJob)
 	if err != nil {

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -96,9 +96,6 @@ func TestCreateJobHandler(t *testing.T) {
 		CheckInProgressJobFunc: func(ctx context.Context) error {
 			return nil
 		},
-		ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
-			return nil
-		},
 		CreateJobFunc: func(ctx context.Context, job models.Job) error {
 			return nil
 		},
@@ -307,41 +304,9 @@ func TestCreateJobHandler(t *testing.T) {
 		})
 	})
 
-	Convey("Given the job ID is not unique for the new job", t, func() {
-		createJobDataStorerFailMock := &apiMock.DataStorerMock{
-			CheckInProgressJobFunc: func(ctx context.Context) error {
-				return nil
-			},
-			ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
-				return mongo.ErrDuplicateIDProvided
-			},
-		}
-
-		apiInstance := api.Setup(mux.NewRouter(), createJobDataStorerFailMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, dpHTTP.NewClient(), indexerMock, producerMock)
-
-		Convey("When the POST /jobs endpoint is called to create and store a new reindex job", func() {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost:25700/jobs", nil)
-			resp := httptest.NewRecorder()
-
-			apiInstance.CreateJobHandler(resp, req)
-
-			Convey("Then the response should return a 500 status code", func() {
-				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
-
-				Convey("And an error message should be returned in the response body", func() {
-					errMsg := strings.TrimSpace(resp.Body.String())
-					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
-				})
-			})
-		})
-	})
-
 	Convey("Given an error to create a reindex job in the datastore", t, func() {
 		createJobDataStorerFailMock := &apiMock.DataStorerMock{
 			CheckInProgressJobFunc: func(ctx context.Context) error {
-				return nil
-			},
-			ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
 				return nil
 			},
 			CreateJobFunc: func(ctx context.Context, job models.Job) error {

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -13,18 +13,17 @@ import (
 )
 
 var (
-	lockDataStorerMockAcquireJobLock      sync.RWMutex
-	lockDataStorerMockCheckInProgressJob  sync.RWMutex
-	lockDataStorerMockCreateJob           sync.RWMutex
-	lockDataStorerMockCreateTask          sync.RWMutex
-	lockDataStorerMockGetJob              sync.RWMutex
-	lockDataStorerMockGetJobs             sync.RWMutex
-	lockDataStorerMockGetTask             sync.RWMutex
-	lockDataStorerMockGetTasks            sync.RWMutex
-	lockDataStorerMockPutNumberOfTasks    sync.RWMutex
-	lockDataStorerMockUnlockJob           sync.RWMutex
-	lockDataStorerMockUpdateJob           sync.RWMutex
-	lockDataStorerMockValidateJobIDUnique sync.RWMutex
+	lockDataStorerMockAcquireJobLock     sync.RWMutex
+	lockDataStorerMockCheckInProgressJob sync.RWMutex
+	lockDataStorerMockCreateJob          sync.RWMutex
+	lockDataStorerMockCreateTask         sync.RWMutex
+	lockDataStorerMockGetJob             sync.RWMutex
+	lockDataStorerMockGetJobs            sync.RWMutex
+	lockDataStorerMockGetTask            sync.RWMutex
+	lockDataStorerMockGetTasks           sync.RWMutex
+	lockDataStorerMockPutNumberOfTasks   sync.RWMutex
+	lockDataStorerMockUnlockJob          sync.RWMutex
+	lockDataStorerMockUpdateJob          sync.RWMutex
 )
 
 // Ensure, that DataStorerMock does implement DataStorer.
@@ -70,9 +69,6 @@ var _ api.DataStorer = &DataStorerMock{}
 //             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
 // 	               panic("mock out the UpdateJob method")
 //             },
-//             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
-// 	               panic("mock out the ValidateJobIDUnique method")
-//             },
 //         }
 //
 //         // use mockedDataStorer in code that requires api.DataStorer
@@ -112,9 +108,6 @@ type DataStorerMock struct {
 
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
-
-	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
-	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -204,13 +197,6 @@ type DataStorerMock struct {
 			ID string
 			// Updates is the updates argument value.
 			Updates bson.M
-		}
-		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
-		ValidateJobIDUnique []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ID is the id argument value.
-			ID string
 		}
 	}
 }
@@ -617,40 +603,5 @@ func (mock *DataStorerMock) UpdateJobCalls() []struct {
 	lockDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
 	lockDataStorerMockUpdateJob.RUnlock()
-	return calls
-}
-
-// ValidateJobIDUnique calls ValidateJobIDUniqueFunc.
-func (mock *DataStorerMock) ValidateJobIDUnique(ctx context.Context, id string) error {
-	if mock.ValidateJobIDUniqueFunc == nil {
-		panic("DataStorerMock.ValidateJobIDUniqueFunc: method is nil but DataStorer.ValidateJobIDUnique was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-		ID  string
-	}{
-		Ctx: ctx,
-		ID:  id,
-	}
-	lockDataStorerMockValidateJobIDUnique.Lock()
-	mock.calls.ValidateJobIDUnique = append(mock.calls.ValidateJobIDUnique, callInfo)
-	lockDataStorerMockValidateJobIDUnique.Unlock()
-	return mock.ValidateJobIDUniqueFunc(ctx, id)
-}
-
-// ValidateJobIDUniqueCalls gets all the calls that were made to ValidateJobIDUnique.
-// Check the length with:
-//     len(mockedDataStorer.ValidateJobIDUniqueCalls())
-func (mock *DataStorerMock) ValidateJobIDUniqueCalls() []struct {
-	Ctx context.Context
-	ID  string
-} {
-	var calls []struct {
-		Ctx context.Context
-		ID  string
-	}
-	lockDataStorerMockValidateJobIDUnique.RLock()
-	calls = mock.calls.ValidateJobIDUnique
-	lockDataStorerMockValidateJobIDUnique.RUnlock()
 	return calls
 }

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -12,64 +12,82 @@ import (
 	"sync"
 )
 
-// Ensure, that DataStorerMock does implement api.DataStorer.
+var (
+	lockDataStorerMockAcquireJobLock      sync.RWMutex
+	lockDataStorerMockCheckInProgressJob  sync.RWMutex
+	lockDataStorerMockCreateJob           sync.RWMutex
+	lockDataStorerMockCreateTask          sync.RWMutex
+	lockDataStorerMockGetJob              sync.RWMutex
+	lockDataStorerMockGetJobs             sync.RWMutex
+	lockDataStorerMockGetTask             sync.RWMutex
+	lockDataStorerMockGetTasks            sync.RWMutex
+	lockDataStorerMockPutNumberOfTasks    sync.RWMutex
+	lockDataStorerMockUnlockJob           sync.RWMutex
+	lockDataStorerMockUpdateJob           sync.RWMutex
+	lockDataStorerMockValidateJobIDUnique sync.RWMutex
+)
+
+// Ensure, that DataStorerMock does implement DataStorer.
 // If this is not the case, regenerate this file with moq.
 var _ api.DataStorer = &DataStorerMock{}
 
 // DataStorerMock is a mock implementation of api.DataStorer.
 //
-// 	func TestSomethingThatUsesDataStorer(t *testing.T) {
+//     func TestSomethingThatUsesDataStorer(t *testing.T) {
 //
-// 		// make and configure a mocked api.DataStorer
-// 		mockedDataStorer := &DataStorerMock{
-// 			AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
-// 				panic("mock out the AcquireJobLock method")
-// 			},
-// 			CheckNewReindexCanBeCreatedFunc: func(ctx context.Context) error {
-// 				panic("mock out the CheckNewReindexCanBeCreated method")
-// 			},
-// 			CreateJobFunc: func(ctx context.Context, searchIndexName string) (*models.Job, error) {
-// 				panic("mock out the CreateJob method")
-// 			},
-// 			CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-// 				panic("mock out the CreateTask method")
-// 			},
-// 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
-// 				panic("mock out the GetJob method")
-// 			},
-// 			GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
-// 				panic("mock out the GetJobs method")
-// 			},
-// 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
-// 				panic("mock out the GetTask method")
-// 			},
-// 			GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
-// 				panic("mock out the GetTasks method")
-// 			},
-// 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
-// 				panic("mock out the PutNumberOfTasks method")
-// 			},
-// 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
-// 				panic("mock out the UnlockJob method")
-// 			},
-// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
-// 				panic("mock out the UpdateJob method")
-// 			},
-// 		}
+//         // make and configure a mocked api.DataStorer
+//         mockedDataStorer := &DataStorerMock{
+//             AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+// 	               panic("mock out the AcquireJobLock method")
+//             },
+//             CheckInProgressJobFunc: func(ctx context.Context) error {
+// 	               panic("mock out the CheckInProgressJob method")
+//             },
+//             CreateJobFunc: func(ctx context.Context, job models.Job) error {
+// 	               panic("mock out the CreateJob method")
+//             },
+//             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
+// 	               panic("mock out the CreateTask method")
+//             },
+//             GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
+// 	               panic("mock out the GetJob method")
+//             },
+//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+// 	               panic("mock out the GetJobs method")
+//             },
+//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+// 	               panic("mock out the GetTask method")
+//             },
+//             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+// 	               panic("mock out the GetTasks method")
+//             },
+//             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
+// 	               panic("mock out the PutNumberOfTasks method")
+//             },
+//             UnlockJobFunc: func(ctx context.Context, lockID string)  {
+// 	               panic("mock out the UnlockJob method")
+//             },
+//             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 	               panic("mock out the UpdateJob method")
+//             },
+//             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
+// 	               panic("mock out the ValidateJobIDUnique method")
+//             },
+//         }
 //
-// 		// use mockedDataStorer in code that requires api.DataStorer
-// 		// and then make assertions.
+//         // use mockedDataStorer in code that requires api.DataStorer
+//         // and then make assertions.
 //
-// 	}
+//     }
 type DataStorerMock struct {
 	// AcquireJobLockFunc mocks the AcquireJobLock method.
 	AcquireJobLockFunc func(ctx context.Context, id string) (string, error)
 
-	// CheckNewReindexCanBeCreatedFunc mocks the CheckNewReindexCanBeCreated method.
-	CheckNewReindexCanBeCreatedFunc func(ctx context.Context) error
+	// CheckInProgressJobFunc mocks the CheckInProgressJob method.
+	CheckInProgressJobFunc func(ctx context.Context) error
 
 	// CreateJobFunc mocks the CreateJob method.
-	CreateJobFunc func(ctx context.Context, searchIndexName string) (*models.Job, error)
+	CreateJobFunc func(ctx context.Context, job models.Job) error
 
 	// CreateTaskFunc mocks the CreateTask method.
 	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
@@ -95,6 +113,9 @@ type DataStorerMock struct {
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
 
+	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
+	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// AcquireJobLock holds details about calls to the AcquireJobLock method.
@@ -104,8 +125,8 @@ type DataStorerMock struct {
 			// ID is the id argument value.
 			ID string
 		}
-		// CheckNewReindexCanBeCreated holds details about calls to the CheckNewReindexCanBeCreated method.
-		CheckNewReindexCanBeCreated []struct {
+		// CheckInProgressJob holds details about calls to the CheckInProgressJob method.
+		CheckInProgressJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -113,8 +134,8 @@ type DataStorerMock struct {
 		CreateJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// SearchIndexName is the searchIndexName argument value.
-			SearchIndexName string
+			// Job is the job argument value.
+			Job models.Job
 		}
 		// CreateTask holds details about calls to the CreateTask method.
 		CreateTask []struct {
@@ -184,18 +205,14 @@ type DataStorerMock struct {
 			// Updates is the updates argument value.
 			Updates bson.M
 		}
+		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
+		ValidateJobIDUnique []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+		}
 	}
-	lockAcquireJobLock              sync.RWMutex
-	lockCheckNewReindexCanBeCreated sync.RWMutex
-	lockCreateJob                   sync.RWMutex
-	lockCreateTask                  sync.RWMutex
-	lockGetJob                      sync.RWMutex
-	lockGetJobs                     sync.RWMutex
-	lockGetTask                     sync.RWMutex
-	lockGetTasks                    sync.RWMutex
-	lockPutNumberOfTasks            sync.RWMutex
-	lockUnlockJob                   sync.RWMutex
-	lockUpdateJob                   sync.RWMutex
 }
 
 // AcquireJobLock calls AcquireJobLockFunc.
@@ -210,9 +227,9 @@ func (mock *DataStorerMock) AcquireJobLock(ctx context.Context, id string) (stri
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockAcquireJobLock.Lock()
+	lockDataStorerMockAcquireJobLock.Lock()
 	mock.calls.AcquireJobLock = append(mock.calls.AcquireJobLock, callInfo)
-	mock.lockAcquireJobLock.Unlock()
+	lockDataStorerMockAcquireJobLock.Unlock()
 	return mock.AcquireJobLockFunc(ctx, id)
 }
 
@@ -227,75 +244,75 @@ func (mock *DataStorerMock) AcquireJobLockCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockAcquireJobLock.RLock()
+	lockDataStorerMockAcquireJobLock.RLock()
 	calls = mock.calls.AcquireJobLock
-	mock.lockAcquireJobLock.RUnlock()
+	lockDataStorerMockAcquireJobLock.RUnlock()
 	return calls
 }
 
-// CheckNewReindexCanBeCreated calls CheckNewReindexCanBeCreatedFunc.
-func (mock *DataStorerMock) CheckNewReindexCanBeCreated(ctx context.Context) error {
-	if mock.CheckNewReindexCanBeCreatedFunc == nil {
-		panic("DataStorerMock.CheckNewReindexCanBeCreatedFunc: method is nil but DataStorer.CheckNewReindexCanBeCreated was just called")
+// CheckInProgressJob calls CheckInProgressJobFunc.
+func (mock *DataStorerMock) CheckInProgressJob(ctx context.Context) error {
+	if mock.CheckInProgressJobFunc == nil {
+		panic("DataStorerMock.CheckInProgressJobFunc: method is nil but DataStorer.CheckInProgressJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 	}{
 		Ctx: ctx,
 	}
-	mock.lockCheckNewReindexCanBeCreated.Lock()
-	mock.calls.CheckNewReindexCanBeCreated = append(mock.calls.CheckNewReindexCanBeCreated, callInfo)
-	mock.lockCheckNewReindexCanBeCreated.Unlock()
-	return mock.CheckNewReindexCanBeCreatedFunc(ctx)
+	lockDataStorerMockCheckInProgressJob.Lock()
+	mock.calls.CheckInProgressJob = append(mock.calls.CheckInProgressJob, callInfo)
+	lockDataStorerMockCheckInProgressJob.Unlock()
+	return mock.CheckInProgressJobFunc(ctx)
 }
 
-// CheckNewReindexCanBeCreatedCalls gets all the calls that were made to CheckNewReindexCanBeCreated.
+// CheckInProgressJobCalls gets all the calls that were made to CheckInProgressJob.
 // Check the length with:
-//     len(mockedDataStorer.CheckNewReindexCanBeCreatedCalls())
-func (mock *DataStorerMock) CheckNewReindexCanBeCreatedCalls() []struct {
+//     len(mockedDataStorer.CheckInProgressJobCalls())
+func (mock *DataStorerMock) CheckInProgressJobCalls() []struct {
 	Ctx context.Context
 } {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockCheckNewReindexCanBeCreated.RLock()
-	calls = mock.calls.CheckNewReindexCanBeCreated
-	mock.lockCheckNewReindexCanBeCreated.RUnlock()
+	lockDataStorerMockCheckInProgressJob.RLock()
+	calls = mock.calls.CheckInProgressJob
+	lockDataStorerMockCheckInProgressJob.RUnlock()
 	return calls
 }
 
 // CreateJob calls CreateJobFunc.
-func (mock *DataStorerMock) CreateJob(ctx context.Context, searchIndexName string) (*models.Job, error) {
+func (mock *DataStorerMock) CreateJob(ctx context.Context, job models.Job) error {
 	if mock.CreateJobFunc == nil {
 		panic("DataStorerMock.CreateJobFunc: method is nil but DataStorer.CreateJob was just called")
 	}
 	callInfo := struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}{
-		Ctx:             ctx,
-		SearchIndexName: searchIndexName,
+		Ctx: ctx,
+		Job: job,
 	}
-	mock.lockCreateJob.Lock()
+	lockDataStorerMockCreateJob.Lock()
 	mock.calls.CreateJob = append(mock.calls.CreateJob, callInfo)
-	mock.lockCreateJob.Unlock()
-	return mock.CreateJobFunc(ctx, searchIndexName)
+	lockDataStorerMockCreateJob.Unlock()
+	return mock.CreateJobFunc(ctx, job)
 }
 
 // CreateJobCalls gets all the calls that were made to CreateJob.
 // Check the length with:
 //     len(mockedDataStorer.CreateJobCalls())
 func (mock *DataStorerMock) CreateJobCalls() []struct {
-	Ctx             context.Context
-	SearchIndexName string
+	Ctx context.Context
+	Job models.Job
 } {
 	var calls []struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}
-	mock.lockCreateJob.RLock()
+	lockDataStorerMockCreateJob.RLock()
 	calls = mock.calls.CreateJob
-	mock.lockCreateJob.RUnlock()
+	lockDataStorerMockCreateJob.RUnlock()
 	return calls
 }
 
@@ -315,9 +332,9 @@ func (mock *DataStorerMock) CreateTask(ctx context.Context, jobID string, taskNa
 		TaskName:     taskName,
 		NumDocuments: numDocuments,
 	}
-	mock.lockCreateTask.Lock()
+	lockDataStorerMockCreateTask.Lock()
 	mock.calls.CreateTask = append(mock.calls.CreateTask, callInfo)
-	mock.lockCreateTask.Unlock()
+	lockDataStorerMockCreateTask.Unlock()
 	return mock.CreateTaskFunc(ctx, jobID, taskName, numDocuments)
 }
 
@@ -336,9 +353,9 @@ func (mock *DataStorerMock) CreateTaskCalls() []struct {
 		TaskName     string
 		NumDocuments int
 	}
-	mock.lockCreateTask.RLock()
+	lockDataStorerMockCreateTask.RLock()
 	calls = mock.calls.CreateTask
-	mock.lockCreateTask.RUnlock()
+	lockDataStorerMockCreateTask.RUnlock()
 	return calls
 }
 
@@ -354,9 +371,9 @@ func (mock *DataStorerMock) GetJob(ctx context.Context, id string) (models.Job, 
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockGetJob.Lock()
+	lockDataStorerMockGetJob.Lock()
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
-	mock.lockGetJob.Unlock()
+	lockDataStorerMockGetJob.Unlock()
 	return mock.GetJobFunc(ctx, id)
 }
 
@@ -371,9 +388,9 @@ func (mock *DataStorerMock) GetJobCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockGetJob.RLock()
+	lockDataStorerMockGetJob.RLock()
 	calls = mock.calls.GetJob
-	mock.lockGetJob.RUnlock()
+	lockDataStorerMockGetJob.RUnlock()
 	return calls
 }
 
@@ -389,9 +406,9 @@ func (mock *DataStorerMock) GetJobs(ctx context.Context, options mongo.Options) 
 		Ctx:     ctx,
 		Options: options,
 	}
-	mock.lockGetJobs.Lock()
+	lockDataStorerMockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	mock.lockGetJobs.Unlock()
+	lockDataStorerMockGetJobs.Unlock()
 	return mock.GetJobsFunc(ctx, options)
 }
 
@@ -406,9 +423,9 @@ func (mock *DataStorerMock) GetJobsCalls() []struct {
 		Ctx     context.Context
 		Options mongo.Options
 	}
-	mock.lockGetJobs.RLock()
+	lockDataStorerMockGetJobs.RLock()
 	calls = mock.calls.GetJobs
-	mock.lockGetJobs.RUnlock()
+	lockDataStorerMockGetJobs.RUnlock()
 	return calls
 }
 
@@ -426,9 +443,9 @@ func (mock *DataStorerMock) GetTask(ctx context.Context, jobID string, taskName 
 		JobID:    jobID,
 		TaskName: taskName,
 	}
-	mock.lockGetTask.Lock()
+	lockDataStorerMockGetTask.Lock()
 	mock.calls.GetTask = append(mock.calls.GetTask, callInfo)
-	mock.lockGetTask.Unlock()
+	lockDataStorerMockGetTask.Unlock()
 	return mock.GetTaskFunc(ctx, jobID, taskName)
 }
 
@@ -445,9 +462,9 @@ func (mock *DataStorerMock) GetTaskCalls() []struct {
 		JobID    string
 		TaskName string
 	}
-	mock.lockGetTask.RLock()
+	lockDataStorerMockGetTask.RLock()
 	calls = mock.calls.GetTask
-	mock.lockGetTask.RUnlock()
+	lockDataStorerMockGetTask.RUnlock()
 	return calls
 }
 
@@ -465,9 +482,9 @@ func (mock *DataStorerMock) GetTasks(ctx context.Context, options mongo.Options,
 		Options: options,
 		JobID:   jobID,
 	}
-	mock.lockGetTasks.Lock()
+	lockDataStorerMockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
-	mock.lockGetTasks.Unlock()
+	lockDataStorerMockGetTasks.Unlock()
 	return mock.GetTasksFunc(ctx, options, jobID)
 }
 
@@ -484,9 +501,9 @@ func (mock *DataStorerMock) GetTasksCalls() []struct {
 		Options mongo.Options
 		JobID   string
 	}
-	mock.lockGetTasks.RLock()
+	lockDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks
-	mock.lockGetTasks.RUnlock()
+	lockDataStorerMockGetTasks.RUnlock()
 	return calls
 }
 
@@ -504,9 +521,9 @@ func (mock *DataStorerMock) PutNumberOfTasks(ctx context.Context, id string, cou
 		ID:    id,
 		Count: count,
 	}
-	mock.lockPutNumberOfTasks.Lock()
+	lockDataStorerMockPutNumberOfTasks.Lock()
 	mock.calls.PutNumberOfTasks = append(mock.calls.PutNumberOfTasks, callInfo)
-	mock.lockPutNumberOfTasks.Unlock()
+	lockDataStorerMockPutNumberOfTasks.Unlock()
 	return mock.PutNumberOfTasksFunc(ctx, id, count)
 }
 
@@ -523,9 +540,9 @@ func (mock *DataStorerMock) PutNumberOfTasksCalls() []struct {
 		ID    string
 		Count int
 	}
-	mock.lockPutNumberOfTasks.RLock()
+	lockDataStorerMockPutNumberOfTasks.RLock()
 	calls = mock.calls.PutNumberOfTasks
-	mock.lockPutNumberOfTasks.RUnlock()
+	lockDataStorerMockPutNumberOfTasks.RUnlock()
 	return calls
 }
 
@@ -541,9 +558,9 @@ func (mock *DataStorerMock) UnlockJob(ctx context.Context, lockID string) {
 		Ctx:    ctx,
 		LockID: lockID,
 	}
-	mock.lockUnlockJob.Lock()
+	lockDataStorerMockUnlockJob.Lock()
 	mock.calls.UnlockJob = append(mock.calls.UnlockJob, callInfo)
-	mock.lockUnlockJob.Unlock()
+	lockDataStorerMockUnlockJob.Unlock()
 	mock.UnlockJobFunc(ctx, lockID)
 }
 
@@ -558,9 +575,9 @@ func (mock *DataStorerMock) UnlockJobCalls() []struct {
 		Ctx    context.Context
 		LockID string
 	}
-	mock.lockUnlockJob.RLock()
+	lockDataStorerMockUnlockJob.RLock()
 	calls = mock.calls.UnlockJob
-	mock.lockUnlockJob.RUnlock()
+	lockDataStorerMockUnlockJob.RUnlock()
 	return calls
 }
 
@@ -578,9 +595,9 @@ func (mock *DataStorerMock) UpdateJob(ctx context.Context, id string, updates bs
 		ID:      id,
 		Updates: updates,
 	}
-	mock.lockUpdateJob.Lock()
+	lockDataStorerMockUpdateJob.Lock()
 	mock.calls.UpdateJob = append(mock.calls.UpdateJob, callInfo)
-	mock.lockUpdateJob.Unlock()
+	lockDataStorerMockUpdateJob.Unlock()
 	return mock.UpdateJobFunc(ctx, id, updates)
 }
 
@@ -597,8 +614,43 @@ func (mock *DataStorerMock) UpdateJobCalls() []struct {
 		ID      string
 		Updates bson.M
 	}
-	mock.lockUpdateJob.RLock()
+	lockDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
-	mock.lockUpdateJob.RUnlock()
+	lockDataStorerMockUpdateJob.RUnlock()
+	return calls
+}
+
+// ValidateJobIDUnique calls ValidateJobIDUniqueFunc.
+func (mock *DataStorerMock) ValidateJobIDUnique(ctx context.Context, id string) error {
+	if mock.ValidateJobIDUniqueFunc == nil {
+		panic("DataStorerMock.ValidateJobIDUniqueFunc: method is nil but DataStorer.ValidateJobIDUnique was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  string
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	lockDataStorerMockValidateJobIDUnique.Lock()
+	mock.calls.ValidateJobIDUnique = append(mock.calls.ValidateJobIDUnique, callInfo)
+	lockDataStorerMockValidateJobIDUnique.Unlock()
+	return mock.ValidateJobIDUniqueFunc(ctx, id)
+}
+
+// ValidateJobIDUniqueCalls gets all the calls that were made to ValidateJobIDUnique.
+// Check the length with:
+//     len(mockedDataStorer.ValidateJobIDUniqueCalls())
+func (mock *DataStorerMock) ValidateJobIDUniqueCalls() []struct {
+	Ctx context.Context
+	ID  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  string
+	}
+	lockDataStorerMockValidateJobIDUnique.RLock()
+	calls = mock.calls.ValidateJobIDUnique
+	lockDataStorerMockValidateJobIDUnique.RUnlock()
 	return calls
 }

--- a/features/latest_version_features/posting_a_job.feature
+++ b/features/latest_version_features/posting_a_job.feature
@@ -39,6 +39,22 @@ Feature: Posting a job
     """
     existing reindex job in progress
     """
+
+  Scenario: Newly created job's ID is not unique
+
+    Given the search api is working correctly
+    And the api version is undefined for incoming requests
+    And the generated id for a new job is not going to be unique
+    And the number of existing jobs in the Job Store is 1
+    When I POST "/jobs"
+    """
+    """
+    Then the HTTP status code should be "500"
+    And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And I should receive the following response: 
+    """
+    internal server error
+    """
   
   Scenario: The connection to mongo DB is lost and a post request returns an internal server error
 

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -135,6 +135,7 @@ func runSearchReindexAPIFeature(ctx context.Context, f *SearchReindexAPIFeature,
 	serviceList := service.NewServiceList(initFunctions)
 	testIdentityClient := clientsidentity.New(cfg.ZebedeeURL)
 	testSearchClient := clientssitesearch.NewClient(cfg.SearchAPIURL)
+	models.NewJobID = models.JobUUID
 
 	f.svc, err = service.Run(ctx, cfg, serviceList, "1", "", "", svcErrors, testIdentityClient, taskNames, testSearchClient)
 	return err

--- a/features/steps/job_steps.go
+++ b/features/steps/job_steps.go
@@ -368,9 +368,14 @@ func (f *SearchReindexAPIFeature) theNoOfExistingJobsInTheJobStore(noOfJobs int)
 		var job *models.Job
 		for i := 1; i <= noOfJobs; i++ {
 			// create a job in mongo
-			job, err = f.MongoClient.CreateJob(ctx, "")
+			job, err = models.NewJob(ctx, "")
 			if err != nil {
-				return fmt.Errorf("failed to create job in mongo: %w", err)
+				return fmt.Errorf("failed to create new job: %w", err)
+			}
+
+			err = f.MongoClient.CreateJob(ctx, *job)
+			if err != nil {
+				return fmt.Errorf("failed to insert new job in mongo: %w", err)
 			}
 
 			if i <= noOfJobs {

--- a/features/steps/job_steps.go
+++ b/features/steps/job_steps.go
@@ -302,6 +302,15 @@ func (f *SearchReindexAPIFeature) inEachJobIWouldExpectTheResponseToContainValue
 	return f.ErrorFeature.StepError()
 }
 
+// theGeneratedIDForNewJobIsNotGoingToBeUnique is a feature step that ensures that a new job's id is not going to be unique
+func (f *SearchReindexAPIFeature) theGeneratedIDForNewJobIsNotGoingToBeUnique() error {
+	models.NewJobID = func() string {
+		return "same_id"
+	}
+
+	return f.ErrorFeature.StepError()
+}
+
 // theJobShouldOnlyBeUpdatedWithTheFollowingFieldsAndValues is a feature step that checks the updated job in mongo with the expected result given via table
 func (f *SearchReindexAPIFeature) theJobShouldOnlyBeUpdatedWithTheFollowingFieldsAndValues(table *godog.Table) error {
 	ctx := context.Background()

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -37,6 +37,7 @@ func (f *SearchReindexAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I have created a task for the generated job$`, f.iHaveCreatedATaskForTheGeneratedJob)
 	ctx.Step(`^I set the If-Match header to the generated e-tag$`, f.iSetIfMatchHeaderToTheGeneratedETag)
 	ctx.Step(`^I set the "If-Match" header to the old e-tag$`, f.iSetIfMatchHeaderToTheOldGeneratedETag)
+	ctx.Step(`^the generated id for a new job is not going to be unique$`, f.theGeneratedIDForNewJobIsNotGoingToBeUnique)
 	ctx.Step(`^the number of existing jobs in the Job Store is (\d+)$`, f.theNoOfExistingJobsInTheJobStore)
 
 	ctx.Step(`^I would expect the response to be an empty list$`, f.iWouldExpectTheResponseToBeAnEmptyList)

--- a/features/v1_features/latest_version_features/posting_a_job.feature
+++ b/features/v1_features/latest_version_features/posting_a_job.feature
@@ -39,6 +39,22 @@ Feature: Posting a job
     """
     existing reindex job in progress
     """
+
+  Scenario: Newly created job's ID is not unique
+
+    Given the search api is working correctly
+    And the api version is v1 for incoming requests
+    And the generated id for a new job is not going to be unique
+    And the number of existing jobs in the Job Store is 1
+    When I POST "/jobs"
+    """
+    """
+    Then the HTTP status code should be "500"
+    And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And I should receive the following response: 
+    """
+    internal server error
+    """
   
   Scenario: The connection to mongo DB is lost and a post request returns an internal server error
 

--- a/models/job.go
+++ b/models/job.go
@@ -61,9 +61,12 @@ type JobLinks struct {
 }
 
 // NewJobID returns a unique UUID for a job resource and this can be used to mock the ID in tests
-var NewJobID = func() string {
-	return uuid.NewV4().String()
-}
+var (
+	JobUUID = func() string {
+		return uuid.NewV4().String()
+	}
+	NewJobID = JobUUID
+)
 
 // NewJob returns a new Job resource that it creates and populates with default values.
 func NewJob(ctx context.Context, searchIndexName string) (*Job, error) {

--- a/models/job.go
+++ b/models/job.go
@@ -60,9 +60,14 @@ type JobLinks struct {
 	Self  string `json:"self"`
 }
 
+// NewJobID returns a unique UUID for a job resource and this can be used to mock the ID in tests
+var NewJobID = func() string {
+	return uuid.NewV4().String()
+}
+
 // NewJob returns a new Job resource that it creates and populates with default values.
 func NewJob(ctx context.Context, searchIndexName string) (*Job, error) {
-	id := uuid.NewV4().String()
+	id := NewJobID()
 	zeroTime := time.Time{}.UTC()
 
 	newJob := Job{

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -202,30 +202,3 @@ func (m *JobStore) UpdateJob(ctx context.Context, id string, updates bson.M) err
 
 	return nil
 }
-
-// ValidateJobIDUnique checks if there exists a reindex job in mongo with the given id
-func (m *JobStore) ValidateJobIDUnique(ctx context.Context, id string) error {
-	s := m.Session.Copy()
-	defer s.Close()
-
-	logData := log.Data{
-		"database":         m.Database,
-		"jobs_collections": m.JobsCollection,
-		"job_id":           id,
-	}
-
-	var jobToFind models.Job
-	err := s.DB(m.Database).C(m.JobsCollection).Find(bson.M{"_id": id}).One(&jobToFind)
-	if err != nil {
-		if err == mgo.ErrNotFound {
-			// success as none of the existing jobs have the given id
-			return nil
-		}
-		log.Error(ctx, "failed to check if given id is unique in mongo", err, logData)
-		return err
-	}
-
-	// if found then there exists an existing job with the given id
-	log.Error(ctx, "job id not unique", err, logData)
-	return ErrDuplicateIDProvided
-}

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -13,67 +13,87 @@ import (
 	"sync"
 )
 
-// Ensure, that MongoDataStorerMock does implement service.MongoDataStorer.
+var (
+	lockMongoDataStorerMockAcquireJobLock      sync.RWMutex
+	lockMongoDataStorerMockCheckInProgressJob  sync.RWMutex
+	lockMongoDataStorerMockChecker             sync.RWMutex
+	lockMongoDataStorerMockClose               sync.RWMutex
+	lockMongoDataStorerMockCreateJob           sync.RWMutex
+	lockMongoDataStorerMockCreateTask          sync.RWMutex
+	lockMongoDataStorerMockGetJob              sync.RWMutex
+	lockMongoDataStorerMockGetJobs             sync.RWMutex
+	lockMongoDataStorerMockGetTask             sync.RWMutex
+	lockMongoDataStorerMockGetTasks            sync.RWMutex
+	lockMongoDataStorerMockPutNumberOfTasks    sync.RWMutex
+	lockMongoDataStorerMockUnlockJob           sync.RWMutex
+	lockMongoDataStorerMockUpdateJob           sync.RWMutex
+	lockMongoDataStorerMockValidateJobIDUnique sync.RWMutex
+)
+
+// Ensure, that MongoDataStorerMock does implement MongoDataStorer.
 // If this is not the case, regenerate this file with moq.
 var _ service.MongoDataStorer = &MongoDataStorerMock{}
 
 // MongoDataStorerMock is a mock implementation of service.MongoDataStorer.
 //
-// 	func TestSomethingThatUsesMongoDataStorer(t *testing.T) {
+//     func TestSomethingThatUsesMongoDataStorer(t *testing.T) {
 //
-// 		// make and configure a mocked service.MongoDataStorer
-// 		mockedMongoDataStorer := &MongoDataStorerMock{
-// 			AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
-// 				panic("mock out the AcquireJobLock method")
-// 			},
-// 			CheckNewReindexCanBeCreatedFunc: func(ctx context.Context) error {
-// 				panic("mock out the CheckNewReindexCanBeCreated method")
-// 			},
-// 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
-// 				panic("mock out the Checker method")
-// 			},
-// 			CloseFunc: func(ctx context.Context) error {
-// 				panic("mock out the Close method")
-// 			},
-// 			CreateJobFunc: func(ctx context.Context, searchIndexName string) (*models.Job, error) {
-// 				panic("mock out the CreateJob method")
-// 			},
-// 			CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-// 				panic("mock out the CreateTask method")
-// 			},
-// 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
-// 				panic("mock out the GetJob method")
-// 			},
-// 			GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
-// 				panic("mock out the GetJobs method")
-// 			},
-// 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
-// 				panic("mock out the GetTask method")
-// 			},
-// 			GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
-// 				panic("mock out the GetTasks method")
-// 			},
-// 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
-// 				panic("mock out the PutNumberOfTasks method")
-// 			},
-// 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
-// 				panic("mock out the UnlockJob method")
-// 			},
-// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
-// 				panic("mock out the UpdateJob method")
-// 			},
-// 		}
+//         // make and configure a mocked service.MongoDataStorer
+//         mockedMongoDataStorer := &MongoDataStorerMock{
+//             AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+// 	               panic("mock out the AcquireJobLock method")
+//             },
+//             CheckInProgressJobFunc: func(ctx context.Context) error {
+// 	               panic("mock out the CheckInProgressJob method")
+//             },
+//             CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
+// 	               panic("mock out the Checker method")
+//             },
+//             CloseFunc: func(ctx context.Context) error {
+// 	               panic("mock out the Close method")
+//             },
+//             CreateJobFunc: func(ctx context.Context, job models.Job) error {
+// 	               panic("mock out the CreateJob method")
+//             },
+//             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
+// 	               panic("mock out the CreateTask method")
+//             },
+//             GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
+// 	               panic("mock out the GetJob method")
+//             },
+//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+// 	               panic("mock out the GetJobs method")
+//             },
+//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+// 	               panic("mock out the GetTask method")
+//             },
+//             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+// 	               panic("mock out the GetTasks method")
+//             },
+//             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
+// 	               panic("mock out the PutNumberOfTasks method")
+//             },
+//             UnlockJobFunc: func(ctx context.Context, lockID string)  {
+// 	               panic("mock out the UnlockJob method")
+//             },
+//             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 	               panic("mock out the UpdateJob method")
+//             },
+//             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
+// 	               panic("mock out the ValidateJobIDUnique method")
+//             },
+//         }
 //
-// 		// use mockedMongoDataStorer in code that requires service.MongoDataStorer
-// 		// and then make assertions.
+//         // use mockedMongoDataStorer in code that requires service.MongoDataStorer
+//         // and then make assertions.
 //
-// 	}
+//     }
 type MongoDataStorerMock struct {
 	// AcquireJobLockFunc mocks the AcquireJobLock method.
 	AcquireJobLockFunc func(ctx context.Context, id string) (string, error)
 
-	// CheckNewReindexCanBeCreatedFunc mocks the CheckNewReindexCanBeCreated method.
-	CheckNewReindexCanBeCreatedFunc func(ctx context.Context) error
+	// CheckInProgressJobFunc mocks the CheckInProgressJob method.
+	CheckInProgressJobFunc func(ctx context.Context) error
 
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *healthcheck.CheckState) error
@@ -82,7 +102,7 @@ type MongoDataStorerMock struct {
 	CloseFunc func(ctx context.Context) error
 
 	// CreateJobFunc mocks the CreateJob method.
-	CreateJobFunc func(ctx context.Context, searchIndexName string) (*models.Job, error)
+	CreateJobFunc func(ctx context.Context, job models.Job) error
 
 	// CreateTaskFunc mocks the CreateTask method.
 	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
@@ -108,6 +128,9 @@ type MongoDataStorerMock struct {
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
 
+	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
+	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// AcquireJobLock holds details about calls to the AcquireJobLock method.
@@ -117,8 +140,8 @@ type MongoDataStorerMock struct {
 			// ID is the id argument value.
 			ID string
 		}
-		// CheckNewReindexCanBeCreated holds details about calls to the CheckNewReindexCanBeCreated method.
-		CheckNewReindexCanBeCreated []struct {
+		// CheckInProgressJob holds details about calls to the CheckInProgressJob method.
+		CheckInProgressJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -138,8 +161,8 @@ type MongoDataStorerMock struct {
 		CreateJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// SearchIndexName is the searchIndexName argument value.
-			SearchIndexName string
+			// Job is the job argument value.
+			Job models.Job
 		}
 		// CreateTask holds details about calls to the CreateTask method.
 		CreateTask []struct {
@@ -209,20 +232,14 @@ type MongoDataStorerMock struct {
 			// Updates is the updates argument value.
 			Updates bson.M
 		}
+		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
+		ValidateJobIDUnique []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+		}
 	}
-	lockAcquireJobLock              sync.RWMutex
-	lockCheckNewReindexCanBeCreated sync.RWMutex
-	lockChecker                     sync.RWMutex
-	lockClose                       sync.RWMutex
-	lockCreateJob                   sync.RWMutex
-	lockCreateTask                  sync.RWMutex
-	lockGetJob                      sync.RWMutex
-	lockGetJobs                     sync.RWMutex
-	lockGetTask                     sync.RWMutex
-	lockGetTasks                    sync.RWMutex
-	lockPutNumberOfTasks            sync.RWMutex
-	lockUnlockJob                   sync.RWMutex
-	lockUpdateJob                   sync.RWMutex
 }
 
 // AcquireJobLock calls AcquireJobLockFunc.
@@ -237,9 +254,9 @@ func (mock *MongoDataStorerMock) AcquireJobLock(ctx context.Context, id string) 
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockAcquireJobLock.Lock()
+	lockMongoDataStorerMockAcquireJobLock.Lock()
 	mock.calls.AcquireJobLock = append(mock.calls.AcquireJobLock, callInfo)
-	mock.lockAcquireJobLock.Unlock()
+	lockMongoDataStorerMockAcquireJobLock.Unlock()
 	return mock.AcquireJobLockFunc(ctx, id)
 }
 
@@ -254,40 +271,40 @@ func (mock *MongoDataStorerMock) AcquireJobLockCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockAcquireJobLock.RLock()
+	lockMongoDataStorerMockAcquireJobLock.RLock()
 	calls = mock.calls.AcquireJobLock
-	mock.lockAcquireJobLock.RUnlock()
+	lockMongoDataStorerMockAcquireJobLock.RUnlock()
 	return calls
 }
 
-// CheckNewReindexCanBeCreated calls CheckNewReindexCanBeCreatedFunc.
-func (mock *MongoDataStorerMock) CheckNewReindexCanBeCreated(ctx context.Context) error {
-	if mock.CheckNewReindexCanBeCreatedFunc == nil {
-		panic("MongoDataStorerMock.CheckNewReindexCanBeCreatedFunc: method is nil but MongoDataStorer.CheckNewReindexCanBeCreated was just called")
+// CheckInProgressJob calls CheckInProgressJobFunc.
+func (mock *MongoDataStorerMock) CheckInProgressJob(ctx context.Context) error {
+	if mock.CheckInProgressJobFunc == nil {
+		panic("MongoDataStorerMock.CheckInProgressJobFunc: method is nil but MongoDataStorer.CheckInProgressJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 	}{
 		Ctx: ctx,
 	}
-	mock.lockCheckNewReindexCanBeCreated.Lock()
-	mock.calls.CheckNewReindexCanBeCreated = append(mock.calls.CheckNewReindexCanBeCreated, callInfo)
-	mock.lockCheckNewReindexCanBeCreated.Unlock()
-	return mock.CheckNewReindexCanBeCreatedFunc(ctx)
+	lockMongoDataStorerMockCheckInProgressJob.Lock()
+	mock.calls.CheckInProgressJob = append(mock.calls.CheckInProgressJob, callInfo)
+	lockMongoDataStorerMockCheckInProgressJob.Unlock()
+	return mock.CheckInProgressJobFunc(ctx)
 }
 
-// CheckNewReindexCanBeCreatedCalls gets all the calls that were made to CheckNewReindexCanBeCreated.
+// CheckInProgressJobCalls gets all the calls that were made to CheckInProgressJob.
 // Check the length with:
-//     len(mockedMongoDataStorer.CheckNewReindexCanBeCreatedCalls())
-func (mock *MongoDataStorerMock) CheckNewReindexCanBeCreatedCalls() []struct {
+//     len(mockedMongoDataStorer.CheckInProgressJobCalls())
+func (mock *MongoDataStorerMock) CheckInProgressJobCalls() []struct {
 	Ctx context.Context
 } {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockCheckNewReindexCanBeCreated.RLock()
-	calls = mock.calls.CheckNewReindexCanBeCreated
-	mock.lockCheckNewReindexCanBeCreated.RUnlock()
+	lockMongoDataStorerMockCheckInProgressJob.RLock()
+	calls = mock.calls.CheckInProgressJob
+	lockMongoDataStorerMockCheckInProgressJob.RUnlock()
 	return calls
 }
 
@@ -303,9 +320,9 @@ func (mock *MongoDataStorerMock) Checker(ctx context.Context, state *healthcheck
 		Ctx:   ctx,
 		State: state,
 	}
-	mock.lockChecker.Lock()
+	lockMongoDataStorerMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
+	lockMongoDataStorerMockChecker.Unlock()
 	return mock.CheckerFunc(ctx, state)
 }
 
@@ -320,9 +337,9 @@ func (mock *MongoDataStorerMock) CheckerCalls() []struct {
 		Ctx   context.Context
 		State *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockMongoDataStorerMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockMongoDataStorerMockChecker.RUnlock()
 	return calls
 }
 
@@ -336,9 +353,9 @@ func (mock *MongoDataStorerMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	mock.lockClose.Lock()
+	lockMongoDataStorerMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
+	lockMongoDataStorerMockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -351,44 +368,44 @@ func (mock *MongoDataStorerMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockClose.RLock()
+	lockMongoDataStorerMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockMongoDataStorerMockClose.RUnlock()
 	return calls
 }
 
 // CreateJob calls CreateJobFunc.
-func (mock *MongoDataStorerMock) CreateJob(ctx context.Context, searchIndexName string) (*models.Job, error) {
+func (mock *MongoDataStorerMock) CreateJob(ctx context.Context, job models.Job) error {
 	if mock.CreateJobFunc == nil {
 		panic("MongoDataStorerMock.CreateJobFunc: method is nil but MongoDataStorer.CreateJob was just called")
 	}
 	callInfo := struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}{
-		Ctx:             ctx,
-		SearchIndexName: searchIndexName,
+		Ctx: ctx,
+		Job: job,
 	}
-	mock.lockCreateJob.Lock()
+	lockMongoDataStorerMockCreateJob.Lock()
 	mock.calls.CreateJob = append(mock.calls.CreateJob, callInfo)
-	mock.lockCreateJob.Unlock()
-	return mock.CreateJobFunc(ctx, searchIndexName)
+	lockMongoDataStorerMockCreateJob.Unlock()
+	return mock.CreateJobFunc(ctx, job)
 }
 
 // CreateJobCalls gets all the calls that were made to CreateJob.
 // Check the length with:
 //     len(mockedMongoDataStorer.CreateJobCalls())
 func (mock *MongoDataStorerMock) CreateJobCalls() []struct {
-	Ctx             context.Context
-	SearchIndexName string
+	Ctx context.Context
+	Job models.Job
 } {
 	var calls []struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}
-	mock.lockCreateJob.RLock()
+	lockMongoDataStorerMockCreateJob.RLock()
 	calls = mock.calls.CreateJob
-	mock.lockCreateJob.RUnlock()
+	lockMongoDataStorerMockCreateJob.RUnlock()
 	return calls
 }
 
@@ -408,9 +425,9 @@ func (mock *MongoDataStorerMock) CreateTask(ctx context.Context, jobID string, t
 		TaskName:     taskName,
 		NumDocuments: numDocuments,
 	}
-	mock.lockCreateTask.Lock()
+	lockMongoDataStorerMockCreateTask.Lock()
 	mock.calls.CreateTask = append(mock.calls.CreateTask, callInfo)
-	mock.lockCreateTask.Unlock()
+	lockMongoDataStorerMockCreateTask.Unlock()
 	return mock.CreateTaskFunc(ctx, jobID, taskName, numDocuments)
 }
 
@@ -429,9 +446,9 @@ func (mock *MongoDataStorerMock) CreateTaskCalls() []struct {
 		TaskName     string
 		NumDocuments int
 	}
-	mock.lockCreateTask.RLock()
+	lockMongoDataStorerMockCreateTask.RLock()
 	calls = mock.calls.CreateTask
-	mock.lockCreateTask.RUnlock()
+	lockMongoDataStorerMockCreateTask.RUnlock()
 	return calls
 }
 
@@ -447,9 +464,9 @@ func (mock *MongoDataStorerMock) GetJob(ctx context.Context, id string) (models.
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockGetJob.Lock()
+	lockMongoDataStorerMockGetJob.Lock()
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
-	mock.lockGetJob.Unlock()
+	lockMongoDataStorerMockGetJob.Unlock()
 	return mock.GetJobFunc(ctx, id)
 }
 
@@ -464,9 +481,9 @@ func (mock *MongoDataStorerMock) GetJobCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockGetJob.RLock()
+	lockMongoDataStorerMockGetJob.RLock()
 	calls = mock.calls.GetJob
-	mock.lockGetJob.RUnlock()
+	lockMongoDataStorerMockGetJob.RUnlock()
 	return calls
 }
 
@@ -482,9 +499,9 @@ func (mock *MongoDataStorerMock) GetJobs(ctx context.Context, options mongo.Opti
 		Ctx:     ctx,
 		Options: options,
 	}
-	mock.lockGetJobs.Lock()
+	lockMongoDataStorerMockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	mock.lockGetJobs.Unlock()
+	lockMongoDataStorerMockGetJobs.Unlock()
 	return mock.GetJobsFunc(ctx, options)
 }
 
@@ -499,9 +516,9 @@ func (mock *MongoDataStorerMock) GetJobsCalls() []struct {
 		Ctx     context.Context
 		Options mongo.Options
 	}
-	mock.lockGetJobs.RLock()
+	lockMongoDataStorerMockGetJobs.RLock()
 	calls = mock.calls.GetJobs
-	mock.lockGetJobs.RUnlock()
+	lockMongoDataStorerMockGetJobs.RUnlock()
 	return calls
 }
 
@@ -519,9 +536,9 @@ func (mock *MongoDataStorerMock) GetTask(ctx context.Context, jobID string, task
 		JobID:    jobID,
 		TaskName: taskName,
 	}
-	mock.lockGetTask.Lock()
+	lockMongoDataStorerMockGetTask.Lock()
 	mock.calls.GetTask = append(mock.calls.GetTask, callInfo)
-	mock.lockGetTask.Unlock()
+	lockMongoDataStorerMockGetTask.Unlock()
 	return mock.GetTaskFunc(ctx, jobID, taskName)
 }
 
@@ -538,9 +555,9 @@ func (mock *MongoDataStorerMock) GetTaskCalls() []struct {
 		JobID    string
 		TaskName string
 	}
-	mock.lockGetTask.RLock()
+	lockMongoDataStorerMockGetTask.RLock()
 	calls = mock.calls.GetTask
-	mock.lockGetTask.RUnlock()
+	lockMongoDataStorerMockGetTask.RUnlock()
 	return calls
 }
 
@@ -558,9 +575,9 @@ func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, options mongo.Opt
 		Options: options,
 		JobID:   jobID,
 	}
-	mock.lockGetTasks.Lock()
+	lockMongoDataStorerMockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
-	mock.lockGetTasks.Unlock()
+	lockMongoDataStorerMockGetTasks.Unlock()
 	return mock.GetTasksFunc(ctx, options, jobID)
 }
 
@@ -577,9 +594,9 @@ func (mock *MongoDataStorerMock) GetTasksCalls() []struct {
 		Options mongo.Options
 		JobID   string
 	}
-	mock.lockGetTasks.RLock()
+	lockMongoDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks
-	mock.lockGetTasks.RUnlock()
+	lockMongoDataStorerMockGetTasks.RUnlock()
 	return calls
 }
 
@@ -597,9 +614,9 @@ func (mock *MongoDataStorerMock) PutNumberOfTasks(ctx context.Context, id string
 		ID:    id,
 		Count: count,
 	}
-	mock.lockPutNumberOfTasks.Lock()
+	lockMongoDataStorerMockPutNumberOfTasks.Lock()
 	mock.calls.PutNumberOfTasks = append(mock.calls.PutNumberOfTasks, callInfo)
-	mock.lockPutNumberOfTasks.Unlock()
+	lockMongoDataStorerMockPutNumberOfTasks.Unlock()
 	return mock.PutNumberOfTasksFunc(ctx, id, count)
 }
 
@@ -616,9 +633,9 @@ func (mock *MongoDataStorerMock) PutNumberOfTasksCalls() []struct {
 		ID    string
 		Count int
 	}
-	mock.lockPutNumberOfTasks.RLock()
+	lockMongoDataStorerMockPutNumberOfTasks.RLock()
 	calls = mock.calls.PutNumberOfTasks
-	mock.lockPutNumberOfTasks.RUnlock()
+	lockMongoDataStorerMockPutNumberOfTasks.RUnlock()
 	return calls
 }
 
@@ -634,9 +651,9 @@ func (mock *MongoDataStorerMock) UnlockJob(ctx context.Context, lockID string) {
 		Ctx:    ctx,
 		LockID: lockID,
 	}
-	mock.lockUnlockJob.Lock()
+	lockMongoDataStorerMockUnlockJob.Lock()
 	mock.calls.UnlockJob = append(mock.calls.UnlockJob, callInfo)
-	mock.lockUnlockJob.Unlock()
+	lockMongoDataStorerMockUnlockJob.Unlock()
 	mock.UnlockJobFunc(ctx, lockID)
 }
 
@@ -651,9 +668,9 @@ func (mock *MongoDataStorerMock) UnlockJobCalls() []struct {
 		Ctx    context.Context
 		LockID string
 	}
-	mock.lockUnlockJob.RLock()
+	lockMongoDataStorerMockUnlockJob.RLock()
 	calls = mock.calls.UnlockJob
-	mock.lockUnlockJob.RUnlock()
+	lockMongoDataStorerMockUnlockJob.RUnlock()
 	return calls
 }
 
@@ -671,9 +688,9 @@ func (mock *MongoDataStorerMock) UpdateJob(ctx context.Context, id string, updat
 		ID:      id,
 		Updates: updates,
 	}
-	mock.lockUpdateJob.Lock()
+	lockMongoDataStorerMockUpdateJob.Lock()
 	mock.calls.UpdateJob = append(mock.calls.UpdateJob, callInfo)
-	mock.lockUpdateJob.Unlock()
+	lockMongoDataStorerMockUpdateJob.Unlock()
 	return mock.UpdateJobFunc(ctx, id, updates)
 }
 
@@ -690,8 +707,43 @@ func (mock *MongoDataStorerMock) UpdateJobCalls() []struct {
 		ID      string
 		Updates bson.M
 	}
-	mock.lockUpdateJob.RLock()
+	lockMongoDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
-	mock.lockUpdateJob.RUnlock()
+	lockMongoDataStorerMockUpdateJob.RUnlock()
+	return calls
+}
+
+// ValidateJobIDUnique calls ValidateJobIDUniqueFunc.
+func (mock *MongoDataStorerMock) ValidateJobIDUnique(ctx context.Context, id string) error {
+	if mock.ValidateJobIDUniqueFunc == nil {
+		panic("MongoDataStorerMock.ValidateJobIDUniqueFunc: method is nil but MongoDataStorer.ValidateJobIDUnique was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  string
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	lockMongoDataStorerMockValidateJobIDUnique.Lock()
+	mock.calls.ValidateJobIDUnique = append(mock.calls.ValidateJobIDUnique, callInfo)
+	lockMongoDataStorerMockValidateJobIDUnique.Unlock()
+	return mock.ValidateJobIDUniqueFunc(ctx, id)
+}
+
+// ValidateJobIDUniqueCalls gets all the calls that were made to ValidateJobIDUnique.
+// Check the length with:
+//     len(mockedMongoDataStorer.ValidateJobIDUniqueCalls())
+func (mock *MongoDataStorerMock) ValidateJobIDUniqueCalls() []struct {
+	Ctx context.Context
+	ID  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  string
+	}
+	lockMongoDataStorerMockValidateJobIDUnique.RLock()
+	calls = mock.calls.ValidateJobIDUnique
+	lockMongoDataStorerMockValidateJobIDUnique.RUnlock()
 	return calls
 }

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -14,20 +14,19 @@ import (
 )
 
 var (
-	lockMongoDataStorerMockAcquireJobLock      sync.RWMutex
-	lockMongoDataStorerMockCheckInProgressJob  sync.RWMutex
-	lockMongoDataStorerMockChecker             sync.RWMutex
-	lockMongoDataStorerMockClose               sync.RWMutex
-	lockMongoDataStorerMockCreateJob           sync.RWMutex
-	lockMongoDataStorerMockCreateTask          sync.RWMutex
-	lockMongoDataStorerMockGetJob              sync.RWMutex
-	lockMongoDataStorerMockGetJobs             sync.RWMutex
-	lockMongoDataStorerMockGetTask             sync.RWMutex
-	lockMongoDataStorerMockGetTasks            sync.RWMutex
-	lockMongoDataStorerMockPutNumberOfTasks    sync.RWMutex
-	lockMongoDataStorerMockUnlockJob           sync.RWMutex
-	lockMongoDataStorerMockUpdateJob           sync.RWMutex
-	lockMongoDataStorerMockValidateJobIDUnique sync.RWMutex
+	lockMongoDataStorerMockAcquireJobLock     sync.RWMutex
+	lockMongoDataStorerMockCheckInProgressJob sync.RWMutex
+	lockMongoDataStorerMockChecker            sync.RWMutex
+	lockMongoDataStorerMockClose              sync.RWMutex
+	lockMongoDataStorerMockCreateJob          sync.RWMutex
+	lockMongoDataStorerMockCreateTask         sync.RWMutex
+	lockMongoDataStorerMockGetJob             sync.RWMutex
+	lockMongoDataStorerMockGetJobs            sync.RWMutex
+	lockMongoDataStorerMockGetTask            sync.RWMutex
+	lockMongoDataStorerMockGetTasks           sync.RWMutex
+	lockMongoDataStorerMockPutNumberOfTasks   sync.RWMutex
+	lockMongoDataStorerMockUnlockJob          sync.RWMutex
+	lockMongoDataStorerMockUpdateJob          sync.RWMutex
 )
 
 // Ensure, that MongoDataStorerMock does implement MongoDataStorer.
@@ -79,9 +78,6 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
 // 	               panic("mock out the UpdateJob method")
 //             },
-//             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
-// 	               panic("mock out the ValidateJobIDUnique method")
-//             },
 //         }
 //
 //         // use mockedMongoDataStorer in code that requires service.MongoDataStorer
@@ -127,9 +123,6 @@ type MongoDataStorerMock struct {
 
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
-
-	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
-	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -231,13 +224,6 @@ type MongoDataStorerMock struct {
 			ID string
 			// Updates is the updates argument value.
 			Updates bson.M
-		}
-		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
-		ValidateJobIDUnique []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ID is the id argument value.
-			ID string
 		}
 	}
 }
@@ -710,40 +696,5 @@ func (mock *MongoDataStorerMock) UpdateJobCalls() []struct {
 	lockMongoDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
 	lockMongoDataStorerMockUpdateJob.RUnlock()
-	return calls
-}
-
-// ValidateJobIDUnique calls ValidateJobIDUniqueFunc.
-func (mock *MongoDataStorerMock) ValidateJobIDUnique(ctx context.Context, id string) error {
-	if mock.ValidateJobIDUniqueFunc == nil {
-		panic("MongoDataStorerMock.ValidateJobIDUniqueFunc: method is nil but MongoDataStorer.ValidateJobIDUnique was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-		ID  string
-	}{
-		Ctx: ctx,
-		ID:  id,
-	}
-	lockMongoDataStorerMockValidateJobIDUnique.Lock()
-	mock.calls.ValidateJobIDUnique = append(mock.calls.ValidateJobIDUnique, callInfo)
-	lockMongoDataStorerMockValidateJobIDUnique.Unlock()
-	return mock.ValidateJobIDUniqueFunc(ctx, id)
-}
-
-// ValidateJobIDUniqueCalls gets all the calls that were made to ValidateJobIDUnique.
-// Check the length with:
-//     len(mockedMongoDataStorer.ValidateJobIDUniqueCalls())
-func (mock *MongoDataStorerMock) ValidateJobIDUniqueCalls() []struct {
-	Ctx context.Context
-	ID  string
-} {
-	var calls []struct {
-		Ctx context.Context
-		ID  string
-	}
-	lockMongoDataStorerMockValidateJobIDUnique.RLock()
-	calls = mock.calls.ValidateJobIDUnique
-	lockMongoDataStorerMockValidateJobIDUnique.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Refactor `CreateJob` handler data layer so that the validation of data exists in the handler layer
- Simplify `CheckIfProgressJob` by only returning one job which is in state `in-progress` and with the most recent `reindex_started` time rather than returning all the jobs and then iterating through it - this is more performant and does the same job

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense
- Check if all the tests pass

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone