### PR TITLE
add etag functionality to GET `/jobs`

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -188,6 +188,19 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	limitParam := req.URL.Query().Get("limit")
 	logData := log.Data{}
 
+	// get eTag from If-Match header
+	eTagFromIfMatch, err := headers.GetIfMatch(req)
+	if err != nil {
+		if err != headers.ErrHeaderNotFound {
+			log.Error(ctx, "if-match header not found", err, logData)
+		} else {
+			log.Error(ctx, "unable to get eTag from if-match header", err, logData)
+		}
+
+		log.Info(ctx, "ignoring eTag check")
+		eTagFromIfMatch = headers.IfMatchAnyETag
+	}
+
 	// initialise pagination
 	offset, limit, err := pagination.InitialisePagination(api.cfg, offsetParam, limitParam)
 	if err != nil {
@@ -213,16 +226,41 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	logData["jobs_count"] = jobs.Count
+	logData["jobs_limit"] = jobs.Limit
+	logData["jobs_offset"] = jobs.Offset
+	logData["jobs_total_count"] = jobs.TotalCount
+
+	jobsETag, err := models.GenerateETagForJobs(ctx, *jobs)
+	if err != nil {
+		log.Error(ctx, "failed to generate etag for jobs", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	// check eTags to see if it matches with the current state of the jobs resource
+	if jobsETag != eTagFromIfMatch && eTagFromIfMatch != headers.IfMatchAnyETag {
+		logData["current_etag"] = jobsETag
+		logData["given_etag"] = eTagFromIfMatch
+
+		err = apierrors.ErrConflictWithETag
+		log.Error(ctx, "given and current etags do not match", err, logData)
+		http.Error(w, apierrors.ErrConflictWithETag.Error(), http.StatusConflict)
+		return
+	}
+
 	// update links for json response
 	for i := range jobs.JobList {
 		jobs.JobList[i].Links.Self = fmt.Sprintf("%s/%s%s", host, v1, jobs.JobList[i].Links.Self)
 		jobs.JobList[i].Links.Tasks = fmt.Sprintf("%s/%s%s", host, v1, jobs.JobList[i].Links.Tasks)
 	}
 
+	// set eTag on ETag response header
+	dpresponse.SetETag(w, jobsETag)
+
 	// write response
 	err = dpresponse.WriteJSON(w, jobs, http.StatusOK)
 	if err != nil {
-		logData["jobs"] = jobs
 		logData["response_status_to_write"] = http.StatusOK
 
 		log.Error(ctx, "failed to write response", err, logData)
@@ -296,7 +334,13 @@ func (api *API) PatchJobStatusHandler(w http.ResponseWriter, req *http.Request) 
 	// get eTag from If-Match header
 	eTag, err := headers.GetIfMatch(req)
 	if err != nil {
-		log.Error(ctx, "unable to retrieve eTag from If-Match header - setting to ignore eTag check", err, logData)
+		if err != headers.ErrHeaderNotFound {
+			log.Error(ctx, "if-match header not found", err, logData)
+		} else {
+			log.Error(ctx, "unable to get eTag from if-match header", err, logData)
+		}
+
+		log.Info(ctx, "ignoring eTag check")
 		eTag = headers.IfMatchAnyETag
 	}
 
@@ -342,7 +386,7 @@ func (api *API) PatchJobStatusHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// check eTag to see if request conflicts with the current state of the job resource
+	// check eTags to see if it matches with the current state of the jobs resource
 	if currentJob.ETag != eTag && eTag != headers.IfMatchAnyETag {
 		logData["current_etag"] = currentJob.ETag
 		logData["given_etag"] = eTag

--- a/features/latest_version_features/getting_jobs.feature
+++ b/features/latest_version_features/getting_jobs.feature
@@ -4,6 +4,7 @@ Feature: Getting a list of jobs
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs"
     """
     """
@@ -23,16 +24,19 @@ Feature: Getting a list of jobs
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
 
   Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
     Given the number of existing jobs in the Job Store is 0
     And the api version is undefined for incoming requests
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs"
     """
     """
     Then I would expect the response to be an empty list
     And the HTTP status code should be "200"
+    And the response ETag header should not be empty
 
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
@@ -57,30 +61,114 @@ Feature: Getting a list of jobs
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "*" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
 
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?offset=-2"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
 
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?limit=-3"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
 
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?limit=1001"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""

--- a/features/latest_version_features/getting_jobs.feature
+++ b/features/latest_version_features/getting_jobs.feature
@@ -140,6 +140,19 @@ Feature: Getting a list of jobs
     And the jobs should be ordered, by last_updated, with the oldest first
     And the response ETag header should not be empty
 
+  Scenario: Request made with outdated or invalid etag returns an conflict error
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "invalid"
+    When I GET "/jobs"
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
+
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
     Given the api version is undefined for incoming requests

--- a/features/latest_version_features/patch_job_state_success.feature
+++ b/features/latest_version_features/patch_job_state_success.feature
@@ -82,6 +82,33 @@ Feature: Patch job state - Success
             | last_updated           | now or earlier            |
             | reindex_started        | now or earlier            |
             | state                  | in-progress               |
+
+    Scenario: Request is made where If-Match header is sets `*` to ask the API to ignore the ETag check
+
+        Given I use a service auth token "validServiceAuthToken"
+        And zebedee recognises the service auth token as valid
+        And the api version is undefined for incoming requests
+        And the number of existing jobs in the Job Store is 1
+        And I set the "If-Match" header to "*"
+        
+        When I call PATCH /jobs/{id} using the generated id
+        """
+        [
+            { "op": "replace", "path": "/state", "value": "in-progress" }
+        ]
+        """
+        
+        And the HTTP status code should be "204"
+        And the response header "Content-Type" should be ""
+        And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
+        And the job should only be updated with the following fields and values
+            | e_tag                  | new eTag                  |
+            | last_updated           | now or earlier            |
+            | reindex_started        | now or earlier            |
+            | state                  | in-progress               |
   
     Scenario: Request is made to update state to in-progress
 

--- a/features/latest_version_features/patch_job_state_success.feature
+++ b/features/latest_version_features/patch_job_state_success.feature
@@ -83,7 +83,7 @@ Feature: Patch job state - Success
             | reindex_started        | now or earlier            |
             | state                  | in-progress               |
 
-    Scenario: Request is made where If-Match header is sets `*` to ask the API to ignore the ETag check
+    Scenario: Request is made where If-Match header is set to IfMatchAnyETag (`*`) to ask the API to ignore the ETag check
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -37,6 +37,7 @@ func (f *SearchReindexAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I have created a task for the generated job$`, f.iHaveCreatedATaskForTheGeneratedJob)
 	ctx.Step(`^I set the If-Match header to the generated e-tag$`, f.iSetIfMatchHeaderToTheGeneratedETag)
 	ctx.Step(`^I set the "If-Match" header to the old e-tag$`, f.iSetIfMatchHeaderToTheOldGeneratedETag)
+	ctx.Step(`^I set the If-Match header to a valid e-tag to get jobs$`, f.iSetIfMatchHeaderToValidETagForJobs)
 	ctx.Step(`^the number of existing jobs in the Job Store is (\d+)$`, f.theNoOfExistingJobsInTheJobStore)
 
 	ctx.Step(`^I would expect the response to be an empty list$`, f.iWouldExpectTheResponseToBeAnEmptyList)

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -1,17 +1,21 @@
-Feature: Getting a job
+Feature: Getting a list of jobs
 
-  Scenario: Job exists in the Job Store and a get request returns it successfully
+  Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 1
-    When I call GET /jobs/{id} using the generated id
-    Then the response should contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
-      | search_index_name | ons{date_stamp}           |
-    And the response should also contain the following values:
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
       | reindex_failed                  | 0001-01-01T00:00:00Z      |
@@ -19,28 +23,152 @@ Feature: Getting a job
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
 
-  Scenario: When request is made with empty job id and request returns StatusNotFound by gorilla/mux as handler is not found
-
-    Given the number of existing jobs in the Job Store is 0
-    And the api version is undefined for incoming requests
-    When I GET "/jobs/"
-    Then the HTTP status code should be "404"
-    And I should receive the following response:
-    """
-      404 page not found
-    """
-  
-  Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
+  Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
     Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
-    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
-    Then the HTTP status code should be "404"
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect the response to be an empty list
+    And the HTTP status code should be "200"
+    And the response ETag header should not be empty
 
-  Scenario: The connection to mongo DB is lost and a get request returns an internal server error
+  Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
-    Given the search reindex api loses its connection to mongo DB
-    And the api version is v1 for incoming requests
-    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
-    Then the HTTP status code should be "500"
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 6
+    When I GET "/jobs?offset=1&limit=4"
+    """
+    """
+    Then I would expect there to be four jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "*" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Three jobs exist and a get request with negative offset returns an error
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs?offset=-2"
+    """
+    """
+    Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
+
+  Scenario: Three jobs exist and a get request with negative limit returns an error
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs?limit=-3"
+    """
+    """
+    Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
+
+  Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs?limit=1001"
+    """
+    """
+    Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -1,21 +1,17 @@
-Feature: Getting a list of jobs
+Feature: Getting a job
 
-  Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
+  Scenario: Job exists in the Job Store and a get request returns it successfully
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
+    And the number of existing jobs in the Job Store is 1
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
       | id                | UUID                                    |
       | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | links: tasks      | {host}/v1/jobs/{id}/tasks               |
+      | links: self       | {host}/v1/jobs/{id}                     |
       | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
+    And the response should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
       | reindex_failed                  | 0001-01-01T00:00:00Z      |
@@ -23,8 +19,6 @@ Feature: Getting a list of jobs
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
-    And the response ETag header should not be empty
 
   Scenario: When request is made with empty job id and request returns StatusNotFound by router as handler is not found
 
@@ -41,145 +35,12 @@ Feature: Getting a list of jobs
 
     Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect the response to be an empty list
-    And the HTTP status code should be "200"
-    And the response ETag header should not be empty
+    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
+    Then the HTTP status code should be "404"
 
-  Scenario: Six jobs exist and a get request with offset and limit correctly returns four
+  Scenario: The connection to mongo DB is lost and a get request returns an internal server error
 
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 6
-    When I GET "/jobs?offset=1&limit=4"
-    """
-    """
-    Then I would expect there to be four jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
-      | number_of_tasks                 | 0                         |
-      | reindex_completed               | 0001-01-01T00:00:00Z      |
-      | reindex_failed                  | 0001-01-01T00:00:00Z      |
-      | reindex_started                 | 0001-01-01T00:00:00Z      |
-      | state                           | created                   |
-      | total_search_documents          | 0                         |
-      | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
-    And the response ETag header should not be empty
-
-  Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
-
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
-      | number_of_tasks                 | 0                         |
-      | reindex_completed               | 0001-01-01T00:00:00Z      |
-      | reindex_failed                  | 0001-01-01T00:00:00Z      |
-      | reindex_started                 | 0001-01-01T00:00:00Z      |
-      | state                           | created                   |
-      | total_search_documents          | 0                         |
-      | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
-    And the response ETag header should not be empty
-
-  Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
-
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the "If-Match" header to "" 
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
-      | number_of_tasks                 | 0                         |
-      | reindex_completed               | 0001-01-01T00:00:00Z      |
-      | reindex_failed                  | 0001-01-01T00:00:00Z      |
-      | reindex_started                 | 0001-01-01T00:00:00Z      |
-      | state                           | created                   |
-      | total_search_documents          | 0                         |
-      | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
-    And the response ETag header should not be empty
-
-  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
-
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the "If-Match" header to "*" 
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
-      | number_of_tasks                 | 0                         |
-      | reindex_completed               | 0001-01-01T00:00:00Z      |
-      | reindex_failed                  | 0001-01-01T00:00:00Z      |
-      | reindex_started                 | 0001-01-01T00:00:00Z      |
-      | state                           | created                   |
-      | total_search_documents          | 0                         |
-      | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
-    And the response ETag header should not be empty
-
-  Scenario: Three jobs exist and a get request with negative offset returns an error
-
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs?offset=-2"
-    """
-    """
-    Then the HTTP status code should be "400"
-    And the response header "E-Tag" should be ""
-
-  Scenario: Three jobs exist and a get request with negative limit returns an error
-
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs?limit=-3"
-    """
-    """
-    Then the HTTP status code should be "400"
-    And the response header "E-Tag" should be ""
-
-  Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
-
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs?limit=1001"
-    """
-    """
-    Then the HTTP status code should be "400"
-    And the response header "E-Tag" should be ""
+    Given the search reindex api loses its connection to mongo DB
+    And the api version is v1 for incoming requests
+    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
+    Then the HTTP status code should be "500"

--- a/features/v1_features/latest_version_features/getting_jobs.feature
+++ b/features/v1_features/latest_version_features/getting_jobs.feature
@@ -4,16 +4,17 @@ Feature: Getting a list of jobs
 
     Given the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs"
     """
     """
     Then I would expect there to be three or more jobs returned in a list
     And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
-      | search_index_name | ons{date_stamp}           |
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
     And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
@@ -23,16 +24,19 @@ Feature: Getting a list of jobs
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
 
   Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
     Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs"
     """
     """
     Then I would expect the response to be an empty list
     And the HTTP status code should be "200"
+    And the response ETag header should not be empty
 
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
@@ -43,11 +47,11 @@ Feature: Getting a list of jobs
     """
     Then I would expect there to be four jobs returned in a list
     And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
-      | search_index_name | ons{date_stamp}           |
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
     And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
@@ -57,30 +61,127 @@ Feature: Getting a list of jobs
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "*" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with outdated or invalid etag returns an conflict error
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "invalid"
+    When I GET "/jobs"
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
     Given the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?offset=-2"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
 
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
     Given the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?limit=-3"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
 
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
     Given the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?limit=1001"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""

--- a/features/v1_features/latest_version_features/patch_job_state_success.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_success.feature
@@ -83,7 +83,7 @@ Feature: Patch job state - Success
             | reindex_started        | now or earlier            |
             | state                  | in-progress               |
     
-    Scenario: Request is made where If-Match header is sets `*` to ask the API to ignore the ETag check
+    Scenario: Request is made where If-Match header is set to IfMatchAnyETag (`*`) to ask the API to ignore the ETag check
 
         Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid

--- a/features/v1_features/latest_version_features/patch_job_state_success.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_success.feature
@@ -82,6 +82,33 @@ Feature: Patch job state - Success
             | last_updated           | now or earlier            |
             | reindex_started        | now or earlier            |
             | state                  | in-progress               |
+    
+    Scenario: Request is made where If-Match header is sets `*` to ask the API to ignore the ETag check
+
+        Given I use a service auth token "validServiceAuthToken"
+        And zebedee recognises the service auth token as valid
+        And the api version is v1 for incoming requests
+        And the number of existing jobs in the Job Store is 1
+        And I set the "If-Match" header to "*"
+        
+        When I call PATCH /jobs/{id} using the generated id
+        """
+        [
+            { "op": "replace", "path": "/state", "value": "in-progress" }
+        ]
+        """
+        
+        And the HTTP status code should be "204"
+        And the response header "Content-Type" should be ""
+        And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
+        And the job should only be updated with the following fields and values
+            | e_tag                  | new eTag                  |
+            | last_updated           | now or earlier            |
+            | reindex_started        | now or earlier            |
+            | state                  | in-progress               |
   
     Scenario: Request is made to update state to in-progress
 

--- a/models/etag.go
+++ b/models/etag.go
@@ -30,6 +30,19 @@ func GenerateETagForJob(ctx context.Context, updatedJob Job) (eTag string, err e
 	return eTag, nil
 }
 
+// GenerateETagForJobs generates a new eTag for a jobs resource
+func GenerateETagForJobs(ctx context.Context, jobs Jobs) (eTag string, err error) {
+	b, err := bson.Marshal(jobs)
+	if err != nil {
+		log.Error(ctx, "failed to marshal jobs", err)
+		return "", err
+	}
+
+	eTag = dpresponse.GenerateETag(b, false)
+
+	return eTag, nil
+}
+
 // GenerateETagForTask generates a new eTag for a task resource
 func GenerateETagForTask(task Task) (eTag string, err error) {
 	// ignoring the metadata LastUpdated and currentEtag when generating new eTag

--- a/models/etag_test.go
+++ b/models/etag_test.go
@@ -59,7 +59,7 @@ func getTestJob() models.Job {
 	return models.Job{
 		ID:          "test1",
 		ETag:        `"56b6890f1321590998d5fd8d293b620581ff3531"`,
-		LastUpdated: time.Now().UTC(),
+		LastUpdated: zeroTime,
 		Links: &models.JobLinks{
 			Tasks: "http://localhost:25700/jobs/test1234/tasks",
 			Self:  "http://localhost:25700/jobs/test1234",
@@ -73,6 +73,60 @@ func getTestJob() models.Job {
 		TotalSearchDocuments:         0,
 		TotalInsertedSearchDocuments: 0,
 	}
+}
+
+func TestGenerateETagForJobs(t *testing.T) {
+	ctx := context.Background()
+
+	job := getTestJob()
+	jobs := models.Jobs{
+		Count:      1,
+		JobList:    []models.Job{job},
+		Limit:      1,
+		Offset:     0,
+		TotalCount: 1,
+	}
+
+	jobsETag := `"89ffa9ad7f168112ad68de35a7bef9c64535b019"`
+
+	Convey("Given the list of jobs has updated", t, func() {
+		updatedJobs := jobs
+		updatedJobs.Limit = 10
+
+		Convey("When GenerateETagForJobs is called", func() {
+			newETag, err := models.GenerateETagForJobs(ctx, updatedJobs)
+
+			Convey("Then a new eTag is created", func() {
+				So(newETag, ShouldNotBeEmpty)
+
+				Convey("And new eTag should not be the same as the old eTag", func() {
+					So(newETag, ShouldNotEqual, jobsETag)
+
+					Convey("And no errors should be returned", func() {
+						So(err, ShouldBeNil)
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given an existing task with no new updates", t, func() {
+		Convey("When GenerateETagForTask is called", func() {
+			newETag, err := models.GenerateETagForJobs(ctx, jobs)
+
+			Convey("Then an eTag is returned", func() {
+				So(newETag, ShouldNotBeEmpty)
+
+				Convey("And the eTag should be the same as the existing eTag", func() {
+					So(newETag, ShouldEqual, jobsETag)
+
+					Convey("And no errors should be returned", func() {
+						So(err, ShouldBeNil)
+					})
+				})
+			})
+		})
+	})
 }
 
 func TestGenerateETagForTask(t *testing.T) {

--- a/models/etag_test.go
+++ b/models/etag_test.go
@@ -110,8 +110,8 @@ func TestGenerateETagForJobs(t *testing.T) {
 		})
 	})
 
-	Convey("Given an existing task with no new updates", t, func() {
-		Convey("When GenerateETagForTask is called", func() {
+	Convey("Given the list of jobs has not updated", t, func() {
+		Convey("When GenerateETagForJobs is called", func() {
 			newETag, err := models.GenerateETagForJobs(ctx, jobs)
 
 			Convey("Then an eTag is returned", func() {


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Ensure that we check the If-Match header in the request if it exists
- Ensure ETag is generated after retrieving data from database and checks this with the `IfMatch` header value if set and not set to `*`
- Ensure we set `ETag` header in the response back
- Add unit test and component test

### How to review
**Describe the steps required to test the changes.**
- Check if the test passes
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone