### PR TITLE
add etag functionality for GET `/jobs/<job_id>/tasks/<task_id>`

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -104,13 +104,6 @@ func expectedJobs(ctx context.Context, t *testing.T, cfg *config.Config, jsonRes
 		jobs.JobList = []models.Job{secondJob}
 	}
 
-	if jsonResponse {
-		for i := range jobs.JobList {
-			jobs.JobList[i].Links.Self = fmt.Sprintf("%s/%s%s", cfg.BindAddr, cfg.LatestVersion, jobs.JobList[i].Links.Self)
-			jobs.JobList[i].Links.Tasks = fmt.Sprintf("%s/%s%s", cfg.BindAddr, cfg.LatestVersion, jobs.JobList[i].Links.Tasks)
-		}
-	}
-
 	return jobs
 }
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -113,8 +113,21 @@ func (api *API) GetTaskHandler(w http.ResponseWriter, req *http.Request) {
 		"task_name": taskName,
 	}
 
+	// get eTag from If-Match header
+	eTag, err := headers.GetIfMatch(req)
+	if err != nil {
+		if err != headers.ErrHeaderNotFound {
+			log.Error(ctx, "if-match header not found", err, logData)
+		} else {
+			log.Error(ctx, "unable to get eTag from if-match header", err, logData)
+		}
+
+		log.Info(ctx, "ignoring eTag check")
+		eTag = headers.IfMatchAnyETag
+	}
+
 	// check if job exists
-	_, err := api.dataStore.GetJob(ctx, jobID)
+	_, err = api.dataStore.GetJob(ctx, jobID)
 	if err != nil {
 		if err == mongo.ErrJobNotFound {
 			log.Error(ctx, "job not found", err, logData)
@@ -140,6 +153,20 @@ func (api *API) GetTaskHandler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 		return
 	}
+
+	// check eTags to see if it matches with the current state of the tasks resource
+	if task.ETag != eTag && eTag != headers.IfMatchAnyETag {
+		logData["current_etag"] = task.ETag
+		logData["given_etag"] = eTag
+
+		err = apierrors.ErrConflictWithETag
+		log.Error(ctx, "given and current etags do not match", err, logData)
+		http.Error(w, apierrors.ErrConflictWithETag.Error(), http.StatusConflict)
+		return
+	}
+
+	// set eTag on ETag response header
+	dpresponse.SetETag(w, task.ETag)
 
 	// update links with host and version for json response
 	task.Links.Job = fmt.Sprintf("%s/%s%s", host, v1, task.Links.Job)

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -30,12 +30,12 @@ import (
 const (
 	invalidJobID          = "UUID3"
 	emptyTaskName         = ""
-	validTaskName1        = "zebedee"
-	validTaskName2        = "dataset-api"
 	invalidTaskName       = "any-word-not-in-valid-list"
 	validLimit            = 2
 	validOffset           = 0
 	validServiceAuthToken = "Bearer fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67"
+	validTaskName1        = "zebedee"
+	validTaskName2        = "dataset-api"
 )
 
 // Create Task Payload
@@ -304,13 +304,36 @@ func TestGetTaskHandler(t *testing.T) {
 	}
 
 	dataStorerMock := &apiMock.DataStorerMock{
+		AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+			switch id {
+			case unLockableJobID:
+				return "", errUnexpected
+			default:
+				return "", nil
+			}
+		},
+		UnlockJobFunc: func(ctx context.Context, lockID string) {
+			// mock UnlockJob to be successful by doing nothing
+		},
 		GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
-			job := expectedJob(ctx, t, cfg, true, id, "", 1)
-			return &job, nil
+			switch id {
+			case validJobID2:
+				return nil, errUnexpected
+			case invalidJobID:
+				return nil, mongo.ErrJobNotFound
+			default:
+				job := expectedJob(ctx, t, cfg, true, id, "", 1)
+				return &job, nil
+			}
 		},
 		GetTaskFunc: func(ctx context.Context, jobID, taskName string) (*models.Task, error) {
-			task := expectedTask(ctx, cfg, t, jobID, taskName, false, zeroTime, 1)
-			return &task, nil
+			switch taskName {
+			case invalidTaskName:
+				return nil, mongo.ErrTaskNotFound
+			default:
+				task := expectedTask(ctx, cfg, t, jobID, taskName, false, zeroTime, 1)
+				return &task, nil
+			}
 		},
 	}
 
@@ -344,7 +367,7 @@ func TestGetTaskHandler(t *testing.T) {
 					So(respTask.NumberOfDocuments, ShouldEqual, expectedTask.NumberOfDocuments)
 					So(respTask.TaskName, ShouldEqual, expectedTask.TaskName)
 
-					Convey("And the etag of the response jobs resource should be returned via the ETag header", func() {
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
 						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
 					})
 				})
@@ -383,7 +406,7 @@ func TestGetTaskHandler(t *testing.T) {
 					So(respTask.NumberOfDocuments, ShouldEqual, expectedTask.NumberOfDocuments)
 					So(respTask.TaskName, ShouldEqual, expectedTask.TaskName)
 
-					Convey("And the etag of the response jobs resource should be returned via the ETag header", func() {
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
 						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
 					})
 				})
@@ -422,7 +445,7 @@ func TestGetTaskHandler(t *testing.T) {
 					So(respTask.NumberOfDocuments, ShouldEqual, expectedTask.NumberOfDocuments)
 					So(respTask.TaskName, ShouldEqual, expectedTask.TaskName)
 
-					Convey("And the etag of the response jobs resource should be returned via the ETag header", func() {
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
 						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
 					})
 				})
@@ -461,7 +484,7 @@ func TestGetTaskHandler(t *testing.T) {
 					So(respTask.NumberOfDocuments, ShouldEqual, expectedTask.NumberOfDocuments)
 					So(respTask.TaskName, ShouldEqual, expectedTask.TaskName)
 
-					Convey("And the etag of the response jobs resource should be returned via the ETag header", func() {
+					Convey("And the etag of the resource should be returned via the ETag header", func() {
 						So(resp.Header().Get(dpresponse.ETagHeader), ShouldNotBeEmpty)
 					})
 				})
@@ -515,14 +538,8 @@ func TestGetTaskHandler(t *testing.T) {
 	})
 
 	Convey("Given job id is invalid or job does not exist with the given job id", t, func() {
-		jobNotFoundDataStoreMock := &apiMock.DataStorerMock{
-			GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
-				return nil, mongo.ErrJobNotFound
-			},
-		}
-
 		httpClient := dpHTTP.NewClient()
-		apiInstance := api.Setup(mux.NewRouter(), jobNotFoundDataStoreMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
 
 		Convey("When request is made to get task", func() {
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks/%s", invalidJobID, validTaskName1), nil)
@@ -565,18 +582,8 @@ func TestGetTaskHandler(t *testing.T) {
 	})
 
 	Convey("Given task name is invalid or task does not exist with the given task name", t, func() {
-		invalidTaskNameDataStoreMock := &apiMock.DataStorerMock{
-			GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
-				job := expectedJob(ctx, t, cfg, true, id, "", 1)
-				return &job, nil
-			},
-			GetTaskFunc: func(ctx context.Context, jobID, taskName string) (*models.Task, error) {
-				return nil, mongo.ErrTaskNotFound
-			},
-		}
-
 		httpClient := dpHTTP.NewClient()
-		apiInstance := api.Setup(mux.NewRouter(), invalidTaskNameDataStoreMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
 
 		Convey("When request is made to get task", func() {
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks/%s", validJobID1, invalidTaskName), nil)
@@ -596,18 +603,34 @@ func TestGetTaskHandler(t *testing.T) {
 		})
 	})
 
-	Convey("Given an unexpected error occurs in the datastore", t, func() {
-		unexpectedErrDataStoreMock := &apiMock.DataStorerMock{
-			GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
-				return nil, errUnexpected
-			},
-		}
-
+	Convey("Given datastore is unable to lock job id", t, func() {
 		httpClient := dpHTTP.NewClient()
-		apiInstance := api.Setup(mux.NewRouter(), unexpectedErrDataStoreMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
 
 		Convey("When request is made to get task", func() {
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks/%s", validJobID1, invalidTaskName), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks/%s", unLockableJobID, validTaskName1), nil)
+			resp := httptest.NewRecorder()
+
+			apiInstance.Router.ServeHTTP(resp, req)
+
+			Convey("Then status code 500 is returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+				errMsg := strings.TrimSpace(resp.Body.String())
+				So(errMsg, ShouldEqual, apierrors.ErrInternalServer.Error())
+
+				Convey("And the response ETag header should be empty", func() {
+					So(resp.Header().Get(dpresponse.ETagHeader), ShouldBeEmpty)
+				})
+			})
+		})
+	})
+
+	Convey("Given an unexpected error occurs in the datastore", t, func() {
+		httpClient := dpHTTP.NewClient()
+		apiInstance := api.Setup(mux.NewRouter(), dataStorerMock, &apiMock.AuthHandlerMock{}, taskNames, cfg, httpClient, &apiMock.IndexerMock{}, &apiMock.ReindexRequestedProducerMock{})
+
+		Convey("When request is made to get task", func() {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25700/jobs/%s/tasks/%s", validJobID2, validTaskName1), nil)
 			resp := httptest.NewRecorder()
 
 			apiInstance.Router.ServeHTTP(resp, req)

--- a/features/latest_version_features/getting_a_job.feature
+++ b/features/latest_version_features/getting_a_job.feature
@@ -4,7 +4,7 @@ Feature: Getting a job
 
     Given the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
       | id                | UUID                                    |

--- a/features/latest_version_features/getting_a_task.feature
+++ b/features/latest_version_features/getting_a_task.feature
@@ -10,6 +10,7 @@ Feature: Getting a task
     """
     { "task_name": "dataset-api", "number_of_documents": 30 }
     """
+    And I set the If-Match header to the generated task e-tag
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "200"
     And the response for getting task to look like this
@@ -19,6 +20,91 @@ Feature: Getting a task
       | links: job          | {host}/{latest_version}/jobs/{id}                   |
       | number_of_documents | 30                                                  |
       | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns task successfully
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "200"
+    And the response for getting task to look like this
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns task successfully
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    And I set the "If-Match" header to ""
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "200"
+    And the response for getting task to look like this
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns task successfully
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    And I set the "If-Match" header to "*"
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "200"
+    And the response for getting task to look like this
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with outdated or invalid etag returns an conflict error
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is undefined for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    And I set the "If-Match" header to "invalid"
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 

--- a/features/latest_version_features/patch_job_state_fail.feature
+++ b/features/latest_version_features/patch_job_state_fail.feature
@@ -6,7 +6,7 @@ Feature: Patch job state - Failure
     And zebedee does not recognise the service auth token
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -72,7 +72,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I PATCH "/jobs/invalid"
     """
@@ -94,7 +94,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -113,7 +113,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -135,7 +135,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -157,7 +157,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -179,7 +179,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -201,7 +201,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -223,7 +223,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -245,7 +245,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is undefined for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """

--- a/features/latest_version_features/patch_job_state_success.feature
+++ b/features/latest_version_features/patch_job_state_success.feature
@@ -6,7 +6,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -116,7 +116,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -143,7 +143,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -170,7 +170,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -197,7 +197,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -223,7 +223,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is undefined for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -48,6 +48,7 @@ type SearchReindexAPIFeature struct {
 	AuthFeature             *componentTest.AuthorizationFeature
 	Config                  *config.Config
 	createdJob              *models.Job
+	createdTask             *models.Task
 	errorChan               chan error
 	ErrorFeature            componentTest.ErrorFeature
 	HTTPServer              *http.Server

--- a/features/steps/job_steps.go
+++ b/features/steps/job_steps.go
@@ -206,9 +206,9 @@ func (f *SearchReindexAPIFeature) iSetIfMatchHeaderToValidETagForJobs() error {
 	return f.ErrorFeature.StepError()
 }
 
-// iSetIfMatchHeaderToTheGeneratedETag is a feature step that gets the eTag from the response body generated in the previous step
+// iSetIfMatchHeaderToTheGeneratedJobETag is a feature step that gets the eTag of the job from the response body generated in the previous step
 // and then sets If-Match header to that eTag
-func (f *SearchReindexAPIFeature) iSetIfMatchHeaderToTheGeneratedETag() error {
+func (f *SearchReindexAPIFeature) iSetIfMatchHeaderToTheGeneratedJobETag() error {
 	err := f.APIFeature.ISetTheHeaderTo("If-Match", f.createdJob.ETag)
 	if err != nil {
 		return fmt.Errorf("failed to set If-Match header - err: %w", err)

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -35,7 +35,8 @@ func (f *SearchReindexAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I call PATCH \/jobs\/{id} using the generated id$`, f.iCallPATCHJobsIDUsingTheGeneratedID)
 
 	ctx.Step(`^I have created a task for the generated job$`, f.iHaveCreatedATaskForTheGeneratedJob)
-	ctx.Step(`^I set the If-Match header to the generated e-tag$`, f.iSetIfMatchHeaderToTheGeneratedETag)
+	ctx.Step(`^I set the If-Match header to the generated job e-tag$`, f.iSetIfMatchHeaderToTheGeneratedJobETag)
+	ctx.Step(`^I set the If-Match header to the generated task e-tag$`, f.iSetIfMatchHeaderToTheGeneratedTaskETag)
 	ctx.Step(`^I set the "If-Match" header to the old e-tag$`, f.iSetIfMatchHeaderToTheOldGeneratedETag)
 	ctx.Step(`^I set the If-Match header to a valid e-tag to get jobs$`, f.iSetIfMatchHeaderToValidETagForJobs)
 	ctx.Step(`^I set the If-Match header to a valid e-tag to get tasks$`, f.iSetIfMatchHeaderToValidETagForTasks)

--- a/features/v1_features/latest_version_features/getting_a_job.feature
+++ b/features/v1_features/latest_version_features/getting_a_job.feature
@@ -4,7 +4,7 @@ Feature: Getting a job
 
     Given the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     When I call GET /jobs/{id} using the generated id
     Then the response should contain values that have these structures
       | id                | UUID                                    |

--- a/features/v1_features/latest_version_features/getting_a_task.feature
+++ b/features/v1_features/latest_version_features/getting_a_task.feature
@@ -10,15 +10,101 @@ Feature: Getting a task
     """
     { "task_name": "dataset-api", "number_of_documents": 30 }
     """
+    And I set the If-Match header to the generated task e-tag
     When I call GET /jobs/{id}/tasks/{"dataset-api"}
     Then the HTTP status code should be "200"
     And the response for getting task to look like this
-      | job_id              | UUID                                  |
-      | last_updated        | Not in the future                     |
-      | links: self         | {host}/v1/jobs/{id}/tasks/dataset-api |
-      | links: job          | {host}/v1/jobs/{id}                   |
-      | number_of_documents | 30                                    |
-      | task_name           | dataset-api                           |
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with no If-Match header ignores the ETag check and returns task successfully
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "200"
+    And the response for getting task to look like this
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and returns task successfully
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    And I set the "If-Match" header to ""
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "200"
+    And the response for getting task to look like this
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and returns task successfully
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    And I set the "If-Match" header to "*"
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "200"
+    And the response for getting task to look like this
+      | job_id              | UUID                                                |
+      | last_updated        | Not in the future                                   |
+      | links: self         | {host}/{latest_version}/jobs/{id}/tasks/dataset-api |
+      | links: job          | {host}/{latest_version}/jobs/{id}                   |
+      | number_of_documents | 30                                                  |
+      | task_name           | dataset-api                                         |
+    And the response ETag header should not be empty
+
+  Scenario: Request made with outdated or invalid etag returns an conflict error
+
+    Given I use a service auth token "validServiceAuthToken"
+    And zebedee recognises the service auth token as valid
+    And the api version is v1 for incoming requests
+    And the number of existing jobs in the Job Store is 1
+    And I have created a task for the generated job
+    """
+    { "task_name": "dataset-api", "number_of_documents": 30 }
+    """
+    And I set the "If-Match" header to "invalid"
+    When I call GET /jobs/{id}/tasks/{"dataset-api"}
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: Job does not exist in the Job Store and a get task for job id request returns StatusNotFound
 

--- a/features/v1_features/latest_version_features/patch_job_state_fail.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_fail.feature
@@ -6,7 +6,7 @@ Feature: Patch job state - Failure
     And zebedee does not recognise the service auth token
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -72,7 +72,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I PATCH "/jobs/invalid"
     """
@@ -94,7 +94,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -113,7 +113,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -135,7 +135,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -157,7 +157,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -179,7 +179,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -201,7 +201,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -223,7 +223,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """
@@ -245,7 +245,7 @@ Feature: Patch job state - Failure
     And zebedee recognises the service auth token as valid
     And the api version is v1 for incoming requests
     And the number of existing jobs in the Job Store is 1
-    And I set the If-Match header to the generated e-tag
+    And I set the If-Match header to the generated job e-tag
     
     When I call PATCH /jobs/{id} using the generated id
     """

--- a/features/v1_features/latest_version_features/patch_job_state_success.feature
+++ b/features/v1_features/latest_version_features/patch_job_state_success.feature
@@ -6,7 +6,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -116,7 +116,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -143,7 +143,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -170,7 +170,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -197,7 +197,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """
@@ -223,7 +223,7 @@ Feature: Patch job state - Success
         And zebedee recognises the service auth token as valid
         And the api version is v1 for incoming requests
         And the number of existing jobs in the Job Store is 1
-        And I set the If-Match header to the generated e-tag
+        And I set the If-Match header to the generated job e-tag
         
         When I call PATCH /jobs/{id} using the generated id
         """

--- a/models/etag.go
+++ b/models/etag.go
@@ -44,7 +44,7 @@ func GenerateETagForJobs(ctx context.Context, jobs Jobs) (eTag string, err error
 }
 
 // GenerateETagForTask generates a new eTag for a task resource
-func GenerateETagForTask(task Task) (eTag string, err error) {
+func GenerateETagForTask(ctx context.Context, task Task) (eTag string, err error) {
 	// ignoring the metadata LastUpdated and currentEtag when generating new eTag
 	zeroTime := time.Time{}.UTC()
 	task.ETag = ""
@@ -52,6 +52,10 @@ func GenerateETagForTask(task Task) (eTag string, err error) {
 
 	b, err := bson.Marshal(task)
 	if err != nil {
+		logData := log.Data{
+			"task": task,
+		}
+		log.Error(ctx, "failed to marshal task", err, logData)
 		return "", err
 	}
 

--- a/models/etag_test.go
+++ b/models/etag_test.go
@@ -130,6 +130,7 @@ func TestGenerateETagForJobs(t *testing.T) {
 }
 
 func TestGenerateETagForTask(t *testing.T) {
+	ctx := context.Background()
 	currentTask := getTestTask()
 
 	Convey("Given an updated task", t, func() {
@@ -137,7 +138,7 @@ func TestGenerateETagForTask(t *testing.T) {
 		updatedTask.TaskName = "zebedee"
 
 		Convey("When GenerateETagForTask is called", func() {
-			newETag, err := models.GenerateETagForTask(updatedTask)
+			newETag, err := models.GenerateETagForTask(ctx, updatedTask)
 
 			Convey("Then a new eTag is created", func() {
 				So(newETag, ShouldNotBeEmpty)
@@ -155,7 +156,7 @@ func TestGenerateETagForTask(t *testing.T) {
 
 	Convey("Given an existing task with no new updates", t, func() {
 		Convey("When GenerateETagForTask is called", func() {
-			newETag, err := models.GenerateETagForTask(currentTask)
+			newETag, err := models.GenerateETagForTask(ctx, currentTask)
 
 			Convey("Then an eTag is returned", func() {
 				So(newETag, ShouldNotBeEmpty)

--- a/models/task.go
+++ b/models/task.go
@@ -46,7 +46,7 @@ func NewTask(ctx context.Context, jobID string, taskToCreate *TaskToCreate) (*Ta
 		TaskName:          taskToCreate.TaskName,
 	}
 
-	taskETag, err := GenerateETagForTask(newTask)
+	taskETag, err := GenerateETagForTask(ctx, newTask)
 	if err != nil {
 		logData := log.Data{"new_task": newTask}
 		log.Error(ctx, "failed to generate etag for task", err, logData)


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Ensure that we check the `If-Match` header in the request if it exists
- Compare ETag from request with ETag of the job resource to check for conflict
- Ensure we set `ETag` header in the response back
- Update unit test and component test

### How to review
**Describe the steps required to test the changes.**
- Check if the test passes
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone