### PR TITLE
add etag functionality for GET `/jobs/{id}`

### DIFF
--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -24,7 +24,7 @@ type DataStorer interface {
 	GetJob(ctx context.Context, id string) (*models.Job, error)
 	GetJobs(ctx context.Context, options mongo.Options) (job *models.Jobs, err error)
 	GetTask(ctx context.Context, jobID, taskName string) (*models.Task, error)
-	GetTasks(ctx context.Context, options mongo.Options, jobID string) (job models.Tasks, err error)
+	GetTasks(ctx context.Context, jobID string, options mongo.Options) (job *models.Tasks, err error)
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	UnlockJob(ctx context.Context, lockID string)
 	UpdateJob(ctx context.Context, id string, updates bson.M) error

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -19,8 +19,8 @@ import (
 // DataStorer is an interface for a type that can store and retrieve jobs
 type DataStorer interface {
 	AcquireJobLock(ctx context.Context, id string) (lockID string, err error)
-	CheckNewReindexCanBeCreated(ctx context.Context) error
-	CreateJob(ctx context.Context, searchIndexName string) (job *models.Job, err error)
+	CheckInProgressJob(ctx context.Context) error
+	CreateJob(ctx context.Context, job models.Job) error
 	CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (task models.Task, err error)
 	GetJob(ctx context.Context, id string) (job models.Job, err error)
 	GetJobs(ctx context.Context, options mongo.Options) (job models.Jobs, err error)
@@ -29,6 +29,7 @@ type DataStorer interface {
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	UnlockJob(ctx context.Context, lockID string)
 	UpdateJob(ctx context.Context, id string, updates bson.M) error
+	ValidateJobIDUnique(ctx context.Context, id string) error
 }
 
 // Paginator defines the required methods from the paginator package

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -23,7 +23,7 @@ type DataStorer interface {
 	CreateJob(ctx context.Context, job models.Job) error
 	CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (task models.Task, err error)
 	GetJob(ctx context.Context, id string) (*models.Job, error)
-	GetJobs(ctx context.Context, options mongo.Options) (job models.Jobs, err error)
+	GetJobs(ctx context.Context, options mongo.Options) (job *models.Jobs, err error)
 	GetTask(ctx context.Context, jobID string, taskName string) (task models.Task, err error)
 	GetTasks(ctx context.Context, options mongo.Options, jobID string) (job models.Tasks, err error)
 	PutNumberOfTasks(ctx context.Context, id string, count int) error

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -21,7 +21,6 @@ type DataStorer interface {
 	AcquireJobLock(ctx context.Context, id string) (lockID string, err error)
 	CheckInProgressJob(ctx context.Context) error
 	CreateJob(ctx context.Context, job models.Job) error
-	CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (task models.Task, err error)
 	GetJob(ctx context.Context, id string) (*models.Job, error)
 	GetJobs(ctx context.Context, options mongo.Options) (job *models.Jobs, err error)
 	GetTask(ctx context.Context, jobID string, taskName string) (task models.Task, err error)
@@ -29,6 +28,7 @@ type DataStorer interface {
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	UnlockJob(ctx context.Context, lockID string)
 	UpdateJob(ctx context.Context, id string, updates bson.M) error
+	UpsertTask(ctx context.Context, jobID, taskName string, task models.Task) error
 	ValidateJobIDUnique(ctx context.Context, id string) error
 }
 

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -22,7 +22,7 @@ type DataStorer interface {
 	CheckInProgressJob(ctx context.Context) error
 	CreateJob(ctx context.Context, job models.Job) error
 	CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (task models.Task, err error)
-	GetJob(ctx context.Context, id string) (job models.Job, err error)
+	GetJob(ctx context.Context, id string) (*models.Job, error)
 	GetJobs(ctx context.Context, options mongo.Options) (job models.Jobs, err error)
 	GetTask(ctx context.Context, jobID string, taskName string) (task models.Task, err error)
 	GetTasks(ctx context.Context, options mongo.Options, jobID string) (job models.Tasks, err error)

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -23,7 +23,7 @@ type DataStorer interface {
 	CreateJob(ctx context.Context, job models.Job) error
 	GetJob(ctx context.Context, id string) (*models.Job, error)
 	GetJobs(ctx context.Context, options mongo.Options) (job *models.Jobs, err error)
-	GetTask(ctx context.Context, jobID string, taskName string) (task models.Task, err error)
+	GetTask(ctx context.Context, jobID, taskName string) (*models.Task, error)
 	GetTasks(ctx context.Context, options mongo.Options, jobID string) (job models.Tasks, err error)
 	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	UnlockJob(ctx context.Context, lockID string)

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -185,6 +185,7 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	limitParam := req.URL.Query().Get("limit")
 	logData := log.Data{}
 
+	// initialise pagination
 	offset, limit, err := pagination.InitialisePagination(api.cfg, offsetParam, limitParam)
 	if err != nil {
 		logData["offset_parameter"] = offsetParam
@@ -199,6 +200,8 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 		Offset: offset,
 		Limit:  limit,
 	}
+
+	// get jobs from mongo
 	jobs, err := api.dataStore.GetJobs(ctx, options)
 	if err != nil {
 		logData["options"] = options
@@ -207,11 +210,13 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// update links for json response
 	for i := range jobs.JobList {
 		jobs.JobList[i].Links.Self = fmt.Sprintf("%s/%s%s", host, v1, jobs.JobList[i].Links.Self)
 		jobs.JobList[i].Links.Tasks = fmt.Sprintf("%s/%s%s", host, v1, jobs.JobList[i].Links.Tasks)
 	}
 
+	// write response
 	err = dpresponse.WriteJSON(w, jobs, http.StatusOK)
 	if err != nil {
 		logData["jobs"] = jobs

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -116,6 +116,9 @@ func (api *API) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 	newJob.Links.Self = fmt.Sprintf("%s/%s%s", host, v1, newJob.Links.Self)
 	newJob.Links.Tasks = fmt.Sprintf("%s/%s%s", host, v1, newJob.Links.Tasks)
 
+	// set eTag on ETag response header
+	dpresponse.SetETag(w, newJob.ETag)
+
 	// write response
 	err = dpresponse.WriteJSON(w, newJob, http.StatusCreated)
 	if err != nil {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -188,6 +188,19 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	limitParam := req.URL.Query().Get("limit")
 	logData := log.Data{}
 
+	// get eTag from If-Match header
+	eTagFromIfMatch, err := headers.GetIfMatch(req)
+	if err != nil {
+		if err != headers.ErrHeaderNotFound {
+			log.Error(ctx, "if-match header not found", err, logData)
+		} else {
+			log.Error(ctx, "unable to get eTag from if-match header", err, logData)
+		}
+
+		log.Info(ctx, "ignoring eTag check")
+		eTagFromIfMatch = headers.IfMatchAnyETag
+	}
+
 	// initialise pagination
 	offset, limit, err := pagination.InitialisePagination(api.cfg, offsetParam, limitParam)
 	if err != nil {
@@ -213,16 +226,41 @@ func (api *API) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	logData["jobs_count"] = jobs.Count
+	logData["jobs_limit"] = jobs.Limit
+	logData["jobs_offset"] = jobs.Offset
+	logData["jobs_total_count"] = jobs.TotalCount
+
+	jobsETag, err := models.GenerateETagForJobs(ctx, *jobs)
+	if err != nil {
+		log.Error(ctx, "failed to generate etag for jobs", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	// check eTags to see if it matches with the current state of the jobs resource
+	if jobsETag != eTagFromIfMatch && eTagFromIfMatch != headers.IfMatchAnyETag {
+		logData["current_etag"] = jobsETag
+		logData["given_etag"] = eTagFromIfMatch
+
+		err = apierrors.ErrConflictWithETag
+		log.Error(ctx, "given and current etags do not match", err, logData)
+		http.Error(w, apierrors.ErrConflictWithETag.Error(), http.StatusConflict)
+		return
+	}
+
 	// update links for json response
 	for i := range jobs.JobList {
 		jobs.JobList[i].Links.Self = fmt.Sprintf("%s/%s%s", host, v1, jobs.JobList[i].Links.Self)
 		jobs.JobList[i].Links.Tasks = fmt.Sprintf("%s/%s%s", host, v1, jobs.JobList[i].Links.Tasks)
 	}
 
+	// set eTag on ETag response header
+	dpresponse.SetETag(w, jobsETag)
+
 	// write response
 	err = dpresponse.WriteJSON(w, jobs, http.StatusOK)
 	if err != nil {
-		logData["jobs"] = jobs
 		logData["response_status_to_write"] = http.StatusOK
 
 		log.Error(ctx, "failed to write response", err, logData)
@@ -296,7 +334,13 @@ func (api *API) PatchJobStatusHandler(w http.ResponseWriter, req *http.Request) 
 	// get eTag from If-Match header
 	eTag, err := headers.GetIfMatch(req)
 	if err != nil {
-		log.Error(ctx, "unable to retrieve eTag from If-Match header - setting to ignore eTag check", err, logData)
+		if err != headers.ErrHeaderNotFound {
+			log.Error(ctx, "if-match header not found", err, logData)
+		} else {
+			log.Error(ctx, "unable to get eTag from if-match header", err, logData)
+		}
+
+		log.Info(ctx, "ignoring eTag check")
 		eTag = headers.IfMatchAnyETag
 	}
 
@@ -342,7 +386,7 @@ func (api *API) PatchJobStatusHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// check eTag to see if request conflicts with the current state of the job resource
+	// check eTags to see if it matches with the current state of the jobs resource
 	if currentJob.ETag != eTag && eTag != headers.IfMatchAnyETag {
 		logData["current_etag"] = currentJob.ETag
 		logData["given_etag"] = eTag

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -36,7 +36,7 @@ func (api *API) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 	log.Info(ctx, "starting post operation of reindex job")
 
 	// check if a new reindex job can be created
-	err := api.dataStore.CheckNewReindexCanBeCreated(ctx)
+	err := api.dataStore.CheckInProgressJob(ctx)
 	if err != nil {
 		log.Error(ctx, "error occurred when checking to create a new reindex job", err)
 
@@ -72,10 +72,28 @@ func (api *API) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// create a reindex job in the datastore with the search index name
-	newJob, err := api.dataStore.CreateJob(ctx, indexName)
+	// create a new job
+	newJob, err := models.NewJob(ctx, indexName)
 	if err != nil {
-		logData["search_index_name"] = indexName
+		logData["index_name"] = indexName
+		log.Error(ctx, "failed to create new job", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	// checks if there exists a reindex job with the same id as the new job in the datastore
+	err = api.dataStore.ValidateJobIDUnique(ctx, newJob.ID)
+	if err != nil {
+		logData["jobID"] = newJob.ID
+		log.Error(ctx, "failed to validate job id is unique", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	// insert new job in the datastore
+	err = api.dataStore.CreateJob(ctx, *newJob)
+	if err != nil {
+		logData["new_job"] = newJob
 		log.Error(ctx, "failed to create reindex job", err, logData)
 		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 		return

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -518,7 +518,7 @@ func TestGetJobsHandler(t *testing.T) {
 
 	Convey("Given a Search Reindex Job API that returns a list of jobs", t, func() {
 		dataStorerMock := &apiMock.DataStorerMock{
-			GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 				jobs := models.Jobs{}
 				jobsList := make([]models.Job, 2)
 				offsetJobsList := make([]models.Job, 1)
@@ -539,7 +539,7 @@ func TestGetJobsHandler(t *testing.T) {
 					jobs.JobList = make([]models.Job, 0)
 				}
 
-				return jobs, err
+				return &jobs, err
 			},
 		}
 
@@ -738,10 +738,10 @@ func TestGetJobsHandlerWithEmptyJobStore(t *testing.T) {
 
 	Convey("Given a Search Reindex Job API that returns an empty list of jobs", t, func() {
 		dataStorerMock := &apiMock.DataStorerMock{
-			GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+			GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 				jobs := models.Jobs{}
 
-				return jobs, nil
+				return &jobs, nil
 			},
 		}
 
@@ -784,10 +784,8 @@ func TestGetJobsHandlerWithInternalServerError(t *testing.T) {
 
 	Convey("Given a Search Reindex Job API that that failed to connect to the Data Store", t, func() {
 		dataStorerMock := &apiMock.DataStorerMock{
-			GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
-				jobs := models.Jobs{}
-
-				return jobs, errors.New("something went wrong in the server")
+			GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
+				return nil, errors.New("something went wrong in the server")
 			},
 		}
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -163,6 +163,10 @@ func TestCreateJobHandler(t *testing.T) {
 					So(newJob.State, ShouldEqual, expectedJob.State)
 					So(newJob.TotalSearchDocuments, ShouldEqual, expectedJob.TotalSearchDocuments)
 					So(newJob.TotalInsertedSearchDocuments, ShouldEqual, expectedJob.TotalInsertedSearchDocuments)
+
+					Convey("And the etag of new job should be returned via the ETag header", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldEqual, expectedJob.ETag)
+					})
 				})
 			})
 		})
@@ -189,6 +193,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrExistingJobInProgress.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -215,6 +223,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -241,6 +253,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -270,6 +286,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -302,6 +322,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -331,6 +355,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -363,6 +391,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -389,6 +421,10 @@ func TestCreateJobHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -55,7 +55,7 @@ var _ api.DataStorer = &DataStorerMock{}
 //             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
 // 	               panic("mock out the GetTask method")
 //             },
-//             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+//             GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
 // 	               panic("mock out the GetTasks method")
 //             },
 //             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
@@ -99,7 +99,7 @@ type DataStorerMock struct {
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (*models.Task, error)
 
 	// GetTasksFunc mocks the GetTasks method.
-	GetTasksFunc func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error)
+	GetTasksFunc func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error)
 
 	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
 	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
@@ -164,10 +164,10 @@ type DataStorerMock struct {
 		GetTasks []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Options is the options argument value.
-			Options mongo.Options
 			// JobID is the jobID argument value.
 			JobID string
+			// Options is the options argument value.
+			Options mongo.Options
 		}
 		// PutNumberOfTasks holds details about calls to the PutNumberOfTasks method.
 		PutNumberOfTasks []struct {
@@ -426,23 +426,23 @@ func (mock *DataStorerMock) GetTaskCalls() []struct {
 }
 
 // GetTasks calls GetTasksFunc.
-func (mock *DataStorerMock) GetTasks(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+func (mock *DataStorerMock) GetTasks(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
 	if mock.GetTasksFunc == nil {
 		panic("DataStorerMock.GetTasksFunc: method is nil but DataStorer.GetTasks was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		Options mongo.Options
 		JobID   string
+		Options mongo.Options
 	}{
 		Ctx:     ctx,
-		Options: options,
 		JobID:   jobID,
+		Options: options,
 	}
 	lockDataStorerMockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
 	lockDataStorerMockGetTasks.Unlock()
-	return mock.GetTasksFunc(ctx, options, jobID)
+	return mock.GetTasksFunc(ctx, jobID, options)
 }
 
 // GetTasksCalls gets all the calls that were made to GetTasks.
@@ -450,13 +450,13 @@ func (mock *DataStorerMock) GetTasks(ctx context.Context, options mongo.Options,
 //     len(mockedDataStorer.GetTasksCalls())
 func (mock *DataStorerMock) GetTasksCalls() []struct {
 	Ctx     context.Context
-	Options mongo.Options
 	JobID   string
+	Options mongo.Options
 } {
 	var calls []struct {
 		Ctx     context.Context
-		Options mongo.Options
 		JobID   string
+		Options mongo.Options
 	}
 	lockDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -52,7 +52,7 @@ var _ api.DataStorer = &DataStorerMock{}
 //             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
 // 	               panic("mock out the GetJob method")
 //             },
-//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 // 	               panic("mock out the GetJobs method")
 //             },
 //             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
@@ -96,7 +96,7 @@ type DataStorerMock struct {
 	GetJobFunc func(ctx context.Context, id string) (*models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
-	GetJobsFunc func(ctx context.Context, options mongo.Options) (models.Jobs, error)
+	GetJobsFunc func(ctx context.Context, options mongo.Options) (*models.Jobs, error)
 
 	// GetTaskFunc mocks the GetTask method.
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
@@ -395,7 +395,7 @@ func (mock *DataStorerMock) GetJobCalls() []struct {
 }
 
 // GetJobs calls GetJobsFunc.
-func (mock *DataStorerMock) GetJobs(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+func (mock *DataStorerMock) GetJobs(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 	if mock.GetJobsFunc == nil {
 		panic("DataStorerMock.GetJobsFunc: method is nil but DataStorer.GetJobs was just called")
 	}

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -12,64 +12,82 @@ import (
 	"sync"
 )
 
-// Ensure, that DataStorerMock does implement api.DataStorer.
+var (
+	lockDataStorerMockAcquireJobLock      sync.RWMutex
+	lockDataStorerMockCheckInProgressJob  sync.RWMutex
+	lockDataStorerMockCreateJob           sync.RWMutex
+	lockDataStorerMockCreateTask          sync.RWMutex
+	lockDataStorerMockGetJob              sync.RWMutex
+	lockDataStorerMockGetJobs             sync.RWMutex
+	lockDataStorerMockGetTask             sync.RWMutex
+	lockDataStorerMockGetTasks            sync.RWMutex
+	lockDataStorerMockPutNumberOfTasks    sync.RWMutex
+	lockDataStorerMockUnlockJob           sync.RWMutex
+	lockDataStorerMockUpdateJob           sync.RWMutex
+	lockDataStorerMockValidateJobIDUnique sync.RWMutex
+)
+
+// Ensure, that DataStorerMock does implement DataStorer.
 // If this is not the case, regenerate this file with moq.
 var _ api.DataStorer = &DataStorerMock{}
 
 // DataStorerMock is a mock implementation of api.DataStorer.
 //
-// 	func TestSomethingThatUsesDataStorer(t *testing.T) {
+//     func TestSomethingThatUsesDataStorer(t *testing.T) {
 //
-// 		// make and configure a mocked api.DataStorer
-// 		mockedDataStorer := &DataStorerMock{
-// 			AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
-// 				panic("mock out the AcquireJobLock method")
-// 			},
-// 			CheckNewReindexCanBeCreatedFunc: func(ctx context.Context) error {
-// 				panic("mock out the CheckNewReindexCanBeCreated method")
-// 			},
-// 			CreateJobFunc: func(ctx context.Context, searchIndexName string) (*models.Job, error) {
-// 				panic("mock out the CreateJob method")
-// 			},
-// 			CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-// 				panic("mock out the CreateTask method")
-// 			},
-// 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
-// 				panic("mock out the GetJob method")
-// 			},
-// 			GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
-// 				panic("mock out the GetJobs method")
-// 			},
-// 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
-// 				panic("mock out the GetTask method")
-// 			},
-// 			GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
-// 				panic("mock out the GetTasks method")
-// 			},
-// 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
-// 				panic("mock out the PutNumberOfTasks method")
-// 			},
-// 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
-// 				panic("mock out the UnlockJob method")
-// 			},
-// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
-// 				panic("mock out the UpdateJob method")
-// 			},
-// 		}
+//         // make and configure a mocked api.DataStorer
+//         mockedDataStorer := &DataStorerMock{
+//             AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+// 	               panic("mock out the AcquireJobLock method")
+//             },
+//             CheckInProgressJobFunc: func(ctx context.Context) error {
+// 	               panic("mock out the CheckInProgressJob method")
+//             },
+//             CreateJobFunc: func(ctx context.Context, job models.Job) error {
+// 	               panic("mock out the CreateJob method")
+//             },
+//             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
+// 	               panic("mock out the CreateTask method")
+//             },
+//             GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
+// 	               panic("mock out the GetJob method")
+//             },
+//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+// 	               panic("mock out the GetJobs method")
+//             },
+//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+// 	               panic("mock out the GetTask method")
+//             },
+//             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+// 	               panic("mock out the GetTasks method")
+//             },
+//             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
+// 	               panic("mock out the PutNumberOfTasks method")
+//             },
+//             UnlockJobFunc: func(ctx context.Context, lockID string)  {
+// 	               panic("mock out the UnlockJob method")
+//             },
+//             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 	               panic("mock out the UpdateJob method")
+//             },
+//             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
+// 	               panic("mock out the ValidateJobIDUnique method")
+//             },
+//         }
 //
-// 		// use mockedDataStorer in code that requires api.DataStorer
-// 		// and then make assertions.
+//         // use mockedDataStorer in code that requires api.DataStorer
+//         // and then make assertions.
 //
-// 	}
+//     }
 type DataStorerMock struct {
 	// AcquireJobLockFunc mocks the AcquireJobLock method.
 	AcquireJobLockFunc func(ctx context.Context, id string) (string, error)
 
-	// CheckNewReindexCanBeCreatedFunc mocks the CheckNewReindexCanBeCreated method.
-	CheckNewReindexCanBeCreatedFunc func(ctx context.Context) error
+	// CheckInProgressJobFunc mocks the CheckInProgressJob method.
+	CheckInProgressJobFunc func(ctx context.Context) error
 
 	// CreateJobFunc mocks the CreateJob method.
-	CreateJobFunc func(ctx context.Context, searchIndexName string) (*models.Job, error)
+	CreateJobFunc func(ctx context.Context, job models.Job) error
 
 	// CreateTaskFunc mocks the CreateTask method.
 	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
@@ -95,6 +113,9 @@ type DataStorerMock struct {
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
 
+	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
+	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// AcquireJobLock holds details about calls to the AcquireJobLock method.
@@ -104,8 +125,8 @@ type DataStorerMock struct {
 			// ID is the id argument value.
 			ID string
 		}
-		// CheckNewReindexCanBeCreated holds details about calls to the CheckNewReindexCanBeCreated method.
-		CheckNewReindexCanBeCreated []struct {
+		// CheckInProgressJob holds details about calls to the CheckInProgressJob method.
+		CheckInProgressJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -113,8 +134,8 @@ type DataStorerMock struct {
 		CreateJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// SearchIndexName is the searchIndexName argument value.
-			SearchIndexName string
+			// Job is the job argument value.
+			Job models.Job
 		}
 		// CreateTask holds details about calls to the CreateTask method.
 		CreateTask []struct {
@@ -184,18 +205,14 @@ type DataStorerMock struct {
 			// Updates is the updates argument value.
 			Updates bson.M
 		}
+		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
+		ValidateJobIDUnique []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+		}
 	}
-	lockAcquireJobLock              sync.RWMutex
-	lockCheckNewReindexCanBeCreated sync.RWMutex
-	lockCreateJob                   sync.RWMutex
-	lockCreateTask                  sync.RWMutex
-	lockGetJob                      sync.RWMutex
-	lockGetJobs                     sync.RWMutex
-	lockGetTask                     sync.RWMutex
-	lockGetTasks                    sync.RWMutex
-	lockPutNumberOfTasks            sync.RWMutex
-	lockUnlockJob                   sync.RWMutex
-	lockUpdateJob                   sync.RWMutex
 }
 
 // AcquireJobLock calls AcquireJobLockFunc.
@@ -210,9 +227,9 @@ func (mock *DataStorerMock) AcquireJobLock(ctx context.Context, id string) (stri
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockAcquireJobLock.Lock()
+	lockDataStorerMockAcquireJobLock.Lock()
 	mock.calls.AcquireJobLock = append(mock.calls.AcquireJobLock, callInfo)
-	mock.lockAcquireJobLock.Unlock()
+	lockDataStorerMockAcquireJobLock.Unlock()
 	return mock.AcquireJobLockFunc(ctx, id)
 }
 
@@ -227,75 +244,75 @@ func (mock *DataStorerMock) AcquireJobLockCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockAcquireJobLock.RLock()
+	lockDataStorerMockAcquireJobLock.RLock()
 	calls = mock.calls.AcquireJobLock
-	mock.lockAcquireJobLock.RUnlock()
+	lockDataStorerMockAcquireJobLock.RUnlock()
 	return calls
 }
 
-// CheckNewReindexCanBeCreated calls CheckNewReindexCanBeCreatedFunc.
-func (mock *DataStorerMock) CheckNewReindexCanBeCreated(ctx context.Context) error {
-	if mock.CheckNewReindexCanBeCreatedFunc == nil {
-		panic("DataStorerMock.CheckNewReindexCanBeCreatedFunc: method is nil but DataStorer.CheckNewReindexCanBeCreated was just called")
+// CheckInProgressJob calls CheckInProgressJobFunc.
+func (mock *DataStorerMock) CheckInProgressJob(ctx context.Context) error {
+	if mock.CheckInProgressJobFunc == nil {
+		panic("DataStorerMock.CheckInProgressJobFunc: method is nil but DataStorer.CheckInProgressJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 	}{
 		Ctx: ctx,
 	}
-	mock.lockCheckNewReindexCanBeCreated.Lock()
-	mock.calls.CheckNewReindexCanBeCreated = append(mock.calls.CheckNewReindexCanBeCreated, callInfo)
-	mock.lockCheckNewReindexCanBeCreated.Unlock()
-	return mock.CheckNewReindexCanBeCreatedFunc(ctx)
+	lockDataStorerMockCheckInProgressJob.Lock()
+	mock.calls.CheckInProgressJob = append(mock.calls.CheckInProgressJob, callInfo)
+	lockDataStorerMockCheckInProgressJob.Unlock()
+	return mock.CheckInProgressJobFunc(ctx)
 }
 
-// CheckNewReindexCanBeCreatedCalls gets all the calls that were made to CheckNewReindexCanBeCreated.
+// CheckInProgressJobCalls gets all the calls that were made to CheckInProgressJob.
 // Check the length with:
-//     len(mockedDataStorer.CheckNewReindexCanBeCreatedCalls())
-func (mock *DataStorerMock) CheckNewReindexCanBeCreatedCalls() []struct {
+//     len(mockedDataStorer.CheckInProgressJobCalls())
+func (mock *DataStorerMock) CheckInProgressJobCalls() []struct {
 	Ctx context.Context
 } {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockCheckNewReindexCanBeCreated.RLock()
-	calls = mock.calls.CheckNewReindexCanBeCreated
-	mock.lockCheckNewReindexCanBeCreated.RUnlock()
+	lockDataStorerMockCheckInProgressJob.RLock()
+	calls = mock.calls.CheckInProgressJob
+	lockDataStorerMockCheckInProgressJob.RUnlock()
 	return calls
 }
 
 // CreateJob calls CreateJobFunc.
-func (mock *DataStorerMock) CreateJob(ctx context.Context, searchIndexName string) (*models.Job, error) {
+func (mock *DataStorerMock) CreateJob(ctx context.Context, job models.Job) error {
 	if mock.CreateJobFunc == nil {
 		panic("DataStorerMock.CreateJobFunc: method is nil but DataStorer.CreateJob was just called")
 	}
 	callInfo := struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}{
-		Ctx:             ctx,
-		SearchIndexName: searchIndexName,
+		Ctx: ctx,
+		Job: job,
 	}
-	mock.lockCreateJob.Lock()
+	lockDataStorerMockCreateJob.Lock()
 	mock.calls.CreateJob = append(mock.calls.CreateJob, callInfo)
-	mock.lockCreateJob.Unlock()
-	return mock.CreateJobFunc(ctx, searchIndexName)
+	lockDataStorerMockCreateJob.Unlock()
+	return mock.CreateJobFunc(ctx, job)
 }
 
 // CreateJobCalls gets all the calls that were made to CreateJob.
 // Check the length with:
 //     len(mockedDataStorer.CreateJobCalls())
 func (mock *DataStorerMock) CreateJobCalls() []struct {
-	Ctx             context.Context
-	SearchIndexName string
+	Ctx context.Context
+	Job models.Job
 } {
 	var calls []struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}
-	mock.lockCreateJob.RLock()
+	lockDataStorerMockCreateJob.RLock()
 	calls = mock.calls.CreateJob
-	mock.lockCreateJob.RUnlock()
+	lockDataStorerMockCreateJob.RUnlock()
 	return calls
 }
 
@@ -315,9 +332,9 @@ func (mock *DataStorerMock) CreateTask(ctx context.Context, jobID string, taskNa
 		TaskName:     taskName,
 		NumDocuments: numDocuments,
 	}
-	mock.lockCreateTask.Lock()
+	lockDataStorerMockCreateTask.Lock()
 	mock.calls.CreateTask = append(mock.calls.CreateTask, callInfo)
-	mock.lockCreateTask.Unlock()
+	lockDataStorerMockCreateTask.Unlock()
 	return mock.CreateTaskFunc(ctx, jobID, taskName, numDocuments)
 }
 
@@ -336,9 +353,9 @@ func (mock *DataStorerMock) CreateTaskCalls() []struct {
 		TaskName     string
 		NumDocuments int
 	}
-	mock.lockCreateTask.RLock()
+	lockDataStorerMockCreateTask.RLock()
 	calls = mock.calls.CreateTask
-	mock.lockCreateTask.RUnlock()
+	lockDataStorerMockCreateTask.RUnlock()
 	return calls
 }
 
@@ -354,9 +371,9 @@ func (mock *DataStorerMock) GetJob(ctx context.Context, id string) (models.Job, 
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockGetJob.Lock()
+	lockDataStorerMockGetJob.Lock()
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
-	mock.lockGetJob.Unlock()
+	lockDataStorerMockGetJob.Unlock()
 	return mock.GetJobFunc(ctx, id)
 }
 
@@ -371,9 +388,9 @@ func (mock *DataStorerMock) GetJobCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockGetJob.RLock()
+	lockDataStorerMockGetJob.RLock()
 	calls = mock.calls.GetJob
-	mock.lockGetJob.RUnlock()
+	lockDataStorerMockGetJob.RUnlock()
 	return calls
 }
 
@@ -389,9 +406,9 @@ func (mock *DataStorerMock) GetJobs(ctx context.Context, options mongo.Options) 
 		Ctx:     ctx,
 		Options: options,
 	}
-	mock.lockGetJobs.Lock()
+	lockDataStorerMockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	mock.lockGetJobs.Unlock()
+	lockDataStorerMockGetJobs.Unlock()
 	return mock.GetJobsFunc(ctx, options)
 }
 
@@ -406,9 +423,9 @@ func (mock *DataStorerMock) GetJobsCalls() []struct {
 		Ctx     context.Context
 		Options mongo.Options
 	}
-	mock.lockGetJobs.RLock()
+	lockDataStorerMockGetJobs.RLock()
 	calls = mock.calls.GetJobs
-	mock.lockGetJobs.RUnlock()
+	lockDataStorerMockGetJobs.RUnlock()
 	return calls
 }
 
@@ -426,9 +443,9 @@ func (mock *DataStorerMock) GetTask(ctx context.Context, jobID string, taskName 
 		JobID:    jobID,
 		TaskName: taskName,
 	}
-	mock.lockGetTask.Lock()
+	lockDataStorerMockGetTask.Lock()
 	mock.calls.GetTask = append(mock.calls.GetTask, callInfo)
-	mock.lockGetTask.Unlock()
+	lockDataStorerMockGetTask.Unlock()
 	return mock.GetTaskFunc(ctx, jobID, taskName)
 }
 
@@ -445,9 +462,9 @@ func (mock *DataStorerMock) GetTaskCalls() []struct {
 		JobID    string
 		TaskName string
 	}
-	mock.lockGetTask.RLock()
+	lockDataStorerMockGetTask.RLock()
 	calls = mock.calls.GetTask
-	mock.lockGetTask.RUnlock()
+	lockDataStorerMockGetTask.RUnlock()
 	return calls
 }
 
@@ -465,9 +482,9 @@ func (mock *DataStorerMock) GetTasks(ctx context.Context, options mongo.Options,
 		Options: options,
 		JobID:   jobID,
 	}
-	mock.lockGetTasks.Lock()
+	lockDataStorerMockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
-	mock.lockGetTasks.Unlock()
+	lockDataStorerMockGetTasks.Unlock()
 	return mock.GetTasksFunc(ctx, options, jobID)
 }
 
@@ -484,9 +501,9 @@ func (mock *DataStorerMock) GetTasksCalls() []struct {
 		Options mongo.Options
 		JobID   string
 	}
-	mock.lockGetTasks.RLock()
+	lockDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks
-	mock.lockGetTasks.RUnlock()
+	lockDataStorerMockGetTasks.RUnlock()
 	return calls
 }
 
@@ -504,9 +521,9 @@ func (mock *DataStorerMock) PutNumberOfTasks(ctx context.Context, id string, cou
 		ID:    id,
 		Count: count,
 	}
-	mock.lockPutNumberOfTasks.Lock()
+	lockDataStorerMockPutNumberOfTasks.Lock()
 	mock.calls.PutNumberOfTasks = append(mock.calls.PutNumberOfTasks, callInfo)
-	mock.lockPutNumberOfTasks.Unlock()
+	lockDataStorerMockPutNumberOfTasks.Unlock()
 	return mock.PutNumberOfTasksFunc(ctx, id, count)
 }
 
@@ -523,9 +540,9 @@ func (mock *DataStorerMock) PutNumberOfTasksCalls() []struct {
 		ID    string
 		Count int
 	}
-	mock.lockPutNumberOfTasks.RLock()
+	lockDataStorerMockPutNumberOfTasks.RLock()
 	calls = mock.calls.PutNumberOfTasks
-	mock.lockPutNumberOfTasks.RUnlock()
+	lockDataStorerMockPutNumberOfTasks.RUnlock()
 	return calls
 }
 
@@ -541,9 +558,9 @@ func (mock *DataStorerMock) UnlockJob(ctx context.Context, lockID string) {
 		Ctx:    ctx,
 		LockID: lockID,
 	}
-	mock.lockUnlockJob.Lock()
+	lockDataStorerMockUnlockJob.Lock()
 	mock.calls.UnlockJob = append(mock.calls.UnlockJob, callInfo)
-	mock.lockUnlockJob.Unlock()
+	lockDataStorerMockUnlockJob.Unlock()
 	mock.UnlockJobFunc(ctx, lockID)
 }
 
@@ -558,9 +575,9 @@ func (mock *DataStorerMock) UnlockJobCalls() []struct {
 		Ctx    context.Context
 		LockID string
 	}
-	mock.lockUnlockJob.RLock()
+	lockDataStorerMockUnlockJob.RLock()
 	calls = mock.calls.UnlockJob
-	mock.lockUnlockJob.RUnlock()
+	lockDataStorerMockUnlockJob.RUnlock()
 	return calls
 }
 
@@ -578,9 +595,9 @@ func (mock *DataStorerMock) UpdateJob(ctx context.Context, id string, updates bs
 		ID:      id,
 		Updates: updates,
 	}
-	mock.lockUpdateJob.Lock()
+	lockDataStorerMockUpdateJob.Lock()
 	mock.calls.UpdateJob = append(mock.calls.UpdateJob, callInfo)
-	mock.lockUpdateJob.Unlock()
+	lockDataStorerMockUpdateJob.Unlock()
 	return mock.UpdateJobFunc(ctx, id, updates)
 }
 
@@ -597,8 +614,43 @@ func (mock *DataStorerMock) UpdateJobCalls() []struct {
 		ID      string
 		Updates bson.M
 	}
-	mock.lockUpdateJob.RLock()
+	lockDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
-	mock.lockUpdateJob.RUnlock()
+	lockDataStorerMockUpdateJob.RUnlock()
+	return calls
+}
+
+// ValidateJobIDUnique calls ValidateJobIDUniqueFunc.
+func (mock *DataStorerMock) ValidateJobIDUnique(ctx context.Context, id string) error {
+	if mock.ValidateJobIDUniqueFunc == nil {
+		panic("DataStorerMock.ValidateJobIDUniqueFunc: method is nil but DataStorer.ValidateJobIDUnique was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  string
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	lockDataStorerMockValidateJobIDUnique.Lock()
+	mock.calls.ValidateJobIDUnique = append(mock.calls.ValidateJobIDUnique, callInfo)
+	lockDataStorerMockValidateJobIDUnique.Unlock()
+	return mock.ValidateJobIDUniqueFunc(ctx, id)
+}
+
+// ValidateJobIDUniqueCalls gets all the calls that were made to ValidateJobIDUnique.
+// Check the length with:
+//     len(mockedDataStorer.ValidateJobIDUniqueCalls())
+func (mock *DataStorerMock) ValidateJobIDUniqueCalls() []struct {
+	Ctx context.Context
+	ID  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  string
+	}
+	lockDataStorerMockValidateJobIDUnique.RLock()
+	calls = mock.calls.ValidateJobIDUnique
+	lockDataStorerMockValidateJobIDUnique.RUnlock()
 	return calls
 }

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -16,7 +16,6 @@ var (
 	lockDataStorerMockAcquireJobLock      sync.RWMutex
 	lockDataStorerMockCheckInProgressJob  sync.RWMutex
 	lockDataStorerMockCreateJob           sync.RWMutex
-	lockDataStorerMockCreateTask          sync.RWMutex
 	lockDataStorerMockGetJob              sync.RWMutex
 	lockDataStorerMockGetJobs             sync.RWMutex
 	lockDataStorerMockGetTask             sync.RWMutex
@@ -24,6 +23,7 @@ var (
 	lockDataStorerMockPutNumberOfTasks    sync.RWMutex
 	lockDataStorerMockUnlockJob           sync.RWMutex
 	lockDataStorerMockUpdateJob           sync.RWMutex
+	lockDataStorerMockUpsertTask          sync.RWMutex
 	lockDataStorerMockValidateJobIDUnique sync.RWMutex
 )
 
@@ -46,9 +46,6 @@ var _ api.DataStorer = &DataStorerMock{}
 //             CreateJobFunc: func(ctx context.Context, job models.Job) error {
 // 	               panic("mock out the CreateJob method")
 //             },
-//             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-// 	               panic("mock out the CreateTask method")
-//             },
 //             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
 // 	               panic("mock out the GetJob method")
 //             },
@@ -70,6 +67,9 @@ var _ api.DataStorer = &DataStorerMock{}
 //             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
 // 	               panic("mock out the UpdateJob method")
 //             },
+//             UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
+// 	               panic("mock out the UpsertTask method")
+//             },
 //             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
 // 	               panic("mock out the ValidateJobIDUnique method")
 //             },
@@ -88,9 +88,6 @@ type DataStorerMock struct {
 
 	// CreateJobFunc mocks the CreateJob method.
 	CreateJobFunc func(ctx context.Context, job models.Job) error
-
-	// CreateTaskFunc mocks the CreateTask method.
-	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
 
 	// GetJobFunc mocks the GetJob method.
 	GetJobFunc func(ctx context.Context, id string) (*models.Job, error)
@@ -112,6 +109,9 @@ type DataStorerMock struct {
 
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
+
+	// UpsertTaskFunc mocks the UpsertTask method.
+	UpsertTaskFunc func(ctx context.Context, jobID string, taskName string, task models.Task) error
 
 	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
 	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
@@ -136,17 +136,6 @@ type DataStorerMock struct {
 			Ctx context.Context
 			// Job is the job argument value.
 			Job models.Job
-		}
-		// CreateTask holds details about calls to the CreateTask method.
-		CreateTask []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// JobID is the jobID argument value.
-			JobID string
-			// TaskName is the taskName argument value.
-			TaskName string
-			// NumDocuments is the numDocuments argument value.
-			NumDocuments int
 		}
 		// GetJob holds details about calls to the GetJob method.
 		GetJob []struct {
@@ -204,6 +193,17 @@ type DataStorerMock struct {
 			ID string
 			// Updates is the updates argument value.
 			Updates bson.M
+		}
+		// UpsertTask holds details about calls to the UpsertTask method.
+		UpsertTask []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// JobID is the jobID argument value.
+			JobID string
+			// TaskName is the taskName argument value.
+			TaskName string
+			// Task is the task argument value.
+			Task models.Task
 		}
 		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
 		ValidateJobIDUnique []struct {
@@ -313,49 +313,6 @@ func (mock *DataStorerMock) CreateJobCalls() []struct {
 	lockDataStorerMockCreateJob.RLock()
 	calls = mock.calls.CreateJob
 	lockDataStorerMockCreateJob.RUnlock()
-	return calls
-}
-
-// CreateTask calls CreateTaskFunc.
-func (mock *DataStorerMock) CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-	if mock.CreateTaskFunc == nil {
-		panic("DataStorerMock.CreateTaskFunc: method is nil but DataStorer.CreateTask was just called")
-	}
-	callInfo := struct {
-		Ctx          context.Context
-		JobID        string
-		TaskName     string
-		NumDocuments int
-	}{
-		Ctx:          ctx,
-		JobID:        jobID,
-		TaskName:     taskName,
-		NumDocuments: numDocuments,
-	}
-	lockDataStorerMockCreateTask.Lock()
-	mock.calls.CreateTask = append(mock.calls.CreateTask, callInfo)
-	lockDataStorerMockCreateTask.Unlock()
-	return mock.CreateTaskFunc(ctx, jobID, taskName, numDocuments)
-}
-
-// CreateTaskCalls gets all the calls that were made to CreateTask.
-// Check the length with:
-//     len(mockedDataStorer.CreateTaskCalls())
-func (mock *DataStorerMock) CreateTaskCalls() []struct {
-	Ctx          context.Context
-	JobID        string
-	TaskName     string
-	NumDocuments int
-} {
-	var calls []struct {
-		Ctx          context.Context
-		JobID        string
-		TaskName     string
-		NumDocuments int
-	}
-	lockDataStorerMockCreateTask.RLock()
-	calls = mock.calls.CreateTask
-	lockDataStorerMockCreateTask.RUnlock()
 	return calls
 }
 
@@ -617,6 +574,49 @@ func (mock *DataStorerMock) UpdateJobCalls() []struct {
 	lockDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
 	lockDataStorerMockUpdateJob.RUnlock()
+	return calls
+}
+
+// UpsertTask calls UpsertTaskFunc.
+func (mock *DataStorerMock) UpsertTask(ctx context.Context, jobID string, taskName string, task models.Task) error {
+	if mock.UpsertTaskFunc == nil {
+		panic("DataStorerMock.UpsertTaskFunc: method is nil but DataStorer.UpsertTask was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		JobID    string
+		TaskName string
+		Task     models.Task
+	}{
+		Ctx:      ctx,
+		JobID:    jobID,
+		TaskName: taskName,
+		Task:     task,
+	}
+	lockDataStorerMockUpsertTask.Lock()
+	mock.calls.UpsertTask = append(mock.calls.UpsertTask, callInfo)
+	lockDataStorerMockUpsertTask.Unlock()
+	return mock.UpsertTaskFunc(ctx, jobID, taskName, task)
+}
+
+// UpsertTaskCalls gets all the calls that were made to UpsertTask.
+// Check the length with:
+//     len(mockedDataStorer.UpsertTaskCalls())
+func (mock *DataStorerMock) UpsertTaskCalls() []struct {
+	Ctx      context.Context
+	JobID    string
+	TaskName string
+	Task     models.Task
+} {
+	var calls []struct {
+		Ctx      context.Context
+		JobID    string
+		TaskName string
+		Task     models.Task
+	}
+	lockDataStorerMockUpsertTask.RLock()
+	calls = mock.calls.UpsertTask
+	lockDataStorerMockUpsertTask.RUnlock()
 	return calls
 }
 

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -49,7 +49,7 @@ var _ api.DataStorer = &DataStorerMock{}
 //             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
 // 	               panic("mock out the CreateTask method")
 //             },
-//             GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
+//             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
 // 	               panic("mock out the GetJob method")
 //             },
 //             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
@@ -93,7 +93,7 @@ type DataStorerMock struct {
 	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
 
 	// GetJobFunc mocks the GetJob method.
-	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
+	GetJobFunc func(ctx context.Context, id string) (*models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
 	GetJobsFunc func(ctx context.Context, options mongo.Options) (models.Jobs, error)
@@ -360,7 +360,7 @@ func (mock *DataStorerMock) CreateTaskCalls() []struct {
 }
 
 // GetJob calls GetJobFunc.
-func (mock *DataStorerMock) GetJob(ctx context.Context, id string) (models.Job, error) {
+func (mock *DataStorerMock) GetJob(ctx context.Context, id string) (*models.Job, error) {
 	if mock.GetJobFunc == nil {
 		panic("DataStorerMock.GetJobFunc: method is nil but DataStorer.GetJob was just called")
 	}

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -52,7 +52,7 @@ var _ api.DataStorer = &DataStorerMock{}
 //             GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 // 	               panic("mock out the GetJobs method")
 //             },
-//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
 // 	               panic("mock out the GetTask method")
 //             },
 //             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
@@ -96,7 +96,7 @@ type DataStorerMock struct {
 	GetJobsFunc func(ctx context.Context, options mongo.Options) (*models.Jobs, error)
 
 	// GetTaskFunc mocks the GetTask method.
-	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
+	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (*models.Task, error)
 
 	// GetTasksFunc mocks the GetTasks method.
 	GetTasksFunc func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error)
@@ -387,7 +387,7 @@ func (mock *DataStorerMock) GetJobsCalls() []struct {
 }
 
 // GetTask calls GetTaskFunc.
-func (mock *DataStorerMock) GetTask(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+func (mock *DataStorerMock) GetTask(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
 	if mock.GetTaskFunc == nil {
 		panic("DataStorerMock.GetTaskFunc: method is nil but DataStorer.GetTask was just called")
 	}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -47,12 +47,14 @@ func (api *API) CreateTaskHandler(w http.ResponseWriter, req *http.Request) {
 	// check if job exists
 	_, err = api.dataStore.GetJob(ctx, jobID)
 	if err != nil {
-		log.Error(ctx, "failed to get job", err, logData)
 		if err == mongo.ErrJobNotFound {
+			log.Error(ctx, "job not found", err, logData)
 			http.Error(w, apierrors.ErrJobNotFound.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+			return
 		}
+
+		log.Error(ctx, "failed to get job", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 		return
 	}
 
@@ -102,22 +104,31 @@ func (api *API) GetTaskHandler(w http.ResponseWriter, req *http.Request) {
 	host := req.Host
 
 	vars := mux.Vars(req)
-	id := vars["id"]
+	jobID := vars["id"]
 	taskName := vars["task_name"]
 
 	logData := log.Data{
-		"job_id":    id,
+		"job_id":    jobID,
 		"task_name": taskName,
 	}
 
-	// get task
-	task, err := api.dataStore.GetTask(ctx, id, taskName)
+	// check if job exists
+	_, err := api.dataStore.GetJob(ctx, jobID)
 	if err != nil {
 		if err == mongo.ErrJobNotFound {
 			log.Error(ctx, "job not found", err, logData)
 			http.Error(w, apierrors.ErrJobNotFound.Error(), http.StatusNotFound)
 			return
 		}
+
+		log.Error(ctx, "failed to get job", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+
+	// get task
+	task, err := api.dataStore.GetTask(ctx, jobID, taskName)
+	if err != nil {
 		if err == mongo.ErrTaskNotFound {
 			log.Error(ctx, "task not found", err, logData)
 			http.Error(w, apierrors.ErrTaskNotFound.Error(), http.StatusNotFound)
@@ -145,8 +156,7 @@ func (api *API) GetTaskHandler(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// GetTasksHandler gets a list of existing Task resources, from the data store, sorted by their values of
-// last_updated time (ascending)
+// GetTasksHandler gets a list of existing Task resources, from the data store, sorted by their values of last_updated time (ascending)
 func (api *API) GetTasksHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	host := req.Host

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -31,6 +31,8 @@ const (
 	validTaskName1        = "zebedee"
 	validTaskName2        = "dataset-api"
 	invalidTaskName       = "any-word-not-in-valid-list"
+	validLimit            = 2
+	validOffset           = 0
 	validServiceAuthToken = "Bearer fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67"
 )
 
@@ -40,12 +42,7 @@ var createTaskPayloadFmt = `{
 	"number_of_documents": 5
 }`
 
-func expectedTask(jobID, taskName string, jsonResponse bool, lastUpdated time.Time, numberOfDocuments int) (models.Task, error) {
-	cfg, err := config.Get()
-	if err != nil {
-		return models.Task{}, err
-	}
-
+func expectedTask(cfg *config.Config, jobID, taskName string, jsonResponse bool, lastUpdated time.Time, numberOfDocuments int) models.Task {
 	task := models.Task{
 		JobID:       jobID,
 		LastUpdated: lastUpdated,
@@ -62,7 +59,7 @@ func expectedTask(jobID, taskName string, jsonResponse bool, lastUpdated time.Ti
 		task.Links.Self = fmt.Sprintf("%s/%s%s", cfg.BindAddr, cfg.LatestVersion, task.Links.Self)
 	}
 
-	return task, nil
+	return task
 }
 
 func TestCreateTaskHandler(t *testing.T) {
@@ -119,10 +116,7 @@ func TestCreateTaskHandler(t *testing.T) {
 				err = json.Unmarshal(payload, &newTask)
 				So(err, ShouldBeNil)
 
-				expectedTask, err := expectedTask(validJobID1, validTaskName1, true, zeroTime, 5)
-				if err != nil {
-					t.Errorf("unable to build expected task, error: %v", err)
-				}
+				expectedTask := expectedTask(cfg, validJobID1, validTaskName1, true, zeroTime, 5)
 				So(resp.Header().Get("Etag"), ShouldNotBeEmpty)
 
 				Convey("And the new task resource should contain expected 	values", func() {
@@ -278,8 +272,8 @@ func TestGetTaskHandler(t *testing.T) {
 			return &job, nil
 		},
 		GetTaskFunc: func(ctx context.Context, jobID, taskName string) (*models.Task, error) {
-			task, err := expectedTask(jobID, taskName, false, zeroTime, 1)
-			return &task, err
+			task := expectedTask(cfg, jobID, taskName, false, zeroTime, 1)
+			return &task, nil
 		},
 	}
 
@@ -305,10 +299,7 @@ func TestGetTaskHandler(t *testing.T) {
 				err = json.Unmarshal(payload, &respTask)
 				So(err, ShouldBeNil)
 
-				expectedTask, err := expectedTask(validJobID1, validTaskName1, true, zeroTime, 1)
-				if err != nil {
-					t.Errorf("unable to build expected task, error: %v", err)
-				}
+				expectedTask := expectedTask(cfg, validJobID1, validTaskName1, true, zeroTime, 1)
 
 				Convey("And the new task resource should contain expected values", func() {
 					So(respTask.JobID, ShouldEqual, expectedTask.JobID)
@@ -429,6 +420,172 @@ func TestGetTaskHandler(t *testing.T) {
 				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
 				errMsg := strings.TrimSpace(resp.Body.String())
 				So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+			})
+		})
+	})
+}
+
+func TestGetTasksHandler(t *testing.T) {
+	cfg, err := config.Get()
+	if err != nil {
+		t.Errorf("failed to retrieve default configuration, error: %v", err)
+	}
+
+	dataStorerMock := &apiMock.DataStorerMock{
+		GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
+			switch id {
+			case validJobID1, validJobID2:
+				job := expectedJob(ctx, t, cfg, true, id, "", 2)
+				return &job, nil
+			case invalidJobID:
+				return nil, mongo.ErrJobNotFound
+			default:
+				return nil, errUnexpected
+			}
+		},
+
+		GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
+			switch jobID {
+			case validJobID2:
+				return nil, errUnexpected
+			default:
+				expectedTask1 := expectedTask(cfg, jobID, validTaskName1, false, zeroTime, 0)
+				expectedTask2 := expectedTask(cfg, jobID, validTaskName2, false, zeroTime, 0)
+
+				tasks := &models.Tasks{
+					Count:      2,
+					TaskList:   []models.Task{expectedTask1, expectedTask2},
+					Limit:      options.Limit,
+					Offset:     options.Offset,
+					TotalCount: 2,
+				}
+				return tasks, nil
+			}
+		},
+	}
+
+	Convey("Given a valid job id which exists in the datastore and valid pagination parameters", t, func() {
+		httpClient := dpHTTP.NewClient()
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+
+		Convey("When request is made to get tasks", func() {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks?offset=%d&limit=%d", validJobID1, validOffset, validLimit), nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then 200 status code should be returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusOK)
+
+				payload, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Errorf("failed to read payload with io.ReadAll, error: %v", err)
+				}
+
+				respTasks := models.Tasks{}
+				err = json.Unmarshal(payload, &respTasks)
+				So(err, ShouldBeNil)
+
+				expectedTask1 := expectedTask(cfg, validJobID1, validTaskName1, true, zeroTime, 0)
+				expectedTask2 := expectedTask(cfg, validJobID1, validTaskName2, true, zeroTime, 0)
+				expectedTasks := &models.Tasks{
+					Count:      2,
+					TaskList:   []models.Task{expectedTask1, expectedTask2},
+					Limit:      2,
+					Offset:     0,
+					TotalCount: 2,
+				}
+
+				Convey("And the new task resource should contain expected values", func() {
+					So(respTasks.Count, ShouldEqual, expectedTasks.Count)
+					So(respTasks.TaskList, ShouldResemble, expectedTasks.TaskList)
+					So(respTasks.Limit, ShouldEqual, expectedTasks.Limit)
+					So(respTasks.Offset, ShouldEqual, expectedTasks.Offset)
+					So(respTasks.TotalCount, ShouldEqual, expectedTasks.TotalCount)
+				})
+			})
+		})
+	})
+
+	Convey("Given invalid pagination parameter is given", t, func() {
+		invalidLimit := "abc"
+
+		httpClient := dpHTTP.NewClient()
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+
+		Convey("When request is made to get tasks", func() {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks?offset=%d&limit=%s", validJobID1, validOffset, invalidLimit), nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then 400 status code should be returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusBadRequest)
+
+				Convey("And an error message should be returned in the response body", func() {
+					errMsg := strings.TrimSpace(resp.Body.String())
+					So(errMsg, ShouldEqual, apierrors.ErrInvalidLimitParameter.Error())
+				})
+			})
+		})
+	})
+
+	Convey("Given job id is empty", t, func() {
+		httpClient := dpHTTP.NewClient()
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+
+		Convey("When request is made to get tasks", func() {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs//tasks?offset=%d&limit=%d", validOffset, validLimit), nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then moved permanently redirection 301 status code is returned by gorilla/mux as it cleans url path", func() {
+				So(resp.Code, ShouldEqual, http.StatusMovedPermanently)
+				errMsg := strings.TrimSpace(resp.Body.String())
+				So(errMsg, ShouldBeEmpty)
+			})
+		})
+	})
+
+	Convey("Given job id is invalid or job does not exist with the given job id", t, func() {
+		httpClient := dpHTTP.NewClient()
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+
+		Convey("When request is made to get tasks", func() {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks?offset=%d&limit=%d", invalidJobID, validOffset, validLimit), nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then status code 404 is returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusNotFound)
+
+				Convey("And an error message should be returned in the response body", func() {
+					errMsg := strings.TrimSpace(resp.Body.String())
+					So(errMsg, ShouldEqual, apierrors.ErrJobNotFound.Error())
+				})
+			})
+		})
+	})
+
+	Convey("Given an unexpected error occurs in the datastore", t, func() {
+		httpClient := dpHTTP.NewClient()
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+
+		Convey("When request is made to get tasks", func() {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks?offset=%d&limit=%d", validJobID2, validOffset, validLimit), nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then status code 500 is returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+
+				Convey("And an error message should be returned in the response body", func() {
+					errMsg := strings.TrimSpace(resp.Body.String())
+					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+				})
 			})
 		})
 	})

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -16,6 +16,7 @@ var (
 
 // A list of job error messages
 var (
+	ErrEmptyJobID            = errors.New("job id must not be an empty string")
 	ErrExistingJobInProgress = errors.New("existing reindex job in progress")
 	ErrInvalidNumTasks       = errors.New("number of tasks must be a positive integer")
 	ErrJobNotFound           = errors.New("failed to find the specified reindex job")

--- a/features/latest_version_features/getting_a_job.feature
+++ b/features/latest_version_features/getting_a_job.feature
@@ -20,6 +20,17 @@ Feature: Getting a job
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
 
+  Scenario: When request is made with empty job id and request returns StatusNotFound by gorilla/mux as handler is not found
+
+    Given the number of existing jobs in the Job Store is 0
+    And the api version is undefined for incoming requests
+    When I GET "/jobs/"
+    Then the HTTP status code should be "404"
+    And I should receive the following response:
+    """
+      404 page not found
+    """
+  
   Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
 
     Given the number of existing jobs in the Job Store is 0

--- a/features/latest_version_features/getting_a_job.feature
+++ b/features/latest_version_features/getting_a_job.feature
@@ -4,6 +4,7 @@ Feature: Getting a job
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
+    And I set the If-Match header to the generated e-tag
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
       | id                | UUID                                    |
@@ -19,6 +20,85 @@ Feature: Getting a job
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And the response should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I set the "If-Match" header to ""
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And the response should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I set the "If-Match" header to "*"
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And the response should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with outdated or invalid etag returns an conflict error
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I set the "If-Match" header to "invalid"
+    When I call GET /jobs/{id} using the generated id
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: When request is made with empty job id and request returns StatusNotFound by gorilla/mux as handler is not found
 
@@ -30,6 +110,7 @@ Feature: Getting a job
     """
       404 page not found
     """
+    And the response header "E-Tag" should be ""
   
   Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
 
@@ -37,6 +118,7 @@ Feature: Getting a job
     And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "404"
+    And the response header "E-Tag" should be ""
 
   Scenario: The connection to mongo DB is lost and a get request returns an internal server error
 
@@ -44,3 +126,4 @@ Feature: Getting a job
     And the api version is undefined for incoming requests
     When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
     Then the HTTP status code should be "500"
+    And the response header "E-Tag" should be ""

--- a/features/latest_version_features/getting_jobs.feature
+++ b/features/latest_version_features/getting_jobs.feature
@@ -4,6 +4,7 @@ Feature: Getting a list of jobs
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs"
     """
     """
@@ -23,16 +24,19 @@ Feature: Getting a list of jobs
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
 
   Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
     Given the number of existing jobs in the Job Store is 0
     And the api version is undefined for incoming requests
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs"
     """
     """
     Then I would expect the response to be an empty list
     And the HTTP status code should be "200"
+    And the response ETag header should not be empty
 
   Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
@@ -57,30 +61,114 @@ Feature: Getting a list of jobs
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
+
+    Given the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "*" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
 
   Scenario: Three jobs exist and a get request with negative offset returns an error
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?offset=-2"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
 
   Scenario: Three jobs exist and a get request with negative limit returns an error
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?limit=-3"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
 
   Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
     When I GET "/jobs?limit=1001"
     """
     """
     Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""

--- a/features/latest_version_features/patch_job_state_success.feature
+++ b/features/latest_version_features/patch_job_state_success.feature
@@ -82,6 +82,33 @@ Feature: Patch job state - Success
             | last_updated           | now or earlier            |
             | reindex_started        | now or earlier            |
             | state                  | in-progress               |
+
+    Scenario: Request is made where If-Match header is sets `*` to ask the API to ignore the ETag check
+
+        Given I use a service auth token "validServiceAuthToken"
+        And zebedee recognises the service auth token as valid
+        And the api version is undefined for incoming requests
+        And the number of existing jobs in the Job Store is 1
+        And I set the "If-Match" header to "*"
+        
+        When I call PATCH /jobs/{id} using the generated id
+        """
+        [
+            { "op": "replace", "path": "/state", "value": "in-progress" }
+        ]
+        """
+        
+        And the HTTP status code should be "204"
+        And the response header "Content-Type" should be ""
+        And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
+        And the job should only be updated with the following fields and values
+            | e_tag                  | new eTag                  |
+            | last_updated           | now or earlier            |
+            | reindex_started        | now or earlier            |
+            | state                  | in-progress               |
   
     Scenario: Request is made to update state to in-progress
 

--- a/features/latest_version_features/posting_a_job.feature
+++ b/features/latest_version_features/posting_a_job.feature
@@ -23,6 +23,7 @@ Feature: Posting a job
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the response header "Content-Type" should be "application/json"
+    And the response ETag header should not be empty
     And the reindex-requested event should contain the expected job ID and search index name
 
   Scenario: An existing reindex job is in progress resulting in conflict error 
@@ -35,6 +36,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "409"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     existing reindex job in progress
@@ -50,6 +52,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "500"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     internal server error
@@ -64,6 +67,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "500"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     internal server error
@@ -79,6 +83,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "500"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     internal server error

--- a/features/latest_version_features/posting_a_task.feature
+++ b/features/latest_version_features/posting_a_task.feature
@@ -19,19 +19,6 @@ Feature: Posting a task
       | number_of_documents | 29                           |
       | task_name           | dataset-api                  |
 
-  Scenario: The connection to mongo DB is lost and a post request returns an internal server error
-
-    Given I use a service auth token "validServiceAuthToken"
-    And zebedee recognises the service auth token as valid
-    And the api version is undefined for incoming requests
-    And the number of existing jobs in the Job Store is 1
-    And the search reindex api loses its connection to mongo DB
-    When I call POST /jobs/{id}/tasks using the generated id
-    """
-    { "task_name": "dataset-api", "number_of_documents": 29 }
-    """
-    Then the HTTP status code should be "500"
-
   Scenario: Task is updated successfully
 
     Given I use a service auth token "validServiceAuthToken"
@@ -58,30 +45,19 @@ Feature: Posting a task
       | number_of_documents | 36                           |
       | task_name           | dataset-api                  |
 
+  Scenario: Task is created successfully when provided with valid user token
 
-  Scenario: Request body cannot be read returns a bad request error
-
-    Given I use a service auth token "validServiceAuthToken"
-    And zebedee recognises the service auth token as valid
+    Given I use an X Florence user token "validXFlorenceToken"
+    And I am identified as "someone@somewhere.com"
+    And zebedee recognises the user token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I call POST /jobs/{id}/tasks using the generated id
-    """
-    { "task_name": "dataset-api", "number_of_documents": 29
-    """
-    Then the HTTP status code should be "400"
-
-  Scenario: Job does not exist and an attempt to create a task for it returns a not found error
-    Given I use a service auth token "validServiceAuthToken"
-    And zebedee recognises the service auth token as valid
-    And the api version is undefined for incoming requests
-    And the number of existing jobs in the Job Store is 0
-    And I POST "/jobs/any-job-id/tasks"
+    When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
     """
-    Then the HTTP status code should be "404"
-
+    Then the HTTP status code should be "201"
+  
   Scenario: No authorisation header set returns a bad request error
 
     Given I am not authorised
@@ -105,19 +81,6 @@ Feature: Posting a task
     """
     Then the HTTP status code should be "401"
 
-  Scenario: Valid user token returns bad request error
-
-    Given I use an X Florence user token "validXFlorenceToken"
-    And I am identified as "someone@somewhere.com"
-    And zebedee recognises the user token as valid
-    And the api version is undefined for incoming requests
-    And the number of existing jobs in the Job Store is 1
-    When I call POST /jobs/{id}/tasks using the generated id
-    """
-    { "task_name": "dataset-api", "number_of_documents": 29
-    """
-    Then the HTTP status code should be "400"
-
   Scenario: Invalid user token returns unauthorised error
 
     Given I use an X Florence user token "invalidXFlorenceToken"
@@ -130,6 +93,42 @@ Feature: Posting a task
     { "task_name": "dataset-api", "number_of_documents": 29
     """
     Then the HTTP status code should be "401"
+
+  Scenario: Invalid request body returns a bad request error
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "dataset-api", "number_of_documents": 29
+    """
+    Then the HTTP status code should be "400"
+  
+  Scenario: The connection to mongo DB is lost and a post request returns an internal server error
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And the search reindex api loses its connection to mongo DB
+    When I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "dataset-api", "number_of_documents": 29 }
+    """
+    Then the HTTP status code should be "500"
+
+  Scenario: Job does not exist and an attempt to create a task for it returns a not found error
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 0
+    And I POST "/jobs/any-job-id/tasks"
+    """
+    { "task_name": "dataset-api", "number_of_documents": 29 }
+    """
+    Then the HTTP status code should be "404"
 
   Scenario: Invalid task name returns bad request error
 

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -47,7 +47,7 @@ type SearchReindexAPIFeature struct {
 	APIFeature              *componentTest.APIFeature
 	AuthFeature             *componentTest.AuthorizationFeature
 	Config                  *config.Config
-	createdJob              models.Job
+	createdJob              *models.Job
 	errorChan               chan error
 	ErrorFeature            componentTest.ErrorFeature
 	HTTPServer              *http.Server

--- a/features/steps/datastore_steps.go
+++ b/features/steps/datastore_steps.go
@@ -23,7 +23,7 @@ func (f *SearchReindexAPIFeature) theTaskResourceShouldHaveTheFollowingFieldsAnd
 		Offset: f.Config.DefaultOffset,
 		Limit:  1,
 	}
-	tasksList, err := f.MongoClient.GetTasks(context.Background(), options, f.createdJob.ID)
+	tasksList, err := f.MongoClient.GetTasks(context.Background(), f.createdJob.ID, options)
 	if err != nil {
 		return fmt.Errorf("failed to get list of tasks: %w", err)
 	}

--- a/features/steps/helper.go
+++ b/features/steps/helper.go
@@ -34,8 +34,8 @@ func (f *SearchReindexAPIFeature) CallGetJobByID(version, id string) error {
 }
 
 // PutNumberOfTasks can be called by a feature step in order to call the PUT /jobs/{id}/number_of_tasks/{count} endpoint
-func (f *SearchReindexAPIFeature) PutNumberOfTasks(version, countStr string) error {
-	path := getPath(version, fmt.Sprintf("/jobs/%s/number_of_tasks/%s", f.createdJob.ID, countStr))
+func (f *SearchReindexAPIFeature) PutNumberOfTasks(version, id, countStr string) error {
+	path := getPath(version, fmt.Sprintf("/jobs/%s/number_of_tasks/%s", id, countStr))
 
 	var emptyBody = godog.DocString{}
 	err := f.APIFeature.IPut(path, &emptyBody)
@@ -72,7 +72,7 @@ func (f *SearchReindexAPIFeature) GetTaskForJob(version, jobID, taskName string)
 
 // checkJobUpdates can be called by a feature step that checks every field of a job resource to see if any updates have been made and checks if the expected
 // result have been updated to the relevant fields
-func (f *SearchReindexAPIFeature) checkJobUpdates(oldJob, updatedJob models.Job, expectedResult map[string]string) (err error) {
+func (f *SearchReindexAPIFeature) checkJobUpdates(oldJob, updatedJob *models.Job, expectedResult map[string]string) (err error) {
 	// get BSON tags for all fields of a job resource
 	jobBSONTags := getJobBSONTags()
 
@@ -116,7 +116,7 @@ func getJobBSONTags() []string {
 }
 
 // checkUpdateForJobField checks for an update of a given field in a job resource
-func (f *SearchReindexAPIFeature) checkUpdateForJobField(field string, oldJob, updatedJob models.Job, expectedResult map[string]string) error {
+func (f *SearchReindexAPIFeature) checkUpdateForJobField(field string, oldJob, updatedJob *models.Job, expectedResult map[string]string) error {
 	timeDifferenceCheck := 1 * time.Second
 
 	switch field {
@@ -154,7 +154,7 @@ func (f *SearchReindexAPIFeature) checkUpdateForJobField(field string, oldJob, u
 }
 
 // checkForNoChangeInJobField checks for no change in the value of a given field in a job resource
-func (f *SearchReindexAPIFeature) checkForNoChangeInJobField(field string, oldJob, updatedJob models.Job) error {
+func (f *SearchReindexAPIFeature) checkForNoChangeInJobField(field string, oldJob, updatedJob *models.Job) error {
 	switch field {
 	case models.JobETagKey:
 		assert.Equal(&f.ErrorFeature, oldJob.ETag, updatedJob.ETag)

--- a/features/steps/job_steps.go
+++ b/features/steps/job_steps.go
@@ -368,9 +368,14 @@ func (f *SearchReindexAPIFeature) theNoOfExistingJobsInTheJobStore(noOfJobs int)
 		var job *models.Job
 		for i := 1; i <= noOfJobs; i++ {
 			// create a job in mongo
-			job, err = f.MongoClient.CreateJob(ctx, "")
+			job, err = models.NewJob(ctx, "")
 			if err != nil {
-				return fmt.Errorf("failed to create job in mongo: %w", err)
+				return fmt.Errorf("failed to create new job: %w", err)
+			}
+
+			err = f.MongoClient.CreateJob(ctx, *job)
+			if err != nil {
+				return fmt.Errorf("failed to insert new job in mongo: %w", err)
 			}
 
 			if i <= noOfJobs {

--- a/features/steps/job_steps.go
+++ b/features/steps/job_steps.go
@@ -104,7 +104,7 @@ func (f *SearchReindexAPIFeature) iCallGETJobsUsingAValidUUID(id string) error {
 func (f *SearchReindexAPIFeature) iCallPUTJobsidnumberTofTasksUsingTheGeneratedID(count int) error {
 	countStr := strconv.Itoa(count)
 
-	err := f.PutNumberOfTasks(f.apiVersion, countStr)
+	err := f.PutNumberOfTasks(f.apiVersion, f.createdJob.ID, countStr)
 	if err != nil {
 		return fmt.Errorf("error occurred in PutNumberOfTasks: %w", err)
 	}
@@ -114,11 +114,10 @@ func (f *SearchReindexAPIFeature) iCallPUTJobsidnumberTofTasksUsingTheGeneratedI
 
 // iCallPUTJobsNumberoftasksUsingAValidUUID is a feature step that can be defined for a specific SearchReindexAPIFeature.
 // It uses the parameters passed in to call PUT /jobs/{id}/number_of_tasks/{count}
-func (f *SearchReindexAPIFeature) iCallPUTJobsNumberoftasksUsingAValidUUID(idStr string, count int) error {
+func (f *SearchReindexAPIFeature) iCallPUTJobsNumberoftasksUsingAValidUUID(id string, count int) error {
 	countStr := strconv.Itoa(count)
-	f.createdJob.ID = idStr
 
-	err := f.PutNumberOfTasks(f.apiVersion, countStr)
+	err := f.PutNumberOfTasks(f.apiVersion, id, countStr)
 	if err != nil {
 		return fmt.Errorf("error occurred in PutNumberOfTasks: %w", err)
 	}
@@ -129,7 +128,7 @@ func (f *SearchReindexAPIFeature) iCallPUTJobsNumberoftasksUsingAValidUUID(idStr
 // iCallPUTJobsidnumberoftasksUsingTheGeneratedIDWithAnInvalidCount is a feature step that can be defined for a specific SearchReindexAPIFeature.
 // It gets the id from the response body, generated in the previous step, and then uses this to call PUT /jobs/{id}/number_of_tasks/{invalidCount}
 func (f *SearchReindexAPIFeature) iCallPUTJobsidnumberoftasksUsingTheGeneratedIDWithAnInvalidCount(invalidCount string) error {
-	err := f.PutNumberOfTasks(f.apiVersion, invalidCount)
+	err := f.PutNumberOfTasks(f.apiVersion, f.createdJob.ID, invalidCount)
 	if err != nil {
 		return fmt.Errorf("error occurred in PutNumberOfTasks: %w", err)
 	}
@@ -140,7 +139,7 @@ func (f *SearchReindexAPIFeature) iCallPUTJobsidnumberoftasksUsingTheGeneratedID
 // iCallPUTJobsidnumberoftasksUsingTheGeneratedIDWithANegativeCount is a feature step that can be defined for a specific SearchReindexAPIFeature.
 // It gets the id from the response body, generated in the previous step, and then uses this to call PUT /jobs/{id}/number_of_tasks/{negativeCount}
 func (f *SearchReindexAPIFeature) iCallPUTJobsidnumberoftasksUsingTheGeneratedIDWithANegativeCount(negativeCount string) error {
-	err := f.PutNumberOfTasks(f.apiVersion, negativeCount)
+	err := f.PutNumberOfTasks(f.apiVersion, f.createdJob.ID, negativeCount)
 	if err != nil {
 		return fmt.Errorf("error occurred in PutNumberOfTasks: %w", err)
 	}
@@ -383,7 +382,7 @@ func (f *SearchReindexAPIFeature) theNoOfExistingJobsInTheJobStore(noOfJobs int)
 			}
 		}
 
-		f.createdJob = *job
+		f.createdJob = job
 	}
 
 	return f.ErrorFeature.StepError()
@@ -478,6 +477,7 @@ func (f *SearchReindexAPIFeature) theResponseShouldContainValuesThatHaveTheseStr
 	if err != nil {
 		return err
 	}
+	f.createdJob = responseJob
 
 	assist := assistdog.NewDefault()
 	expectedResult, err := assist.ParseMap(table)

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -37,6 +37,7 @@ func (f *SearchReindexAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I have created a task for the generated job$`, f.iHaveCreatedATaskForTheGeneratedJob)
 	ctx.Step(`^I set the If-Match header to the generated e-tag$`, f.iSetIfMatchHeaderToTheGeneratedETag)
 	ctx.Step(`^I set the "If-Match" header to the old e-tag$`, f.iSetIfMatchHeaderToTheOldGeneratedETag)
+	ctx.Step(`^I set the If-Match header to a valid e-tag to get jobs$`, f.iSetIfMatchHeaderToValidETagForJobs)
 	ctx.Step(`^the number of existing jobs in the Job Store is (\d+)$`, f.theNoOfExistingJobsInTheJobStore)
 
 	ctx.Step(`^I would expect the response to be an empty list$`, f.iWouldExpectTheResponseToBeAnEmptyList)

--- a/features/steps/task_steps.go
+++ b/features/steps/task_steps.go
@@ -286,7 +286,7 @@ func (f *SearchReindexAPIFeature) theTaskShouldHaveTheFollowingFieldsAndValues(t
 		Offset: f.Config.DefaultOffset,
 		Limit:  1,
 	}
-	tasksList, err := f.MongoClient.GetTasks(context.Background(), options, f.createdJob.ID)
+	tasksList, err := f.MongoClient.GetTasks(context.Background(), f.createdJob.ID, options)
 	if err != nil {
 		return fmt.Errorf("failed to get list of tasks: %w", err)
 	}

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -1,17 +1,21 @@
-Feature: Getting a job
+Feature: Getting a list of jobs
 
-  Scenario: Job exists in the Job Store and a get request returns it successfully
+  Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 1
-    When I call GET /jobs/{id} using the generated id
-    Then the response should contain values that have these structures
-      | id                | UUID                      |
-      | last_updated      | Not in the future         |
-      | links: tasks      | {host}/v1/jobs/{id}/tasks |
-      | links: self       | {host}/v1/jobs/{id}       |
-      | search_index_name | ons{date_stamp}           |
-    And the response should also contain the following values:
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
       | reindex_failed                  | 0001-01-01T00:00:00Z      |
@@ -19,28 +23,152 @@ Feature: Getting a job
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
 
-  Scenario: When request is made with empty job id and request returns StatusNotFound by gorilla/mux as handler is not found
-
-    Given the number of existing jobs in the Job Store is 0
-    And the api version is undefined for incoming requests
-    When I GET "/jobs/"
-    Then the HTTP status code should be "404"
-    And I should receive the following response:
-    """
-      404 page not found
-    """
-  
-  Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
+  Scenario: No Jobs exist in the Job Store and a get request returns an empty list
 
     Given the number of existing jobs in the Job Store is 0
     And the api version is v1 for incoming requests
-    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
-    Then the HTTP status code should be "404"
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect the response to be an empty list
+    And the HTTP status code should be "200"
+    And the response ETag header should not be empty
 
-  Scenario: The connection to mongo DB is lost and a get request returns an internal server error
+  Scenario: Six jobs exist and a get request with offset and limit correctly returns four
 
-    Given the search reindex api loses its connection to mongo DB
-    And the api version is v1 for incoming requests
-    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
-    Then the HTTP status code should be "500"
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 6
+    When I GET "/jobs?offset=1&limit=4"
+    """
+    """
+    Then I would expect there to be four jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the "If-Match" header to "*" 
+    When I GET "/jobs"
+    """
+    """
+    Then I would expect there to be three or more jobs returned in a list
+    And in each job I would expect the response to contain values that have these structures
+      | id                | UUID                                    |
+      | last_updated      | Not in the future                       |
+      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
+      | links: self       | {host}/{latest_version}/jobs/{id}       |
+      | search_index_name | ons{date_stamp}                         |
+    And each job should also contain the following values:
+      | number_of_tasks                 | 0                         |
+      | reindex_completed               | 0001-01-01T00:00:00Z      |
+      | reindex_failed                  | 0001-01-01T00:00:00Z      |
+      | reindex_started                 | 0001-01-01T00:00:00Z      |
+      | state                           | created                   |
+      | total_search_documents          | 0                         |
+      | total_inserted_search_documents | 0                         |
+    And the jobs should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Three jobs exist and a get request with negative offset returns an error
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs?offset=-2"
+    """
+    """
+    Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
+
+  Scenario: Three jobs exist and a get request with negative limit returns an error
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs?limit=-3"
+    """
+    """
+    Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
+
+  Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
+
+    Given the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 3
+    And I set the If-Match header to a valid e-tag to get jobs
+    When I GET "/jobs?limit=1001"
+    """
+    """
+    Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -20,6 +20,17 @@ Feature: Getting a job
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
 
+  Scenario: When request is made with empty job id and request returns StatusNotFound by gorilla/mux as handler is not found
+
+    Given the number of existing jobs in the Job Store is 0
+    And the api version is undefined for incoming requests
+    When I GET "/jobs/"
+    Then the HTTP status code should be "404"
+    And I should receive the following response:
+    """
+      404 page not found
+    """
+  
   Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
 
     Given the number of existing jobs in the Job Store is 0

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -1,21 +1,18 @@
-Feature: Getting a list of jobs
+Feature: Getting a job
 
-  Scenario: Three Jobs exist in the Job Store and a get request returns them successfully
+  Scenario: Job exists in the Job Store and a get request returns it successfully
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
+    And the number of existing jobs in the Job Store is 1
+    And I set the If-Match header to the generated e-tag
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
       | id                | UUID                                    |
       | last_updated      | Not in the future                       |
       | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
       | links: self       | {host}/{latest_version}/jobs/{id}       |
       | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
+    And the response should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
       | reindex_failed                  | 0001-01-01T00:00:00Z      |
@@ -23,61 +20,20 @@ Feature: Getting a list of jobs
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
-    And the response ETag header should not be empty
-
-  Scenario: No Jobs exist in the Job Store and a get request returns an empty list
-
-    Given the number of existing jobs in the Job Store is 0
-    And the api version is v1 for incoming requests
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect the response to be an empty list
-    And the HTTP status code should be "200"
-    And the response ETag header should not be empty
-
-  Scenario: Six jobs exist and a get request with offset and limit correctly returns four
-
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 6
-    When I GET "/jobs?offset=1&limit=4"
-    """
-    """
-    Then I would expect there to be four jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
-      | id                | UUID                                    |
-      | last_updated      | Not in the future                       |
-      | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
-      | links: self       | {host}/{latest_version}/jobs/{id}       |
-      | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
-      | number_of_tasks                 | 0                         |
-      | reindex_completed               | 0001-01-01T00:00:00Z      |
-      | reindex_failed                  | 0001-01-01T00:00:00Z      |
-      | reindex_started                 | 0001-01-01T00:00:00Z      |
-      | state                           | created                   |
-      | total_search_documents          | 0                         |
-      | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
     And the response ETag header should not be empty
 
   Scenario: Request made with no If-Match header ignores the ETag check and returns jobs successfully
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
+    And the number of existing jobs in the Job Store is 1
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
       | id                | UUID                                    |
       | last_updated      | Not in the future                       |
       | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
       | links: self       | {host}/{latest_version}/jobs/{id}       |
       | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
+    And the response should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
       | reindex_failed                  | 0001-01-01T00:00:00Z      |
@@ -85,25 +41,21 @@ Feature: Getting a list of jobs
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
     And the response ETag header should not be empty
 
   Scenario: Request made with empty If-Match header ignores the ETag check and returns jobs successfully
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the "If-Match" header to "" 
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
+    And the number of existing jobs in the Job Store is 1
+    And I set the "If-Match" header to ""
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
       | id                | UUID                                    |
       | last_updated      | Not in the future                       |
       | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
       | links: self       | {host}/{latest_version}/jobs/{id}       |
       | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
+    And the response should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
       | reindex_failed                  | 0001-01-01T00:00:00Z      |
@@ -111,25 +63,21 @@ Feature: Getting a list of jobs
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
     And the response ETag header should not be empty
 
   Scenario: Request made with If-Match set to `*` ignores the ETag check and returns jobs successfully
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the "If-Match" header to "*" 
-    When I GET "/jobs"
-    """
-    """
-    Then I would expect there to be three or more jobs returned in a list
-    And in each job I would expect the response to contain values that have these structures
+    And the number of existing jobs in the Job Store is 1
+    And I set the "If-Match" header to "*"
+    When I call GET /jobs/{id} using the generated id
+    Then the response should contain values that have these structures
       | id                | UUID                                    |
       | last_updated      | Not in the future                       |
       | links: tasks      | {host}/{latest_version}/jobs/{id}/tasks |
       | links: self       | {host}/{latest_version}/jobs/{id}       |
       | search_index_name | ons{date_stamp}                         |
-    And each job should also contain the following values:
+    And the response should also contain the following values:
       | number_of_tasks                 | 0                         |
       | reindex_completed               | 0001-01-01T00:00:00Z      |
       | reindex_failed                  | 0001-01-01T00:00:00Z      |
@@ -137,38 +85,45 @@ Feature: Getting a list of jobs
       | state                           | created                   |
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
-    And the jobs should be ordered, by last_updated, with the oldest first
     And the response ETag header should not be empty
 
-  Scenario: Three jobs exist and a get request with negative offset returns an error
+  Scenario: Request made with outdated or invalid etag returns an conflict error
 
     Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs?offset=-2"
+    And the number of existing jobs in the Job Store is 1
+    And I set the "If-Match" header to "invalid"
+    When I call GET /jobs/{id} using the generated id
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
     """
-    """
-    Then the HTTP status code should be "400"
+      etag does not match with current state of resource
+    """ 
     And the response header "E-Tag" should be ""
 
-  Scenario: Three jobs exist and a get request with negative limit returns an error
+  Scenario: When request is made with empty job id and request returns StatusNotFound by gorilla/mux as handler is not found
 
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs?limit=-3"
+    Given the number of existing jobs in the Job Store is 0
+    And the api version is v1 for incoming requests
+    When I GET "/jobs/"
+    Then the HTTP status code should be "404"
+    And I should receive the following response:
     """
+      404 page not found
     """
-    Then the HTTP status code should be "400"
+    And the response header "E-Tag" should be ""
+  
+  Scenario: Job does not exist in the Job Store and a get request returns StatusNotFound
+
+    Given the number of existing jobs in the Job Store is 0
+    And the api version is v1 for incoming requests
+    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
+    Then the HTTP status code should be "404"
     And the response header "E-Tag" should be ""
 
-  Scenario: Three jobs exist and a get request with limit greater than the maximum returns an error
+  Scenario: The connection to mongo DB is lost and a get request returns an internal server error
 
-    Given the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 3
-    And I set the If-Match header to a valid e-tag to get jobs
-    When I GET "/jobs?limit=1001"
-    """
-    """
-    Then the HTTP status code should be "400"
+    Given the search reindex api loses its connection to mongo DB
+    And the api version is v1 for incoming requests
+    When I call GET /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"} using a valid UUID
+    Then the HTTP status code should be "500"
     And the response header "E-Tag" should be ""

--- a/features/v1_features/latest_version_features/patch_job_state_success.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_success.feature
@@ -82,6 +82,33 @@ Feature: Patch job state - Success
             | last_updated           | now or earlier            |
             | reindex_started        | now or earlier            |
             | state                  | in-progress               |
+    
+    Scenario: Request is made where If-Match header is sets `*` to ask the API to ignore the ETag check
+
+        Given I use a service auth token "validServiceAuthToken"
+        And zebedee recognises the service auth token as valid
+        And the api version is v1 for incoming requests
+        And the number of existing jobs in the Job Store is 1
+        And I set the "If-Match" header to "*"
+        
+        When I call PATCH /jobs/{id} using the generated id
+        """
+        [
+            { "op": "replace", "path": "/state", "value": "in-progress" }
+        ]
+        """
+        
+        And the HTTP status code should be "204"
+        And the response header "Content-Type" should be ""
+        And the response ETag header should not be empty
+        And I should receive the following response:
+        """
+        """
+        And the job should only be updated with the following fields and values
+            | e_tag                  | new eTag                  |
+            | last_updated           | now or earlier            |
+            | reindex_started        | now or earlier            |
+            | state                  | in-progress               |
   
     Scenario: Request is made to update state to in-progress
 

--- a/features/v1_features/latest_version_features/posting_a_job.feature
+++ b/features/v1_features/latest_version_features/posting_a_job.feature
@@ -23,6 +23,7 @@ Feature: Posting a job
       | total_search_documents          | 0                         |
       | total_inserted_search_documents | 0                         |
     And the response header "Content-Type" should be "application/json"
+    And the response ETag header should not be empty
     And the reindex-requested event should contain the expected job ID and search index name
 
   Scenario: An existing reindex job is in progress resulting in conflict error 
@@ -35,6 +36,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "409"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     existing reindex job in progress
@@ -50,6 +52,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "500"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     internal server error
@@ -64,6 +67,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "500"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     internal server error
@@ -79,6 +83,7 @@ Feature: Posting a job
     """
     Then the HTTP status code should be "500"
     And the response header "Content-Type" should be "text/plain; charset=utf-8"
+    And the response header "E-Tag" should be ""
     And I should receive the following response: 
     """
     internal server error

--- a/features/v1_features/latest_version_features/posting_a_task.feature
+++ b/features/v1_features/latest_version_features/posting_a_task.feature
@@ -19,19 +19,6 @@ Feature: Posting a task
       | number_of_documents | 29                           |
       | task_name           | dataset-api                  |
 
-  Scenario: The connection to mongo DB is lost and a post request returns an internal server error
-
-    Given I use a service auth token "validServiceAuthToken"
-    And zebedee recognises the service auth token as valid
-    And the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 1
-    And the search reindex api loses its connection to mongo DB
-    When I call POST /jobs/{id}/tasks using the generated id
-    """
-    { "task_name": "dataset-api", "number_of_documents": 29 }
-    """
-    Then the HTTP status code should be "500"
-
   Scenario: Task is updated successfully
 
     Given I use a service auth token "validServiceAuthToken"
@@ -58,30 +45,19 @@ Feature: Posting a task
       | number_of_documents | 36                           |
       | task_name           | dataset-api                  |
 
+  Scenario: Task is created successfully when provided with valid user token
 
-  Scenario: Request body cannot be read returns a bad request error
-
-    Given I use a service auth token "validServiceAuthToken"
-    And zebedee recognises the service auth token as valid
+    Given I use an X Florence user token "validXFlorenceToken"
+    And I am identified as "someone@somewhere.com"
+    And zebedee recognises the user token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I call POST /jobs/{id}/tasks using the generated id
-    """
-    { "task_name": "dataset-api", "number_of_documents": 29
-    """
-    Then the HTTP status code should be "400"
-
-  Scenario: Job does not exist and an attempt to create a task for it returns a not found error
-    Given I use a service auth token "validServiceAuthToken"
-    And zebedee recognises the service auth token as valid
-    And the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 0
-    And I POST "/jobs/any-job-id/tasks"
+    When I call POST /jobs/{id}/tasks using the generated id
     """
     { "task_name": "dataset-api", "number_of_documents": 29 }
     """
-    Then the HTTP status code should be "404"
-
+    Then the HTTP status code should be "201"
+  
   Scenario: No authorisation header set returns a bad request error
 
     Given I am not authorised
@@ -105,19 +81,6 @@ Feature: Posting a task
     """
     Then the HTTP status code should be "401"
 
-  Scenario: Valid user token returns bad request error
-
-    Given I use an X Florence user token "validXFlorenceToken"
-    And I am identified as "someone@somewhere.com"
-    And zebedee recognises the user token as valid
-    And the api version is v1 for incoming requests
-    And the number of existing jobs in the Job Store is 1
-    When I call POST /jobs/{id}/tasks using the generated id
-    """
-    { "task_name": "dataset-api", "number_of_documents": 29
-    """
-    Then the HTTP status code should be "400"
-
   Scenario: Invalid user token returns unauthorised error
 
     Given I use an X Florence user token "invalidXFlorenceToken"
@@ -130,6 +93,42 @@ Feature: Posting a task
     { "task_name": "dataset-api", "number_of_documents": 29
     """
     Then the HTTP status code should be "401"
+
+  Scenario: Invalid request body returns a bad request error
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "dataset-api", "number_of_documents": 29
+    """
+    Then the HTTP status code should be "400"
+  
+  Scenario: The connection to mongo DB is lost and a post request returns an internal server error
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And the search reindex api loses its connection to mongo DB
+    When I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "dataset-api", "number_of_documents": 29 }
+    """
+    Then the HTTP status code should be "500"
+
+  Scenario: Job does not exist and an attempt to create a task for it returns a not found error
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 0
+    And I POST "/jobs/any-job-id/tasks"
+    """
+    { "task_name": "dataset-api", "number_of_documents": 29 }
+    """
+    Then the HTTP status code should be "404"
 
   Scenario: Invalid task name returns bad request error
 

--- a/models/etag.go
+++ b/models/etag.go
@@ -30,6 +30,19 @@ func GenerateETagForJob(ctx context.Context, updatedJob Job) (eTag string, err e
 	return eTag, nil
 }
 
+// GenerateETagForJobs generates a new eTag for a jobs resource
+func GenerateETagForJobs(ctx context.Context, jobs Jobs) (eTag string, err error) {
+	b, err := bson.Marshal(jobs)
+	if err != nil {
+		log.Error(ctx, "failed to marshal jobs", err)
+		return "", err
+	}
+
+	eTag = dpresponse.GenerateETag(b, false)
+
+	return eTag, nil
+}
+
 // GenerateETagForTask generates a new eTag for a task resource
 func GenerateETagForTask(task Task) (eTag string, err error) {
 	// ignoring the metadata LastUpdated and currentEtag when generating new eTag

--- a/models/etag_test.go
+++ b/models/etag_test.go
@@ -59,7 +59,7 @@ func getTestJob() models.Job {
 	return models.Job{
 		ID:          "test1",
 		ETag:        `"56b6890f1321590998d5fd8d293b620581ff3531"`,
-		LastUpdated: time.Now().UTC(),
+		LastUpdated: zeroTime,
 		Links: &models.JobLinks{
 			Tasks: "http://localhost:25700/jobs/test1234/tasks",
 			Self:  "http://localhost:25700/jobs/test1234",
@@ -73,6 +73,60 @@ func getTestJob() models.Job {
 		TotalSearchDocuments:         0,
 		TotalInsertedSearchDocuments: 0,
 	}
+}
+
+func TestGenerateETagForJobs(t *testing.T) {
+	ctx := context.Background()
+
+	job := getTestJob()
+	jobs := models.Jobs{
+		Count:      1,
+		JobList:    []models.Job{job},
+		Limit:      1,
+		Offset:     0,
+		TotalCount: 1,
+	}
+
+	jobsETag := `"89ffa9ad7f168112ad68de35a7bef9c64535b019"`
+
+	Convey("Given the list of jobs has updated", t, func() {
+		updatedJobs := jobs
+		updatedJobs.Limit = 10
+
+		Convey("When GenerateETagForJobs is called", func() {
+			newETag, err := models.GenerateETagForJobs(ctx, updatedJobs)
+
+			Convey("Then a new eTag is created", func() {
+				So(newETag, ShouldNotBeEmpty)
+
+				Convey("And new eTag should not be the same as the old eTag", func() {
+					So(newETag, ShouldNotEqual, jobsETag)
+
+					Convey("And no errors should be returned", func() {
+						So(err, ShouldBeNil)
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given an existing task with no new updates", t, func() {
+		Convey("When GenerateETagForTask is called", func() {
+			newETag, err := models.GenerateETagForJobs(ctx, jobs)
+
+			Convey("Then an eTag is returned", func() {
+				So(newETag, ShouldNotBeEmpty)
+
+				Convey("And the eTag should be the same as the existing eTag", func() {
+					So(newETag, ShouldEqual, jobsETag)
+
+					Convey("And no errors should be returned", func() {
+						So(err, ShouldBeNil)
+					})
+				})
+			})
+		})
+	})
 }
 
 func TestGenerateETagForTask(t *testing.T) {

--- a/models/job.go
+++ b/models/job.go
@@ -34,7 +34,7 @@ const (
 
 // Job represents a job metadata model and json representation for API
 type Job struct {
-	ETag                         string    `bson:"e_tag"`
+	ETag                         string    `bson:"e_tag"                            json:"-"`
 	ID                           string    `bson:"_id"                              json:"id"`
 	LastUpdated                  time.Time `bson:"last_updated"                     json:"last_updated"`
 	Links                        *JobLinks `bson:"links"                            json:"links"`

--- a/models/job.go
+++ b/models/job.go
@@ -60,9 +60,14 @@ type JobLinks struct {
 	Self  string `json:"self"`
 }
 
+// NewJobID returns a unique UUID for a job resource and this can be used to mock the ID in tests
+var NewJobID = func() string {
+	return uuid.NewV4().String()
+}
+
 // NewJob returns a new Job resource that it creates and populates with default values.
 func NewJob(ctx context.Context, searchIndexName string) (*Job, error) {
-	id := uuid.NewV4().String()
+	id := NewJobID()
 	zeroTime := time.Time{}.UTC()
 
 	newJob := Job{

--- a/models/job_test.go
+++ b/models/job_test.go
@@ -23,6 +23,7 @@ func TestNewJob(t *testing.T) {
 			Convey("Then a new job resource should be created and returned", func() {
 				So(job, ShouldNotBeEmpty)
 				So(job.ID, ShouldNotBeEmpty)
+				So(job.ETag, ShouldNotBeEmpty)
 
 				// check LastUpdated to a degree of seconds
 				So(job.LastUpdated.Day(), ShouldEqual, currentTime.Day())

--- a/models/task.go
+++ b/models/task.go
@@ -34,27 +34,27 @@ func ParseTaskName(taskName string, taskNames map[string]bool) error {
 }
 
 // NewTask returns a new Task resource that it creates and populates with default values.
-func NewTask(ctx context.Context, jobID, taskName string, numDocuments int) (Task, error) {
+func NewTask(ctx context.Context, jobID string, taskToCreate *TaskToCreate) (*Task, error) {
 	newTask := Task{
 		JobID:       jobID,
 		LastUpdated: time.Now().UTC(),
 		Links: &TaskLinks{
-			Self: fmt.Sprintf("/jobs/%s/tasks/%s", jobID, taskName),
+			Self: fmt.Sprintf("/jobs/%s/tasks/%s", jobID, taskToCreate.TaskName),
 			Job:  fmt.Sprintf("/jobs/%s", jobID),
 		},
-		NumberOfDocuments: numDocuments,
-		TaskName:          taskName,
+		NumberOfDocuments: taskToCreate.NumberOfDocuments,
+		TaskName:          taskToCreate.TaskName,
 	}
 
 	taskETag, err := GenerateETagForTask(newTask)
 	if err != nil {
 		logData := log.Data{"new_task": newTask}
 		log.Error(ctx, "failed to generate etag for task", err, logData)
-		return Task{}, err
+		return nil, err
 	}
 	newTask.ETag = taskETag
 
-	return newTask, nil
+	return &newTask, nil
 }
 
 // TaskToCreate is a type that contains the details required for creating a Task type.

--- a/models/task_test.go
+++ b/models/task_test.go
@@ -46,13 +46,16 @@ func TestNewTask(t *testing.T) {
 		ctx := context.Background()
 
 		jobID := "task1234"
-		taskName := "task"
-		noOfDocuments := 3
+
+		taskToCreate := &TaskToCreate{
+			TaskName:          "task",
+			NumberOfDocuments: 3,
+		}
 
 		currentTime := time.Now().UTC()
 
 		Convey("When NewTask is called", func() {
-			task, err := NewTask(ctx, jobID, taskName, noOfDocuments)
+			task, err := NewTask(ctx, jobID, taskToCreate)
 			So(err, ShouldBeNil)
 
 			Convey("Then a new task resource is created", func() {
@@ -70,8 +73,8 @@ func TestNewTask(t *testing.T) {
 				So(task.Links.Self, ShouldEqual, "/jobs/task1234/tasks/task")
 				So(task.Links.Job, ShouldEqual, "/jobs/task1234")
 
-				So(task.NumberOfDocuments, ShouldEqual, noOfDocuments)
-				So(task.TaskName, ShouldEqual, taskName)
+				So(task.NumberOfDocuments, ShouldEqual, taskToCreate.NumberOfDocuments)
+				So(task.TaskName, ShouldEqual, taskToCreate.TaskName)
 			})
 		})
 	})

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -122,39 +122,31 @@ func (m *JobStore) GetJob(ctx context.Context, id string) (*models.Job, error) {
 }
 
 // GetJobs retrieves all the jobs, from the collection, and lists them in order of last_updated
-func (m *JobStore) GetJobs(ctx context.Context, option Options) (models.Jobs, error) {
+func (m *JobStore) GetJobs(ctx context.Context, option Options) (*models.Jobs, error) {
 	logData := log.Data{"option": option}
 	log.Info(ctx, "getting list of jobs", logData)
+
+	// get jobs count
+	numJobs, err := m.getJobsCount(ctx)
+	if err != nil {
+		log.Error(ctx, "failed to get jobs count", err, logData)
+		return nil, err
+	}
 
 	s := m.Session.Copy()
 	defer s.Close()
 
-	results := models.Jobs{}
-
-	numJobs, err := s.DB(m.Database).C(m.JobsCollection).Count()
-	if err != nil {
-		log.Error(ctx, "error counting jobs", err, logData)
-		return results, err
-	}
-
-	logData["no_of_jobs"] = numJobs
-	log.Info(ctx, "number of jobs found in jobs collection", logData)
-
-	if numJobs == 0 {
-		log.Info(ctx, "there are no jobs in the data store - so the list is empty", logData)
-		results.JobList = make([]models.Job, 0)
-		return results, nil
-	}
-
+	// get all jobs from mongo
 	jobsQuery := s.DB(m.Database).C(m.JobsCollection).Find(bson.M{}).Skip(option.Offset).Limit(option.Limit).Sort("last_updated")
 
+	// populate jobsList from jobsQuery
 	jobsList := make([]models.Job, numJobs)
 	if err := jobsQuery.All(&jobsList); err != nil {
 		log.Error(ctx, "failed to populate jobs list", err, logData)
-		return results, err
+		return nil, err
 	}
 
-	jobs := models.Jobs{
+	jobs := &models.Jobs{
 		Count:      len(jobsList),
 		JobList:    jobsList,
 		Limit:      option.Limit,
@@ -162,10 +154,33 @@ func (m *JobStore) GetJobs(ctx context.Context, option Options) (models.Jobs, er
 		TotalCount: numJobs,
 	}
 
-	logData["sorted_jobs"] = jobsList
-	log.Info(ctx, "list of jobs - sorted by last_updated", logData)
-
 	return jobs, nil
+}
+
+// getJobsCount returns the total number of jobs stored in the jobs collection in mongo
+func (m *JobStore) getJobsCount(ctx context.Context) (int, error) {
+	s := m.Session.Copy()
+	defer s.Close()
+
+	logData := log.Data{}
+
+	numJobs, err := s.DB(m.Database).C(m.JobsCollection).Count()
+	if err != nil {
+		logData["database"] = m.Database
+		logData["jobs_collection"] = m.JobsCollection
+
+		log.Error(ctx, "error counting jobs", err, logData)
+		return 0, err
+	}
+
+	logData["no_of_jobs"] = numJobs
+	log.Info(ctx, "number of jobs found in jobs collection", logData)
+
+	if numJobs == 0 {
+		log.Info(ctx, "there are no jobs in the data store", logData)
+	}
+
+	return numJobs, nil
 }
 
 // UpdateJob updates a particular job with the values passed in through the 'updates' input parameter

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -81,7 +81,7 @@ func (m *JobStore) CreateJob(ctx context.Context, job models.Job) error {
 	return nil
 }
 
-func (m *JobStore) findJob(ctx context.Context, jobID string) (models.Job, error) {
+func (m *JobStore) findJob(ctx context.Context, jobID string) (*models.Job, error) {
 	s := m.Session.Copy()
 	defer s.Close()
 
@@ -96,31 +96,26 @@ func (m *JobStore) findJob(ctx context.Context, jobID string) (models.Job, error
 		}
 
 		log.Error(ctx, "failed to find job in mongo", err, logData)
-		return models.Job{}, err
+		return nil, err
 	}
 
-	return job, nil
+	return &job, nil
 }
 
 // GetJob retrieves the details of a particular job, from the collection, specified by its id
-func (m *JobStore) GetJob(ctx context.Context, id string) (models.Job, error) {
+func (m *JobStore) GetJob(ctx context.Context, id string) (*models.Job, error) {
 	logData := log.Data{"id": id}
-	log.Info(ctx, "getting job by ID", logData)
 
-	// If an empty id was passed in, return an error with a message.
-	if id == "" {
-		log.Error(ctx, "empty id given", ErrEmptyIDProvided, logData)
-		return models.Job{}, ErrEmptyIDProvided
-	}
+	log.Info(ctx, "getting job by ID", logData)
 
 	job, err := m.findJob(ctx, id)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			log.Error(ctx, "job not found in mongo", err, logData)
-			return models.Job{}, ErrJobNotFound
+			return nil, ErrJobNotFound
 		}
 		log.Error(ctx, "failed to find job in mongo", err, logData)
-		return models.Job{}, err
+		return nil, err
 	}
 
 	return job, nil

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -10,11 +10,7 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/config"
 )
 
-//go:generate moq -out mock/initialiser.go -pkg mock . Initialiser
-//go:generate moq -out mock/server.go -pkg mock . HTTPServer
-//go:generate moq -out mock/healthCheck.go -pkg mock . HealthChecker
 //go:generate moq -out mock/mongo_data_storer.go -pkg mock . MongoDataStorer
-//go:generate moq -out mock/kafka_producer.go -pkg mock . KafkaProducer
 
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -10,7 +10,11 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/config"
 )
 
+//go:generate moq -out mock/initialiser.go -pkg mock . Initialiser
+//go:generate moq -out mock/server.go -pkg mock . HTTPServer
+//go:generate moq -out mock/healthCheck.go -pkg mock . HealthChecker
 //go:generate moq -out mock/mongo_data_storer.go -pkg mock . MongoDataStorer
+//go:generate moq -out mock/kafka_producer.go -pkg mock . KafkaProducer
 
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -58,7 +58,7 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
 // 	               panic("mock out the CreateTask method")
 //             },
-//             GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
+//             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
 // 	               panic("mock out the GetJob method")
 //             },
 //             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
@@ -108,7 +108,7 @@ type MongoDataStorerMock struct {
 	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
 
 	// GetJobFunc mocks the GetJob method.
-	GetJobFunc func(ctx context.Context, id string) (models.Job, error)
+	GetJobFunc func(ctx context.Context, id string) (*models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
 	GetJobsFunc func(ctx context.Context, options mongo.Options) (models.Jobs, error)
@@ -453,7 +453,7 @@ func (mock *MongoDataStorerMock) CreateTaskCalls() []struct {
 }
 
 // GetJob calls GetJobFunc.
-func (mock *MongoDataStorerMock) GetJob(ctx context.Context, id string) (models.Job, error) {
+func (mock *MongoDataStorerMock) GetJob(ctx context.Context, id string) (*models.Job, error) {
 	if mock.GetJobFunc == nil {
 		panic("MongoDataStorerMock.GetJobFunc: method is nil but MongoDataStorer.GetJob was just called")
 	}

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -61,7 +61,7 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
 // 	               panic("mock out the GetJob method")
 //             },
-//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 // 	               panic("mock out the GetJobs method")
 //             },
 //             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
@@ -111,7 +111,7 @@ type MongoDataStorerMock struct {
 	GetJobFunc func(ctx context.Context, id string) (*models.Job, error)
 
 	// GetJobsFunc mocks the GetJobs method.
-	GetJobsFunc func(ctx context.Context, options mongo.Options) (models.Jobs, error)
+	GetJobsFunc func(ctx context.Context, options mongo.Options) (*models.Jobs, error)
 
 	// GetTaskFunc mocks the GetTask method.
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
@@ -488,7 +488,7 @@ func (mock *MongoDataStorerMock) GetJobCalls() []struct {
 }
 
 // GetJobs calls GetJobsFunc.
-func (mock *MongoDataStorerMock) GetJobs(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+func (mock *MongoDataStorerMock) GetJobs(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 	if mock.GetJobsFunc == nil {
 		panic("MongoDataStorerMock.GetJobsFunc: method is nil but MongoDataStorer.GetJobs was just called")
 	}

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -13,67 +13,87 @@ import (
 	"sync"
 )
 
-// Ensure, that MongoDataStorerMock does implement service.MongoDataStorer.
+var (
+	lockMongoDataStorerMockAcquireJobLock      sync.RWMutex
+	lockMongoDataStorerMockCheckInProgressJob  sync.RWMutex
+	lockMongoDataStorerMockChecker             sync.RWMutex
+	lockMongoDataStorerMockClose               sync.RWMutex
+	lockMongoDataStorerMockCreateJob           sync.RWMutex
+	lockMongoDataStorerMockCreateTask          sync.RWMutex
+	lockMongoDataStorerMockGetJob              sync.RWMutex
+	lockMongoDataStorerMockGetJobs             sync.RWMutex
+	lockMongoDataStorerMockGetTask             sync.RWMutex
+	lockMongoDataStorerMockGetTasks            sync.RWMutex
+	lockMongoDataStorerMockPutNumberOfTasks    sync.RWMutex
+	lockMongoDataStorerMockUnlockJob           sync.RWMutex
+	lockMongoDataStorerMockUpdateJob           sync.RWMutex
+	lockMongoDataStorerMockValidateJobIDUnique sync.RWMutex
+)
+
+// Ensure, that MongoDataStorerMock does implement MongoDataStorer.
 // If this is not the case, regenerate this file with moq.
 var _ service.MongoDataStorer = &MongoDataStorerMock{}
 
 // MongoDataStorerMock is a mock implementation of service.MongoDataStorer.
 //
-// 	func TestSomethingThatUsesMongoDataStorer(t *testing.T) {
+//     func TestSomethingThatUsesMongoDataStorer(t *testing.T) {
 //
-// 		// make and configure a mocked service.MongoDataStorer
-// 		mockedMongoDataStorer := &MongoDataStorerMock{
-// 			AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
-// 				panic("mock out the AcquireJobLock method")
-// 			},
-// 			CheckNewReindexCanBeCreatedFunc: func(ctx context.Context) error {
-// 				panic("mock out the CheckNewReindexCanBeCreated method")
-// 			},
-// 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
-// 				panic("mock out the Checker method")
-// 			},
-// 			CloseFunc: func(ctx context.Context) error {
-// 				panic("mock out the Close method")
-// 			},
-// 			CreateJobFunc: func(ctx context.Context, searchIndexName string) (*models.Job, error) {
-// 				panic("mock out the CreateJob method")
-// 			},
-// 			CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-// 				panic("mock out the CreateTask method")
-// 			},
-// 			GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
-// 				panic("mock out the GetJob method")
-// 			},
-// 			GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
-// 				panic("mock out the GetJobs method")
-// 			},
-// 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
-// 				panic("mock out the GetTask method")
-// 			},
-// 			GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
-// 				panic("mock out the GetTasks method")
-// 			},
-// 			PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
-// 				panic("mock out the PutNumberOfTasks method")
-// 			},
-// 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
-// 				panic("mock out the UnlockJob method")
-// 			},
-// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
-// 				panic("mock out the UpdateJob method")
-// 			},
-// 		}
+//         // make and configure a mocked service.MongoDataStorer
+//         mockedMongoDataStorer := &MongoDataStorerMock{
+//             AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+// 	               panic("mock out the AcquireJobLock method")
+//             },
+//             CheckInProgressJobFunc: func(ctx context.Context) error {
+// 	               panic("mock out the CheckInProgressJob method")
+//             },
+//             CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
+// 	               panic("mock out the Checker method")
+//             },
+//             CloseFunc: func(ctx context.Context) error {
+// 	               panic("mock out the Close method")
+//             },
+//             CreateJobFunc: func(ctx context.Context, job models.Job) error {
+// 	               panic("mock out the CreateJob method")
+//             },
+//             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
+// 	               panic("mock out the CreateTask method")
+//             },
+//             GetJobFunc: func(ctx context.Context, id string) (models.Job, error) {
+// 	               panic("mock out the GetJob method")
+//             },
+//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (models.Jobs, error) {
+// 	               panic("mock out the GetJobs method")
+//             },
+//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+// 	               panic("mock out the GetTask method")
+//             },
+//             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+// 	               panic("mock out the GetTasks method")
+//             },
+//             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
+// 	               panic("mock out the PutNumberOfTasks method")
+//             },
+//             UnlockJobFunc: func(ctx context.Context, lockID string)  {
+// 	               panic("mock out the UnlockJob method")
+//             },
+//             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 	               panic("mock out the UpdateJob method")
+//             },
+//             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
+// 	               panic("mock out the ValidateJobIDUnique method")
+//             },
+//         }
 //
-// 		// use mockedMongoDataStorer in code that requires service.MongoDataStorer
-// 		// and then make assertions.
+//         // use mockedMongoDataStorer in code that requires service.MongoDataStorer
+//         // and then make assertions.
 //
-// 	}
+//     }
 type MongoDataStorerMock struct {
 	// AcquireJobLockFunc mocks the AcquireJobLock method.
 	AcquireJobLockFunc func(ctx context.Context, id string) (string, error)
 
-	// CheckNewReindexCanBeCreatedFunc mocks the CheckNewReindexCanBeCreated method.
-	CheckNewReindexCanBeCreatedFunc func(ctx context.Context) error
+	// CheckInProgressJobFunc mocks the CheckInProgressJob method.
+	CheckInProgressJobFunc func(ctx context.Context) error
 
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *healthcheck.CheckState) error
@@ -82,7 +102,7 @@ type MongoDataStorerMock struct {
 	CloseFunc func(ctx context.Context) error
 
 	// CreateJobFunc mocks the CreateJob method.
-	CreateJobFunc func(ctx context.Context, searchIndexName string) (*models.Job, error)
+	CreateJobFunc func(ctx context.Context, job models.Job) error
 
 	// CreateTaskFunc mocks the CreateTask method.
 	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
@@ -108,6 +128,9 @@ type MongoDataStorerMock struct {
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
 
+	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
+	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// AcquireJobLock holds details about calls to the AcquireJobLock method.
@@ -117,8 +140,8 @@ type MongoDataStorerMock struct {
 			// ID is the id argument value.
 			ID string
 		}
-		// CheckNewReindexCanBeCreated holds details about calls to the CheckNewReindexCanBeCreated method.
-		CheckNewReindexCanBeCreated []struct {
+		// CheckInProgressJob holds details about calls to the CheckInProgressJob method.
+		CheckInProgressJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -138,8 +161,8 @@ type MongoDataStorerMock struct {
 		CreateJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// SearchIndexName is the searchIndexName argument value.
-			SearchIndexName string
+			// Job is the job argument value.
+			Job models.Job
 		}
 		// CreateTask holds details about calls to the CreateTask method.
 		CreateTask []struct {
@@ -209,20 +232,14 @@ type MongoDataStorerMock struct {
 			// Updates is the updates argument value.
 			Updates bson.M
 		}
+		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
+		ValidateJobIDUnique []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+		}
 	}
-	lockAcquireJobLock              sync.RWMutex
-	lockCheckNewReindexCanBeCreated sync.RWMutex
-	lockChecker                     sync.RWMutex
-	lockClose                       sync.RWMutex
-	lockCreateJob                   sync.RWMutex
-	lockCreateTask                  sync.RWMutex
-	lockGetJob                      sync.RWMutex
-	lockGetJobs                     sync.RWMutex
-	lockGetTask                     sync.RWMutex
-	lockGetTasks                    sync.RWMutex
-	lockPutNumberOfTasks            sync.RWMutex
-	lockUnlockJob                   sync.RWMutex
-	lockUpdateJob                   sync.RWMutex
 }
 
 // AcquireJobLock calls AcquireJobLockFunc.
@@ -237,9 +254,9 @@ func (mock *MongoDataStorerMock) AcquireJobLock(ctx context.Context, id string) 
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockAcquireJobLock.Lock()
+	lockMongoDataStorerMockAcquireJobLock.Lock()
 	mock.calls.AcquireJobLock = append(mock.calls.AcquireJobLock, callInfo)
-	mock.lockAcquireJobLock.Unlock()
+	lockMongoDataStorerMockAcquireJobLock.Unlock()
 	return mock.AcquireJobLockFunc(ctx, id)
 }
 
@@ -254,40 +271,40 @@ func (mock *MongoDataStorerMock) AcquireJobLockCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockAcquireJobLock.RLock()
+	lockMongoDataStorerMockAcquireJobLock.RLock()
 	calls = mock.calls.AcquireJobLock
-	mock.lockAcquireJobLock.RUnlock()
+	lockMongoDataStorerMockAcquireJobLock.RUnlock()
 	return calls
 }
 
-// CheckNewReindexCanBeCreated calls CheckNewReindexCanBeCreatedFunc.
-func (mock *MongoDataStorerMock) CheckNewReindexCanBeCreated(ctx context.Context) error {
-	if mock.CheckNewReindexCanBeCreatedFunc == nil {
-		panic("MongoDataStorerMock.CheckNewReindexCanBeCreatedFunc: method is nil but MongoDataStorer.CheckNewReindexCanBeCreated was just called")
+// CheckInProgressJob calls CheckInProgressJobFunc.
+func (mock *MongoDataStorerMock) CheckInProgressJob(ctx context.Context) error {
+	if mock.CheckInProgressJobFunc == nil {
+		panic("MongoDataStorerMock.CheckInProgressJobFunc: method is nil but MongoDataStorer.CheckInProgressJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 	}{
 		Ctx: ctx,
 	}
-	mock.lockCheckNewReindexCanBeCreated.Lock()
-	mock.calls.CheckNewReindexCanBeCreated = append(mock.calls.CheckNewReindexCanBeCreated, callInfo)
-	mock.lockCheckNewReindexCanBeCreated.Unlock()
-	return mock.CheckNewReindexCanBeCreatedFunc(ctx)
+	lockMongoDataStorerMockCheckInProgressJob.Lock()
+	mock.calls.CheckInProgressJob = append(mock.calls.CheckInProgressJob, callInfo)
+	lockMongoDataStorerMockCheckInProgressJob.Unlock()
+	return mock.CheckInProgressJobFunc(ctx)
 }
 
-// CheckNewReindexCanBeCreatedCalls gets all the calls that were made to CheckNewReindexCanBeCreated.
+// CheckInProgressJobCalls gets all the calls that were made to CheckInProgressJob.
 // Check the length with:
-//     len(mockedMongoDataStorer.CheckNewReindexCanBeCreatedCalls())
-func (mock *MongoDataStorerMock) CheckNewReindexCanBeCreatedCalls() []struct {
+//     len(mockedMongoDataStorer.CheckInProgressJobCalls())
+func (mock *MongoDataStorerMock) CheckInProgressJobCalls() []struct {
 	Ctx context.Context
 } {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockCheckNewReindexCanBeCreated.RLock()
-	calls = mock.calls.CheckNewReindexCanBeCreated
-	mock.lockCheckNewReindexCanBeCreated.RUnlock()
+	lockMongoDataStorerMockCheckInProgressJob.RLock()
+	calls = mock.calls.CheckInProgressJob
+	lockMongoDataStorerMockCheckInProgressJob.RUnlock()
 	return calls
 }
 
@@ -303,9 +320,9 @@ func (mock *MongoDataStorerMock) Checker(ctx context.Context, state *healthcheck
 		Ctx:   ctx,
 		State: state,
 	}
-	mock.lockChecker.Lock()
+	lockMongoDataStorerMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
+	lockMongoDataStorerMockChecker.Unlock()
 	return mock.CheckerFunc(ctx, state)
 }
 
@@ -320,9 +337,9 @@ func (mock *MongoDataStorerMock) CheckerCalls() []struct {
 		Ctx   context.Context
 		State *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockMongoDataStorerMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockMongoDataStorerMockChecker.RUnlock()
 	return calls
 }
 
@@ -336,9 +353,9 @@ func (mock *MongoDataStorerMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	mock.lockClose.Lock()
+	lockMongoDataStorerMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
+	lockMongoDataStorerMockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -351,44 +368,44 @@ func (mock *MongoDataStorerMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockClose.RLock()
+	lockMongoDataStorerMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockMongoDataStorerMockClose.RUnlock()
 	return calls
 }
 
 // CreateJob calls CreateJobFunc.
-func (mock *MongoDataStorerMock) CreateJob(ctx context.Context, searchIndexName string) (*models.Job, error) {
+func (mock *MongoDataStorerMock) CreateJob(ctx context.Context, job models.Job) error {
 	if mock.CreateJobFunc == nil {
 		panic("MongoDataStorerMock.CreateJobFunc: method is nil but MongoDataStorer.CreateJob was just called")
 	}
 	callInfo := struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}{
-		Ctx:             ctx,
-		SearchIndexName: searchIndexName,
+		Ctx: ctx,
+		Job: job,
 	}
-	mock.lockCreateJob.Lock()
+	lockMongoDataStorerMockCreateJob.Lock()
 	mock.calls.CreateJob = append(mock.calls.CreateJob, callInfo)
-	mock.lockCreateJob.Unlock()
-	return mock.CreateJobFunc(ctx, searchIndexName)
+	lockMongoDataStorerMockCreateJob.Unlock()
+	return mock.CreateJobFunc(ctx, job)
 }
 
 // CreateJobCalls gets all the calls that were made to CreateJob.
 // Check the length with:
 //     len(mockedMongoDataStorer.CreateJobCalls())
 func (mock *MongoDataStorerMock) CreateJobCalls() []struct {
-	Ctx             context.Context
-	SearchIndexName string
+	Ctx context.Context
+	Job models.Job
 } {
 	var calls []struct {
-		Ctx             context.Context
-		SearchIndexName string
+		Ctx context.Context
+		Job models.Job
 	}
-	mock.lockCreateJob.RLock()
+	lockMongoDataStorerMockCreateJob.RLock()
 	calls = mock.calls.CreateJob
-	mock.lockCreateJob.RUnlock()
+	lockMongoDataStorerMockCreateJob.RUnlock()
 	return calls
 }
 
@@ -408,9 +425,9 @@ func (mock *MongoDataStorerMock) CreateTask(ctx context.Context, jobID string, t
 		TaskName:     taskName,
 		NumDocuments: numDocuments,
 	}
-	mock.lockCreateTask.Lock()
+	lockMongoDataStorerMockCreateTask.Lock()
 	mock.calls.CreateTask = append(mock.calls.CreateTask, callInfo)
-	mock.lockCreateTask.Unlock()
+	lockMongoDataStorerMockCreateTask.Unlock()
 	return mock.CreateTaskFunc(ctx, jobID, taskName, numDocuments)
 }
 
@@ -429,9 +446,9 @@ func (mock *MongoDataStorerMock) CreateTaskCalls() []struct {
 		TaskName     string
 		NumDocuments int
 	}
-	mock.lockCreateTask.RLock()
+	lockMongoDataStorerMockCreateTask.RLock()
 	calls = mock.calls.CreateTask
-	mock.lockCreateTask.RUnlock()
+	lockMongoDataStorerMockCreateTask.RUnlock()
 	return calls
 }
 
@@ -447,9 +464,9 @@ func (mock *MongoDataStorerMock) GetJob(ctx context.Context, id string) (models.
 		Ctx: ctx,
 		ID:  id,
 	}
-	mock.lockGetJob.Lock()
+	lockMongoDataStorerMockGetJob.Lock()
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
-	mock.lockGetJob.Unlock()
+	lockMongoDataStorerMockGetJob.Unlock()
 	return mock.GetJobFunc(ctx, id)
 }
 
@@ -464,9 +481,9 @@ func (mock *MongoDataStorerMock) GetJobCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	mock.lockGetJob.RLock()
+	lockMongoDataStorerMockGetJob.RLock()
 	calls = mock.calls.GetJob
-	mock.lockGetJob.RUnlock()
+	lockMongoDataStorerMockGetJob.RUnlock()
 	return calls
 }
 
@@ -482,9 +499,9 @@ func (mock *MongoDataStorerMock) GetJobs(ctx context.Context, options mongo.Opti
 		Ctx:     ctx,
 		Options: options,
 	}
-	mock.lockGetJobs.Lock()
+	lockMongoDataStorerMockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	mock.lockGetJobs.Unlock()
+	lockMongoDataStorerMockGetJobs.Unlock()
 	return mock.GetJobsFunc(ctx, options)
 }
 
@@ -499,9 +516,9 @@ func (mock *MongoDataStorerMock) GetJobsCalls() []struct {
 		Ctx     context.Context
 		Options mongo.Options
 	}
-	mock.lockGetJobs.RLock()
+	lockMongoDataStorerMockGetJobs.RLock()
 	calls = mock.calls.GetJobs
-	mock.lockGetJobs.RUnlock()
+	lockMongoDataStorerMockGetJobs.RUnlock()
 	return calls
 }
 
@@ -519,9 +536,9 @@ func (mock *MongoDataStorerMock) GetTask(ctx context.Context, jobID string, task
 		JobID:    jobID,
 		TaskName: taskName,
 	}
-	mock.lockGetTask.Lock()
+	lockMongoDataStorerMockGetTask.Lock()
 	mock.calls.GetTask = append(mock.calls.GetTask, callInfo)
-	mock.lockGetTask.Unlock()
+	lockMongoDataStorerMockGetTask.Unlock()
 	return mock.GetTaskFunc(ctx, jobID, taskName)
 }
 
@@ -538,9 +555,9 @@ func (mock *MongoDataStorerMock) GetTaskCalls() []struct {
 		JobID    string
 		TaskName string
 	}
-	mock.lockGetTask.RLock()
+	lockMongoDataStorerMockGetTask.RLock()
 	calls = mock.calls.GetTask
-	mock.lockGetTask.RUnlock()
+	lockMongoDataStorerMockGetTask.RUnlock()
 	return calls
 }
 
@@ -558,9 +575,9 @@ func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, options mongo.Opt
 		Options: options,
 		JobID:   jobID,
 	}
-	mock.lockGetTasks.Lock()
+	lockMongoDataStorerMockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
-	mock.lockGetTasks.Unlock()
+	lockMongoDataStorerMockGetTasks.Unlock()
 	return mock.GetTasksFunc(ctx, options, jobID)
 }
 
@@ -577,9 +594,9 @@ func (mock *MongoDataStorerMock) GetTasksCalls() []struct {
 		Options mongo.Options
 		JobID   string
 	}
-	mock.lockGetTasks.RLock()
+	lockMongoDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks
-	mock.lockGetTasks.RUnlock()
+	lockMongoDataStorerMockGetTasks.RUnlock()
 	return calls
 }
 
@@ -597,9 +614,9 @@ func (mock *MongoDataStorerMock) PutNumberOfTasks(ctx context.Context, id string
 		ID:    id,
 		Count: count,
 	}
-	mock.lockPutNumberOfTasks.Lock()
+	lockMongoDataStorerMockPutNumberOfTasks.Lock()
 	mock.calls.PutNumberOfTasks = append(mock.calls.PutNumberOfTasks, callInfo)
-	mock.lockPutNumberOfTasks.Unlock()
+	lockMongoDataStorerMockPutNumberOfTasks.Unlock()
 	return mock.PutNumberOfTasksFunc(ctx, id, count)
 }
 
@@ -616,9 +633,9 @@ func (mock *MongoDataStorerMock) PutNumberOfTasksCalls() []struct {
 		ID    string
 		Count int
 	}
-	mock.lockPutNumberOfTasks.RLock()
+	lockMongoDataStorerMockPutNumberOfTasks.RLock()
 	calls = mock.calls.PutNumberOfTasks
-	mock.lockPutNumberOfTasks.RUnlock()
+	lockMongoDataStorerMockPutNumberOfTasks.RUnlock()
 	return calls
 }
 
@@ -634,9 +651,9 @@ func (mock *MongoDataStorerMock) UnlockJob(ctx context.Context, lockID string) {
 		Ctx:    ctx,
 		LockID: lockID,
 	}
-	mock.lockUnlockJob.Lock()
+	lockMongoDataStorerMockUnlockJob.Lock()
 	mock.calls.UnlockJob = append(mock.calls.UnlockJob, callInfo)
-	mock.lockUnlockJob.Unlock()
+	lockMongoDataStorerMockUnlockJob.Unlock()
 	mock.UnlockJobFunc(ctx, lockID)
 }
 
@@ -651,9 +668,9 @@ func (mock *MongoDataStorerMock) UnlockJobCalls() []struct {
 		Ctx    context.Context
 		LockID string
 	}
-	mock.lockUnlockJob.RLock()
+	lockMongoDataStorerMockUnlockJob.RLock()
 	calls = mock.calls.UnlockJob
-	mock.lockUnlockJob.RUnlock()
+	lockMongoDataStorerMockUnlockJob.RUnlock()
 	return calls
 }
 
@@ -671,9 +688,9 @@ func (mock *MongoDataStorerMock) UpdateJob(ctx context.Context, id string, updat
 		ID:      id,
 		Updates: updates,
 	}
-	mock.lockUpdateJob.Lock()
+	lockMongoDataStorerMockUpdateJob.Lock()
 	mock.calls.UpdateJob = append(mock.calls.UpdateJob, callInfo)
-	mock.lockUpdateJob.Unlock()
+	lockMongoDataStorerMockUpdateJob.Unlock()
 	return mock.UpdateJobFunc(ctx, id, updates)
 }
 
@@ -690,8 +707,43 @@ func (mock *MongoDataStorerMock) UpdateJobCalls() []struct {
 		ID      string
 		Updates bson.M
 	}
-	mock.lockUpdateJob.RLock()
+	lockMongoDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
-	mock.lockUpdateJob.RUnlock()
+	lockMongoDataStorerMockUpdateJob.RUnlock()
+	return calls
+}
+
+// ValidateJobIDUnique calls ValidateJobIDUniqueFunc.
+func (mock *MongoDataStorerMock) ValidateJobIDUnique(ctx context.Context, id string) error {
+	if mock.ValidateJobIDUniqueFunc == nil {
+		panic("MongoDataStorerMock.ValidateJobIDUniqueFunc: method is nil but MongoDataStorer.ValidateJobIDUnique was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  string
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	lockMongoDataStorerMockValidateJobIDUnique.Lock()
+	mock.calls.ValidateJobIDUnique = append(mock.calls.ValidateJobIDUnique, callInfo)
+	lockMongoDataStorerMockValidateJobIDUnique.Unlock()
+	return mock.ValidateJobIDUniqueFunc(ctx, id)
+}
+
+// ValidateJobIDUniqueCalls gets all the calls that were made to ValidateJobIDUnique.
+// Check the length with:
+//     len(mockedMongoDataStorer.ValidateJobIDUniqueCalls())
+func (mock *MongoDataStorerMock) ValidateJobIDUniqueCalls() []struct {
+	Ctx context.Context
+	ID  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  string
+	}
+	lockMongoDataStorerMockValidateJobIDUnique.RLock()
+	calls = mock.calls.ValidateJobIDUnique
+	lockMongoDataStorerMockValidateJobIDUnique.RUnlock()
 	return calls
 }

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -61,7 +61,7 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
 // 	               panic("mock out the GetJobs method")
 //             },
-//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
 // 	               panic("mock out the GetTask method")
 //             },
 //             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
@@ -111,7 +111,7 @@ type MongoDataStorerMock struct {
 	GetJobsFunc func(ctx context.Context, options mongo.Options) (*models.Jobs, error)
 
 	// GetTaskFunc mocks the GetTask method.
-	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (models.Task, error)
+	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (*models.Task, error)
 
 	// GetTasksFunc mocks the GetTasks method.
 	GetTasksFunc func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error)
@@ -480,7 +480,7 @@ func (mock *MongoDataStorerMock) GetJobsCalls() []struct {
 }
 
 // GetTask calls GetTaskFunc.
-func (mock *MongoDataStorerMock) GetTask(ctx context.Context, jobID string, taskName string) (models.Task, error) {
+func (mock *MongoDataStorerMock) GetTask(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
 	if mock.GetTaskFunc == nil {
 		panic("MongoDataStorerMock.GetTaskFunc: method is nil but MongoDataStorer.GetTask was just called")
 	}

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -19,7 +19,6 @@ var (
 	lockMongoDataStorerMockChecker             sync.RWMutex
 	lockMongoDataStorerMockClose               sync.RWMutex
 	lockMongoDataStorerMockCreateJob           sync.RWMutex
-	lockMongoDataStorerMockCreateTask          sync.RWMutex
 	lockMongoDataStorerMockGetJob              sync.RWMutex
 	lockMongoDataStorerMockGetJobs             sync.RWMutex
 	lockMongoDataStorerMockGetTask             sync.RWMutex
@@ -27,6 +26,7 @@ var (
 	lockMongoDataStorerMockPutNumberOfTasks    sync.RWMutex
 	lockMongoDataStorerMockUnlockJob           sync.RWMutex
 	lockMongoDataStorerMockUpdateJob           sync.RWMutex
+	lockMongoDataStorerMockUpsertTask          sync.RWMutex
 	lockMongoDataStorerMockValidateJobIDUnique sync.RWMutex
 )
 
@@ -55,9 +55,6 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             CreateJobFunc: func(ctx context.Context, job models.Job) error {
 // 	               panic("mock out the CreateJob method")
 //             },
-//             CreateTaskFunc: func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-// 	               panic("mock out the CreateTask method")
-//             },
 //             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
 // 	               panic("mock out the GetJob method")
 //             },
@@ -78,6 +75,9 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             },
 //             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
 // 	               panic("mock out the UpdateJob method")
+//             },
+//             UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
+// 	               panic("mock out the UpsertTask method")
 //             },
 //             ValidateJobIDUniqueFunc: func(ctx context.Context, id string) error {
 // 	               panic("mock out the ValidateJobIDUnique method")
@@ -104,9 +104,6 @@ type MongoDataStorerMock struct {
 	// CreateJobFunc mocks the CreateJob method.
 	CreateJobFunc func(ctx context.Context, job models.Job) error
 
-	// CreateTaskFunc mocks the CreateTask method.
-	CreateTaskFunc func(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error)
-
 	// GetJobFunc mocks the GetJob method.
 	GetJobFunc func(ctx context.Context, id string) (*models.Job, error)
 
@@ -127,6 +124,9 @@ type MongoDataStorerMock struct {
 
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
+
+	// UpsertTaskFunc mocks the UpsertTask method.
+	UpsertTaskFunc func(ctx context.Context, jobID string, taskName string, task models.Task) error
 
 	// ValidateJobIDUniqueFunc mocks the ValidateJobIDUnique method.
 	ValidateJobIDUniqueFunc func(ctx context.Context, id string) error
@@ -163,17 +163,6 @@ type MongoDataStorerMock struct {
 			Ctx context.Context
 			// Job is the job argument value.
 			Job models.Job
-		}
-		// CreateTask holds details about calls to the CreateTask method.
-		CreateTask []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// JobID is the jobID argument value.
-			JobID string
-			// TaskName is the taskName argument value.
-			TaskName string
-			// NumDocuments is the numDocuments argument value.
-			NumDocuments int
 		}
 		// GetJob holds details about calls to the GetJob method.
 		GetJob []struct {
@@ -231,6 +220,17 @@ type MongoDataStorerMock struct {
 			ID string
 			// Updates is the updates argument value.
 			Updates bson.M
+		}
+		// UpsertTask holds details about calls to the UpsertTask method.
+		UpsertTask []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// JobID is the jobID argument value.
+			JobID string
+			// TaskName is the taskName argument value.
+			TaskName string
+			// Task is the task argument value.
+			Task models.Task
 		}
 		// ValidateJobIDUnique holds details about calls to the ValidateJobIDUnique method.
 		ValidateJobIDUnique []struct {
@@ -406,49 +406,6 @@ func (mock *MongoDataStorerMock) CreateJobCalls() []struct {
 	lockMongoDataStorerMockCreateJob.RLock()
 	calls = mock.calls.CreateJob
 	lockMongoDataStorerMockCreateJob.RUnlock()
-	return calls
-}
-
-// CreateTask calls CreateTaskFunc.
-func (mock *MongoDataStorerMock) CreateTask(ctx context.Context, jobID string, taskName string, numDocuments int) (models.Task, error) {
-	if mock.CreateTaskFunc == nil {
-		panic("MongoDataStorerMock.CreateTaskFunc: method is nil but MongoDataStorer.CreateTask was just called")
-	}
-	callInfo := struct {
-		Ctx          context.Context
-		JobID        string
-		TaskName     string
-		NumDocuments int
-	}{
-		Ctx:          ctx,
-		JobID:        jobID,
-		TaskName:     taskName,
-		NumDocuments: numDocuments,
-	}
-	lockMongoDataStorerMockCreateTask.Lock()
-	mock.calls.CreateTask = append(mock.calls.CreateTask, callInfo)
-	lockMongoDataStorerMockCreateTask.Unlock()
-	return mock.CreateTaskFunc(ctx, jobID, taskName, numDocuments)
-}
-
-// CreateTaskCalls gets all the calls that were made to CreateTask.
-// Check the length with:
-//     len(mockedMongoDataStorer.CreateTaskCalls())
-func (mock *MongoDataStorerMock) CreateTaskCalls() []struct {
-	Ctx          context.Context
-	JobID        string
-	TaskName     string
-	NumDocuments int
-} {
-	var calls []struct {
-		Ctx          context.Context
-		JobID        string
-		TaskName     string
-		NumDocuments int
-	}
-	lockMongoDataStorerMockCreateTask.RLock()
-	calls = mock.calls.CreateTask
-	lockMongoDataStorerMockCreateTask.RUnlock()
 	return calls
 }
 
@@ -710,6 +667,49 @@ func (mock *MongoDataStorerMock) UpdateJobCalls() []struct {
 	lockMongoDataStorerMockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
 	lockMongoDataStorerMockUpdateJob.RUnlock()
+	return calls
+}
+
+// UpsertTask calls UpsertTaskFunc.
+func (mock *MongoDataStorerMock) UpsertTask(ctx context.Context, jobID string, taskName string, task models.Task) error {
+	if mock.UpsertTaskFunc == nil {
+		panic("MongoDataStorerMock.UpsertTaskFunc: method is nil but MongoDataStorer.UpsertTask was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		JobID    string
+		TaskName string
+		Task     models.Task
+	}{
+		Ctx:      ctx,
+		JobID:    jobID,
+		TaskName: taskName,
+		Task:     task,
+	}
+	lockMongoDataStorerMockUpsertTask.Lock()
+	mock.calls.UpsertTask = append(mock.calls.UpsertTask, callInfo)
+	lockMongoDataStorerMockUpsertTask.Unlock()
+	return mock.UpsertTaskFunc(ctx, jobID, taskName, task)
+}
+
+// UpsertTaskCalls gets all the calls that were made to UpsertTask.
+// Check the length with:
+//     len(mockedMongoDataStorer.UpsertTaskCalls())
+func (mock *MongoDataStorerMock) UpsertTaskCalls() []struct {
+	Ctx      context.Context
+	JobID    string
+	TaskName string
+	Task     models.Task
+} {
+	var calls []struct {
+		Ctx      context.Context
+		JobID    string
+		TaskName string
+		Task     models.Task
+	}
+	lockMongoDataStorerMockUpsertTask.RLock()
+	calls = mock.calls.UpsertTask
+	lockMongoDataStorerMockUpsertTask.RUnlock()
 	return calls
 }
 

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -64,7 +64,7 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
 // 	               panic("mock out the GetTask method")
 //             },
-//             GetTasksFunc: func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+//             GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
 // 	               panic("mock out the GetTasks method")
 //             },
 //             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
@@ -114,7 +114,7 @@ type MongoDataStorerMock struct {
 	GetTaskFunc func(ctx context.Context, jobID string, taskName string) (*models.Task, error)
 
 	// GetTasksFunc mocks the GetTasks method.
-	GetTasksFunc func(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error)
+	GetTasksFunc func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error)
 
 	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
 	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
@@ -191,10 +191,10 @@ type MongoDataStorerMock struct {
 		GetTasks []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Options is the options argument value.
-			Options mongo.Options
 			// JobID is the jobID argument value.
 			JobID string
+			// Options is the options argument value.
+			Options mongo.Options
 		}
 		// PutNumberOfTasks holds details about calls to the PutNumberOfTasks method.
 		PutNumberOfTasks []struct {
@@ -519,23 +519,23 @@ func (mock *MongoDataStorerMock) GetTaskCalls() []struct {
 }
 
 // GetTasks calls GetTasksFunc.
-func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, options mongo.Options, jobID string) (models.Tasks, error) {
+func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
 	if mock.GetTasksFunc == nil {
 		panic("MongoDataStorerMock.GetTasksFunc: method is nil but MongoDataStorer.GetTasks was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		Options mongo.Options
 		JobID   string
+		Options mongo.Options
 	}{
 		Ctx:     ctx,
-		Options: options,
 		JobID:   jobID,
+		Options: options,
 	}
 	lockMongoDataStorerMockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
 	lockMongoDataStorerMockGetTasks.Unlock()
-	return mock.GetTasksFunc(ctx, options, jobID)
+	return mock.GetTasksFunc(ctx, jobID, options)
 }
 
 // GetTasksCalls gets all the calls that were made to GetTasks.
@@ -543,13 +543,13 @@ func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, options mongo.Opt
 //     len(mockedMongoDataStorer.GetTasksCalls())
 func (mock *MongoDataStorerMock) GetTasksCalls() []struct {
 	Ctx     context.Context
-	Options mongo.Options
 	JobID   string
+	Options mongo.Options
 } {
 	var calls []struct {
 		Ctx     context.Context
-		Options mongo.Options
 		JobID   string
+		Options mongo.Options
 	}
 	lockMongoDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Ensure that we check the `If-Match` header in the request if it exists
- Compare ETag from request with ETag of the job resource to check for conflict
- Ensure we set `ETag` header in the response back
- Update unit test and component test

### How to review
**Describe the steps required to test the changes.**
- Check if the test passes
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone