### PR TITLE
add etag functionality for GET `/jobs/{id}/tasks`

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -192,6 +192,15 @@ func (api *API) GetTasksHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// acquire job lock
+	lockID, err := api.dataStore.AcquireJobLock(ctx, jobID)
+	if err != nil {
+		log.Error(ctx, "acquiring lock for job ID failed", err, logData)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
+	defer api.dataStore.UnlockJob(ctx, lockID)
+
 	// check if job exists
 	_, err = api.dataStore.GetJob(ctx, jobID)
 	if err != nil {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -434,6 +434,18 @@ func TestGetTasksHandler(t *testing.T) {
 	}
 
 	dataStorerMock := &apiMock.DataStorerMock{
+		AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+			switch id {
+			case unLockableJobID:
+				return "", errUnexpected
+			default:
+				return "", nil
+			}
+		},
+		UnlockJobFunc: func(ctx context.Context, lockID string) {
+			// mock UnlockJob to be successful by doing nothing
+		},
+
 		GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
 			switch id {
 			case validJobID1, validJobID2:
@@ -504,6 +516,10 @@ func TestGetTasksHandler(t *testing.T) {
 					So(respTasks.Limit, ShouldEqual, expectedTasks.Limit)
 					So(respTasks.Offset, ShouldEqual, expectedTasks.Offset)
 					So(respTasks.TotalCount, ShouldEqual, expectedTasks.TotalCount)
+
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
+					})
 				})
 			})
 		})
@@ -548,6 +564,10 @@ func TestGetTasksHandler(t *testing.T) {
 					So(respTasks.Limit, ShouldEqual, expectedTasks.Limit)
 					So(respTasks.Offset, ShouldEqual, expectedTasks.Offset)
 					So(respTasks.TotalCount, ShouldEqual, expectedTasks.TotalCount)
+
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
+					})
 				})
 			})
 		})
@@ -592,6 +612,10 @@ func TestGetTasksHandler(t *testing.T) {
 					So(respTasks.Limit, ShouldEqual, expectedTasks.Limit)
 					So(respTasks.Offset, ShouldEqual, expectedTasks.Offset)
 					So(respTasks.TotalCount, ShouldEqual, expectedTasks.TotalCount)
+
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
+					})
 				})
 			})
 		})
@@ -636,6 +660,10 @@ func TestGetTasksHandler(t *testing.T) {
 					So(respTasks.Limit, ShouldEqual, expectedTasks.Limit)
 					So(respTasks.Offset, ShouldEqual, expectedTasks.Offset)
 					So(respTasks.TotalCount, ShouldEqual, expectedTasks.TotalCount)
+
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
+					})
 				})
 			})
 		})
@@ -682,6 +710,10 @@ func TestGetTasksHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInvalidLimitParameter.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -701,6 +733,10 @@ func TestGetTasksHandler(t *testing.T) {
 				So(resp.Code, ShouldEqual, http.StatusMovedPermanently)
 				errMsg := strings.TrimSpace(resp.Body.String())
 				So(errMsg, ShouldBeEmpty)
+
+				Convey("And the response ETag header should be empty", func() {
+					So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+				})
 			})
 		})
 	})
@@ -721,6 +757,35 @@ func TestGetTasksHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrJobNotFound.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given datastore is unable to lock job id", t, func() {
+		httpClient := dpHTTP.NewClient()
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+
+		Convey("When request is made to get tasks", func() {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks?offset=%d&limit=%d", unLockableJobID, validOffset, validLimit), nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then status code 500 is returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+
+				Convey("And an error message should be returned in the response body", func() {
+					errMsg := strings.TrimSpace(resp.Body.String())
+					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})
@@ -742,6 +807,10 @@ func TestGetTasksHandler(t *testing.T) {
 				Convey("And an error message should be returned in the response body", func() {
 					errMsg := strings.TrimSpace(resp.Body.String())
 					So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+					Convey("And the response ETag header should be empty", func() {
+						So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+					})
 				})
 			})
 		})

--- a/features/latest_version_features/getting_tasks.feature
+++ b/features/latest_version_features/getting_tasks.feature
@@ -18,6 +18,7 @@ Feature: Getting a list of tasks
     """
     { "task_name": "another-task-name3", "number_of_documents": 4 }
     """
+    And I set the If-Match header to a valid e-tag to get tasks
     When I call GET /jobs/{id}/tasks using the same id again
     Then I would expect there to be 3 tasks returned in a list
     And the response for getting task to look like this
@@ -29,6 +30,121 @@ Feature: Getting a list of tasks
       | number_of_documents | 4                                            |
       | task_name           | {task_name}                                  |
     And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns tasks successfully 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "dataset-api", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "another-task-name3", "number_of_documents": 4 }
+    """
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then I would expect there to be 3 tasks returned in a list
+    And the response for getting task to look like this
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+    And each task should also contain the following values:
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
+    And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns tasks successfully 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "dataset-api", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "another-task-name3", "number_of_documents": 4 }
+    """
+    And I set the "If-Match" header to ""
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then I would expect there to be 3 tasks returned in a list
+    And the response for getting task to look like this
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+    And each task should also contain the following values:
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
+    And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns tasks successfully 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "dataset-api", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "another-task-name3", "number_of_documents": 4 }
+    """
+    And I set the "If-Match" header to "*"
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then I would expect there to be 3 tasks returned in a list
+    And the response for getting task to look like this
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+    And each task should also contain the following values:
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
+    And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with outdated or invalid etag returns an conflict error 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I set the "If-Match" header to "invalid"
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: No Tasks exist in the Data Store and a get request returns an empty list
 

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -38,6 +38,7 @@ func (f *SearchReindexAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I set the If-Match header to the generated e-tag$`, f.iSetIfMatchHeaderToTheGeneratedETag)
 	ctx.Step(`^I set the "If-Match" header to the old e-tag$`, f.iSetIfMatchHeaderToTheOldGeneratedETag)
 	ctx.Step(`^I set the If-Match header to a valid e-tag to get jobs$`, f.iSetIfMatchHeaderToValidETagForJobs)
+	ctx.Step(`^I set the If-Match header to a valid e-tag to get tasks$`, f.iSetIfMatchHeaderToValidETagForTasks)
 	ctx.Step(`^the number of existing jobs in the Job Store is (\d+)$`, f.theNoOfExistingJobsInTheJobStore)
 
 	ctx.Step(`^I would expect the response to be an empty list$`, f.iWouldExpectTheResponseToBeAnEmptyList)

--- a/features/v1_features/latest_version_features/getting_tasks.feature
+++ b/features/v1_features/latest_version_features/getting_tasks.feature
@@ -18,17 +18,133 @@ Feature: Getting a list of tasks
     """
     { "task_name": "another-task-name3", "number_of_documents": 4 }
     """
+    And I set the If-Match header to a valid e-tag to get tasks
     When I call GET /jobs/{id}/tasks using the same id again
     Then I would expect there to be 3 tasks returned in a list
     And the response for getting task to look like this
-      | job_id       | UUID                                  |
-      | last_updated | Not in the future                     |
-      | links: self  | {host}/v1/jobs/{id}/tasks/{task_name} |
-      | links: job   | {host}/v1/jobs/{id}                   |
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
     And each task should also contain the following values:
-      | number_of_documents | 4                              |
-      | task_name           | {task_name}                    |
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
     And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns tasks successfully 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "dataset-api", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "another-task-name3", "number_of_documents": 4 }
+    """
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then I would expect there to be 3 tasks returned in a list
+    And the response for getting task to look like this
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+    And each task should also contain the following values:
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
+    And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns tasks successfully 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "dataset-api", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "another-task-name3", "number_of_documents": 4 }
+    """
+    And I set the "If-Match" header to ""
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then I would expect there to be 3 tasks returned in a list
+    And the response for getting task to look like this
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+    And each task should also contain the following values:
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
+    And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns tasks successfully 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "dataset-api", "number_of_documents": 4 }
+    """
+    And I call POST /jobs/{id}/tasks using the same id again
+    """
+    { "task_name": "another-task-name3", "number_of_documents": 4 }
+    """
+    And I set the "If-Match" header to "*"
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then I would expect there to be 3 tasks returned in a list
+    And the response for getting task to look like this
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
+    And each task should also contain the following values:
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
+    And the tasks should be ordered, by last_updated, with the oldest first
+    And the response ETag header should not be empty
+
+  Scenario: Request made with outdated or invalid etag returns an conflict error 
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I call POST /jobs/{id}/tasks using the generated id
+    """
+    { "task_name": "zebedee", "number_of_documents": 4 }
+    """
+    And I set the "If-Match" header to "invalid"
+    When I call GET /jobs/{id}/tasks using the same id again
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: No Tasks exist in the Data Store and a get request returns an empty list
 
@@ -64,13 +180,13 @@ Feature: Getting a list of tasks
     When I call GET /jobs/{id}/tasks?offset="1"&limit="2"
     Then I would expect there to be 2 tasks returned in a list
     And the response for getting task to look like this
-      | job_id       | UUID                                  |
-      | last_updated | Not in the future                     |
-      | links: self  | {host}/v1/jobs/{id}/tasks/{task_name} |
-      | links: job   | {host}/v1/jobs/{id}                   |
+      | job_id       | UUID                                                |
+      | last_updated | Not in the future                                   |
+      | links: self  | {host}/{latest_version}/jobs/{id}/tasks/{task_name} |
+      | links: job   | {host}/{latest_version}/jobs/{id}                   |
     And each task should also contain the following values:
-      | number_of_documents | 4                              |
-      | task_name           | {task_name}                    |
+      | number_of_documents | 4                                            |
+      | task_name           | {task_name}                                  |
     And the tasks should be ordered, by last_updated, with the oldest first
 
   Scenario: Three tasks exist and a get request with negative offset returns an error

--- a/models/etag.go
+++ b/models/etag.go
@@ -59,3 +59,16 @@ func GenerateETagForTask(task Task) (eTag string, err error) {
 
 	return eTag, nil
 }
+
+// GenerateETagForTasks generates a new eTag for a tasks resource
+func GenerateETagForTasks(ctx context.Context, tasks Tasks) (eTag string, err error) {
+	b, err := bson.Marshal(tasks)
+	if err != nil {
+		log.Error(ctx, "failed to marshal tasks", err)
+		return "", err
+	}
+
+	eTag = dpresponse.GenerateETag(b, false)
+
+	return eTag, nil
+}

--- a/models/etag_test.go
+++ b/models/etag_test.go
@@ -217,7 +217,7 @@ func TestGenerateETagForTasks(t *testing.T) {
 	})
 
 	Convey("Given the list of tasks has not updated", t, func() {
-		Convey("When GenerateETagForTask is called", func() {
+		Convey("When GenerateETagForTasks is called", func() {
 			newETag, err := models.GenerateETagForTasks(ctx, tasks)
 
 			Convey("Then an eTag is returned", func() {

--- a/models/etag_test.go
+++ b/models/etag_test.go
@@ -180,3 +180,57 @@ func getTestTask() models.Task {
 		NumberOfDocuments: 3,
 	}
 }
+
+func TestGenerateETagForTasks(t *testing.T) {
+	ctx := context.Background()
+
+	task := getTestTask()
+	tasks := models.Tasks{
+		Count:      1,
+		TaskList:   []models.Task{task},
+		Limit:      1,
+		Offset:     0,
+		TotalCount: 1,
+	}
+
+	tasksETag := `"3961b393efe23e1ef5aae27b76d21fbb1a9584b4"`
+
+	Convey("Given the list of tasks has updated", t, func() {
+		updatedTasks := tasks
+		updatedTasks.Limit = 10
+
+		Convey("When GenerateETagForTasks is called", func() {
+			newETag, err := models.GenerateETagForTasks(ctx, updatedTasks)
+
+			Convey("Then a new eTag is created", func() {
+				So(newETag, ShouldNotBeEmpty)
+
+				Convey("And new eTag should not be the same as the old eTag", func() {
+					So(newETag, ShouldNotEqual, tasksETag)
+
+					Convey("And no errors should be returned", func() {
+						So(err, ShouldBeNil)
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given the list of tasks has not updated", t, func() {
+		Convey("When GenerateETagForTask is called", func() {
+			newETag, err := models.GenerateETagForTasks(ctx, tasks)
+
+			Convey("Then an eTag is returned", func() {
+				So(newETag, ShouldNotBeEmpty)
+
+				Convey("And the eTag should be the same as the existing eTag", func() {
+					So(newETag, ShouldEqual, tasksETag)
+
+					Convey("And no errors should be returned", func() {
+						So(err, ShouldBeNil)
+					})
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Ensure that we check the If-Match header in the request if it exists
- Ensure ETag is generated after retrieving data from database and checks this with the `IfMatch` header value if set and not set to `*`
- Ensure we set `ETag` header in the response back
- Add unit test and component test

### How to review
**Describe the steps required to test the changes.**
- Check if the test passes
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone