### PR TITLE
add etag functionality for PUT `/jobs/<id>/tasks/number_of_tasks/<count>`

### DIFF
--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -25,7 +25,6 @@ type DataStorer interface {
 	GetJobs(ctx context.Context, options mongo.Options) (job *models.Jobs, err error)
 	GetTask(ctx context.Context, jobID, taskName string) (*models.Task, error)
 	GetTasks(ctx context.Context, jobID string, options mongo.Options) (job *models.Tasks, err error)
-	PutNumberOfTasks(ctx context.Context, id string, count int) error
 	UnlockJob(ctx context.Context, lockID string)
 	UpdateJob(ctx context.Context, id string, updates bson.M) error
 	UpsertTask(ctx context.Context, jobID, taskName string, task models.Task) error

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1284,7 +1284,11 @@ func TestPutNumTasksHandler(t *testing.T) {
 
 		Convey("When a request is made to update the number of tasks of a specific job", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", validJobID2, validCount), nil)
-			headers.SetIfMatch(req, "*")
+
+			err := headers.SetIfMatch(req, "*")
+			if err != nil {
+				t.Errorf("failed to set if-match header, error: %v", err)
+			}
 
 			resp := httptest.NewRecorder()
 			apiInstance.Router.ServeHTTP(resp, req)
@@ -1306,7 +1310,11 @@ func TestPutNumTasksHandler(t *testing.T) {
 		Convey("When a request is made to update the number of tasks of a specific job", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", validJobID2, validCount), nil)
 			currentETag := `"e68bdfb851ae5b5bb8c2414b05c29708c160274b"`
-			headers.SetIfMatch(req, currentETag)
+
+			err := headers.SetIfMatch(req, currentETag)
+			if err != nil {
+				t.Errorf("failed to set if-match header, error: %v", err)
+			}
 
 			resp := httptest.NewRecorder()
 			apiInstance.Router.ServeHTTP(resp, req)
@@ -1328,7 +1336,11 @@ func TestPutNumTasksHandler(t *testing.T) {
 
 		Convey("When a request is made to update the number of tasks of a specific job", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", validJobID2, validCount), nil)
-			headers.SetIfMatch(req, "")
+
+			err := headers.SetIfMatch(req, "")
+			if err != nil {
+				t.Errorf("failed to set if-match header, error: %v", err)
+			}
 
 			resp := httptest.NewRecorder()
 			apiInstance.Router.ServeHTTP(resp, req)
@@ -1349,7 +1361,11 @@ func TestPutNumTasksHandler(t *testing.T) {
 
 		Convey("When a request is made to update the number of tasks of a specific job", func() {
 			req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:25700/jobs/%s/number_of_tasks/%s", validJobID2, validCount), nil)
-			headers.SetIfMatch(req, "invalid")
+
+			err := headers.SetIfMatch(req, "invalid")
+			if err != nil {
+				t.Errorf("failed to set if-match header, error: %v", err)
+			}
 
 			resp := httptest.NewRecorder()
 			apiInstance.Router.ServeHTTP(resp, req)

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -20,7 +20,6 @@ var (
 	lockDataStorerMockGetJobs             sync.RWMutex
 	lockDataStorerMockGetTask             sync.RWMutex
 	lockDataStorerMockGetTasks            sync.RWMutex
-	lockDataStorerMockPutNumberOfTasks    sync.RWMutex
 	lockDataStorerMockUnlockJob           sync.RWMutex
 	lockDataStorerMockUpdateJob           sync.RWMutex
 	lockDataStorerMockUpsertTask          sync.RWMutex
@@ -57,9 +56,6 @@ var _ api.DataStorer = &DataStorerMock{}
 //             },
 //             GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
 // 	               panic("mock out the GetTasks method")
-//             },
-//             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
-// 	               panic("mock out the PutNumberOfTasks method")
 //             },
 //             UnlockJobFunc: func(ctx context.Context, lockID string)  {
 // 	               panic("mock out the UnlockJob method")
@@ -100,9 +96,6 @@ type DataStorerMock struct {
 
 	// GetTasksFunc mocks the GetTasks method.
 	GetTasksFunc func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error)
-
-	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
-	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
 
 	// UnlockJobFunc mocks the UnlockJob method.
 	UnlockJobFunc func(ctx context.Context, lockID string)
@@ -168,15 +161,6 @@ type DataStorerMock struct {
 			JobID string
 			// Options is the options argument value.
 			Options mongo.Options
-		}
-		// PutNumberOfTasks holds details about calls to the PutNumberOfTasks method.
-		PutNumberOfTasks []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ID is the id argument value.
-			ID string
-			// Count is the count argument value.
-			Count int
 		}
 		// UnlockJob holds details about calls to the UnlockJob method.
 		UnlockJob []struct {
@@ -461,45 +445,6 @@ func (mock *DataStorerMock) GetTasksCalls() []struct {
 	lockDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks
 	lockDataStorerMockGetTasks.RUnlock()
-	return calls
-}
-
-// PutNumberOfTasks calls PutNumberOfTasksFunc.
-func (mock *DataStorerMock) PutNumberOfTasks(ctx context.Context, id string, count int) error {
-	if mock.PutNumberOfTasksFunc == nil {
-		panic("DataStorerMock.PutNumberOfTasksFunc: method is nil but DataStorer.PutNumberOfTasks was just called")
-	}
-	callInfo := struct {
-		Ctx   context.Context
-		ID    string
-		Count int
-	}{
-		Ctx:   ctx,
-		ID:    id,
-		Count: count,
-	}
-	lockDataStorerMockPutNumberOfTasks.Lock()
-	mock.calls.PutNumberOfTasks = append(mock.calls.PutNumberOfTasks, callInfo)
-	lockDataStorerMockPutNumberOfTasks.Unlock()
-	return mock.PutNumberOfTasksFunc(ctx, id, count)
-}
-
-// PutNumberOfTasksCalls gets all the calls that were made to PutNumberOfTasks.
-// Check the length with:
-//     len(mockedDataStorer.PutNumberOfTasksCalls())
-func (mock *DataStorerMock) PutNumberOfTasksCalls() []struct {
-	Ctx   context.Context
-	ID    string
-	Count int
-} {
-	var calls []struct {
-		Ctx   context.Context
-		ID    string
-		Count int
-	}
-	lockDataStorerMockPutNumberOfTasks.RLock()
-	calls = mock.calls.PutNumberOfTasks
-	lockDataStorerMockPutNumberOfTasks.RUnlock()
 	return calls
 }
 

--- a/features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/latest_version_features/putting_number_of_tasks.feature
@@ -4,11 +4,63 @@ Feature: Updating the number of tasks for a particular job
 
     Given the number of existing jobs in the Job Store is 1
     And the api version is undefined for incoming requests
+    And I set the If-Match header to the generated job e-tag
     When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
     Then the HTTP status code should be "200"
-    Given I call GET /jobs/{id} using the generated id
+    And the response ETag header should not be empty
+    
+    Given I set the "If-Match" header to "*"
+    And I call GET /jobs/{id} using the generated id
     Then the response should contain the new number of tasks
       | number_of_tasks | 7 |
+
+  Scenario: Request made with no If-Match header ignores the ETag check and updates number of tasks of job successfully
+
+    Given the number of existing jobs in the Job Store is 1
+    And the api version is undefined for incoming requests
+    When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
+    Then the HTTP status code should be "200"
+    And the response ETag header should not be empty
+    And I call GET /jobs/{id} using the generated id
+    Then the response should contain the new number of tasks
+      | number_of_tasks | 7 |
+
+  Scenario: Request made with empty If-Match header ignores the ETag check and updates its number of tasks of job successfully
+
+    Given the number of existing jobs in the Job Store is 1
+    And the api version is undefined for incoming requests
+    And I set the "If-Match" header to ""
+    When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
+    Then the HTTP status code should be "200"
+    And the response ETag header should not be empty
+    And I call GET /jobs/{id} using the generated id
+    Then the response should contain the new number of tasks
+      | number_of_tasks | 7 |
+
+  Scenario: Request made with If-Match set to `*` ignores the ETag check and updates its number of tasks of job successfully
+
+    Given the number of existing jobs in the Job Store is 1
+    And the api version is undefined for incoming requests
+    And I set the "If-Match" header to "*"
+    When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
+    Then the HTTP status code should be "200"
+    And the response ETag header should not be empty
+    And I call GET /jobs/{id} using the generated id
+    Then the response should contain the new number of tasks
+      | number_of_tasks | 7 |
+
+  Scenario: Request made with outdated or invalid etag returns an conflict error
+
+    Given the number of existing jobs in the Job Store is 1
+    And the api version is undefined for incoming requests
+    And I set the "If-Match" header to "invalid"
+    When I call PUT /jobs/{id}/number_of_tasks/{7} using the generated id
+    Then the HTTP status code should be "409"
+    And I should receive the following response:
+    """
+      etag does not match with current state of resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: Job does not exist in the Job Store and a put request, to update its number of tasks, returns StatusNotFound
 

--- a/features/v1_features/latest_version_features/putting_number_of_tasks.feature
+++ b/features/v1_features/latest_version_features/putting_number_of_tasks.feature
@@ -68,6 +68,11 @@ Feature: Updating the number of tasks for a particular job
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "404"
+    And I should receive the following response:
+    """
+      failed to find the specified reindex job
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: A put request fails to update the number of tasks because it contains an invalid value of count
 
@@ -75,6 +80,11 @@ Feature: Updating the number of tasks for a particular job
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"seven"} using the generated id with an invalid count
     Then the HTTP status code should be "400"
+    And I should receive the following response:
+    """
+      number of tasks must be a positive integer
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: A put request fails to update the number of tasks because it contains a negative value of count
 
@@ -82,6 +92,23 @@ Feature: Updating the number of tasks for a particular job
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{id}/number_of_tasks/{"-7"} using the generated id with a negative count
     Then the HTTP status code should be "400"
+    And I should receive the following response:
+    """
+      number of tasks must be a positive integer
+    """ 
+    And the response header "E-Tag" should be ""
+
+  Scenario: Request results in no modification to job resource and returns an unmodified error
+
+    Given the number of existing jobs in the Job Store is 1
+    And the api version is v1 for incoming requests
+    When I call PUT /jobs/{id}/number_of_tasks/{0} using the generated id
+    Then the HTTP status code should be "304"
+    And I should receive the following response:
+    """
+      no modification made on resource
+    """ 
+    And the response header "E-Tag" should be ""
 
   Scenario: The connection to mongo DB is lost and a put request returns an internal server error
 
@@ -89,3 +116,8 @@ Feature: Updating the number of tasks for a particular job
     And the api version is v1 for incoming requests
     When I call PUT /jobs/{"a219584a-454a-4add-92c6-170359b0ee77"}/number_of_tasks/{7} using a valid UUID
     Then the HTTP status code should be "500"
+    And I should receive the following response:
+    """
+      internal server error
+    """ 
+    And the response header "E-Tag" should be ""

--- a/mongo/tasks.go
+++ b/mongo/tasks.go
@@ -107,29 +107,6 @@ func (m *JobStore) getTasksCount(ctx context.Context, jobID string) (int, error)
 	return numTasks, nil
 }
 
-// PutNumberOfTasks updates the number_of_tasks in a particular job, from the collection, specified by its id
-func (m *JobStore) PutNumberOfTasks(ctx context.Context, id string, numTasks int) error {
-	logData := log.Data{
-		"job_id":   id,
-		"numTasks": numTasks,
-	}
-
-	log.Info(ctx, "putting number of tasks", logData)
-
-	updates := make(bson.M)
-	updates["number_of_tasks"] = numTasks
-	updates["last_updated"] = time.Now().UTC()
-
-	err := m.UpdateJob(ctx, id, updates)
-	if err != nil {
-		logData["updates"] = updates
-		log.Error(ctx, "failed to update job with number of tasks", err, logData)
-		return err
-	}
-
-	return nil
-}
-
 // UpsertTask creates a new task document or overwrites an existing one
 func (m *JobStore) UpsertTask(ctx context.Context, jobID, taskName string, task models.Task) error {
 	log.Info(ctx, "upserting task to mongo")

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -23,7 +23,6 @@ var (
 	lockMongoDataStorerMockGetJobs             sync.RWMutex
 	lockMongoDataStorerMockGetTask             sync.RWMutex
 	lockMongoDataStorerMockGetTasks            sync.RWMutex
-	lockMongoDataStorerMockPutNumberOfTasks    sync.RWMutex
 	lockMongoDataStorerMockUnlockJob           sync.RWMutex
 	lockMongoDataStorerMockUpdateJob           sync.RWMutex
 	lockMongoDataStorerMockUpsertTask          sync.RWMutex
@@ -66,9 +65,6 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 //             },
 //             GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
 // 	               panic("mock out the GetTasks method")
-//             },
-//             PutNumberOfTasksFunc: func(ctx context.Context, id string, count int) error {
-// 	               panic("mock out the PutNumberOfTasks method")
 //             },
 //             UnlockJobFunc: func(ctx context.Context, lockID string)  {
 // 	               panic("mock out the UnlockJob method")
@@ -115,9 +111,6 @@ type MongoDataStorerMock struct {
 
 	// GetTasksFunc mocks the GetTasks method.
 	GetTasksFunc func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error)
-
-	// PutNumberOfTasksFunc mocks the PutNumberOfTasks method.
-	PutNumberOfTasksFunc func(ctx context.Context, id string, count int) error
 
 	// UnlockJobFunc mocks the UnlockJob method.
 	UnlockJobFunc func(ctx context.Context, lockID string)
@@ -195,15 +188,6 @@ type MongoDataStorerMock struct {
 			JobID string
 			// Options is the options argument value.
 			Options mongo.Options
-		}
-		// PutNumberOfTasks holds details about calls to the PutNumberOfTasks method.
-		PutNumberOfTasks []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ID is the id argument value.
-			ID string
-			// Count is the count argument value.
-			Count int
 		}
 		// UnlockJob holds details about calls to the UnlockJob method.
 		UnlockJob []struct {
@@ -554,45 +538,6 @@ func (mock *MongoDataStorerMock) GetTasksCalls() []struct {
 	lockMongoDataStorerMockGetTasks.RLock()
 	calls = mock.calls.GetTasks
 	lockMongoDataStorerMockGetTasks.RUnlock()
-	return calls
-}
-
-// PutNumberOfTasks calls PutNumberOfTasksFunc.
-func (mock *MongoDataStorerMock) PutNumberOfTasks(ctx context.Context, id string, count int) error {
-	if mock.PutNumberOfTasksFunc == nil {
-		panic("MongoDataStorerMock.PutNumberOfTasksFunc: method is nil but MongoDataStorer.PutNumberOfTasks was just called")
-	}
-	callInfo := struct {
-		Ctx   context.Context
-		ID    string
-		Count int
-	}{
-		Ctx:   ctx,
-		ID:    id,
-		Count: count,
-	}
-	lockMongoDataStorerMockPutNumberOfTasks.Lock()
-	mock.calls.PutNumberOfTasks = append(mock.calls.PutNumberOfTasks, callInfo)
-	lockMongoDataStorerMockPutNumberOfTasks.Unlock()
-	return mock.PutNumberOfTasksFunc(ctx, id, count)
-}
-
-// PutNumberOfTasksCalls gets all the calls that were made to PutNumberOfTasks.
-// Check the length with:
-//     len(mockedMongoDataStorer.PutNumberOfTasksCalls())
-func (mock *MongoDataStorerMock) PutNumberOfTasksCalls() []struct {
-	Ctx   context.Context
-	ID    string
-	Count int
-} {
-	var calls []struct {
-		Ctx   context.Context
-		ID    string
-		Count int
-	}
-	lockMongoDataStorerMockPutNumberOfTasks.RLock()
-	calls = mock.calls.PutNumberOfTasks
-	lockMongoDataStorerMockPutNumberOfTasks.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Ensure ETag is generated when writing partial update to job resource
  - Here we would need to get the existing job resource
  - Check the current `etag` value matches the IfMatch header value (if it is set and not equal to `*`)
  - Then transform the data - update `number_of_tasks`
  - Then generate the ETag and add to transformed resource
  - Then store in database
- Ensure we set ETag header in the response
- Add unit test and component test

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if all the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone