### PR TITLE
Migrate to doc db

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,32 +34,42 @@ if not then set one up by following these instructions: https://github.com/ONSdi
 
 ### Configuration
 
-| Environment variable         | Default               | Description
-| ---------------------------- | --------------------- | -----------
-| BIND_ADDR                    | localhost:25700       | The host and port to bind to (The http:// scheme prefix is added programmatically)
-| GRACEFUL_SHUTDOWN_TIMEOUT    | 20s                   | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 30s                   | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                   | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
-| MAX_REINDEX_JOB_RUNTIME      | 3600s                 | The maximum amount of time that a reindex job is allowed to run before another reindex job can be started
-| MONGODB_BIND_ADDR            | localhost:27017       | The MongoDB bind address
-| MONGODB_JOBS_COLLECTION      | jobs                  | MongoDB jobs collection
-| MONGODB_LOCKS_COLLECTION     | jobs_locks            | MongoDB locks collection
-| MONGODB_TASKS_COLLECTION     | tasks                 | MongoDB tasks collection
-| MONGODB_DATABASE             | search                | The MongoDB search database
-| DEFAULT_MAXIMUM_LIMIT        | 1000                  | The maximum number of items to be returned in any list endpoint (to prevent performance issues)
-| DEFAULT_LIMIT                | 20                    | The default number of items to be returned from a list endpoint
-| DEFAULT_OFFSET               | 0                     | The number of items into the full list (i.e. the 0-based index) that a particular response is starting at
-| ZEBEDEE_URL                  | http://localhost:8082 | The URL to Zebedee (for authorisation)
-| TASK_NAME_VALUES             | dataset-api,zebedee   | The list of permissible values that can be used for the task_name when creating a new task for a reindex job
-| SEARCH_API_URL               | http://localhost:23900| The URL to the Search API (for creating new ElasticSearch indexes)
-| SERVICE_AUTH_TOKEN           | _unset_               | This is required to identify the Search Reindex API when it calls the Search API POST /search endpoint
-| KAFKA_ADDR                   | localhost:39092       | The kafka broker addresses (can be comma separated)
-| KAFKA_VERSION                | "1.0.2"               | The kafka version that this service expects to connect to
-| KAFKA_SEC_PROTO              | _unset_               | if set to `TLS`, kafka connections will use TLS [[1]](#note1)
-| KAFKA_SEC_CA_CERTS           | _unset_               | CA cert chain for the server cert [[1]](#note1)
-| KAFKA_SEC_CLIENT_KEY         | _unset_               | PEM for the client key [[1]](#note1)
-| KAFKA_SEC_CLIENT_CERT        | _unset_               | PEM for the client certificate [[1]](#note1)
-| KAFKA_SEC_SKIP_VERIFY        | false                 | ignores server certificate issues if `true` [[1]](#note1)
+| Environment variable          | Default               | Description
+| ------------------------------| --------------------- | -----------
+| BIND_ADDR                     | localhost:25700       | The host and port to bind to (The http:// scheme prefix is added programmatically)
+| DEFAULT_LIMIT                 | 20                    | The default number of items to be returned from a list endpoint
+| DEFAULT_MAXIMUM_LIMIT         | 1000                  | The maximum number of items to be returned in any list endpoint (to prevent performance issues)
+| DEFAULT_OFFSET                | 0                     | The number of items into the full list (i.e. the 0-based index) that a particular response is starting at
+| GRACEFUL_SHUTDOWN_TIMEOUT     | 20s                   | The graceful shutdown timeout in seconds (`time.Duration` format)
+| HEALTHCHECK_CRITICAL_TIMEOUT  | 90s                   | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| HEALTHCHECK_INTERVAL          | 30s                   | Time between self-healthchecks (`time.Duration` format)
+| KAFKA_ADDR                    | localhost:39092       | The kafka broker addresses (can be comma separated)
+| KAFKA_REINDEX_REQUESTED_TOPIC | reindex-requested     | The name of the topic to produce messages for
+| KAFKA_SEC_CA_CERTS            | _unset_               | CA cert chain for the server cert [[1]](#note1)
+| KAFKA_SEC_CLIENT_CERT         | _unset_               | PEM for the client certificate [[1]](#note1)
+| KAFKA_SEC_CLIENT_KEY          | _unset_               | PEM for the client key [[1]](#note1)
+| KAFKA_SEC_PROTO               | _unset_               | if set to `TLS`, kafka connections will use TLS [[1]](#note1)
+| KAFKA_SEC_SKIP_VERIFY         | false                 | ignores server certificate issues if `true` [[1]](#note1)
+| KAFKA_VERSION                 | 1.0.2                 | The kafka version that this service expects to connect to
+| LATEST_VERSION                | v1                    | The latest version of the Search Reindex API
+| MAX_REINDEX_JOB_RUNTIME       | 3600s                 | The maximum amount of time that a reindex job is allowed to run before another reindex job can be started
+| MONGODB_BIND_ADDR             | localhost:27017       | The MongoDB bind address (aka the cluster endpoint)
+| MONGODB_CERT_CHAIN            | _unset_               | CA cert chain for the server cert
+| MONGODB_COLLECTIONS           | JobsCollection: "jobs", LocksCollection: "jobs_locks", TasksCollection: "tasks" | The MongoDB collections
+| MONGODB_CONNECT_TIMEOUT       | 5s                    | The timeout when connecting to MongoDB (`time.Duration` format)
+| MONGODB_DATABASE              | search                | The MongoDB search database
+| MONGODB_ENABLE_READ_CONCERN   | false                 | Switch to use (or not) majority read concern
+| MONGODB_ENABLE_WRITE_CONCERN  | true                  | Switch to use (or not) majority write concern
+| MONGODB_IS_SSL                | false                 | Switch to use (or not) TLS when connecting to mongodb
+| MONGODB_PASSWORD              | _unset_               | The MongoDB Password
+| MONGODB_QUERY_TIMEOUT         | 15s                   | The timeout for querying MongoDB (`time.Duration` format)
+| MONGODB_REPLICA_SET           | _unset_               | The name of the MongoDB replica set
+| MONGODB_USERNAME              | _unset_               | The MongoDB Username
+| MONGODB_VERIFY_CERT           | false                 | Switch for whether the Mongo server certificate is to be validated or not (a major security breach not doing so)
+| ZEBEDEE_URL                   | http://localhost:8082 | The URL to Zebedee (for authorisation)
+| TASK_NAME_VALUES              | dataset-api,zebedee   | The list of permissible values that can be used for the task_name when creating a new task for a reindex job
+| SEARCH_API_URL                | http://localhost:23900| The URL to the Search API (for creating new ElasticSearch indexes)
+| SERVICE_AUTH_TOKEN            | _unset_               | This is required to identify the Search Reindex API when it calls the Search API POST /search endpoint
 
 **Notes:**
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ if not then set one up by following these instructions: https://github.com/ONSdi
 ### Dependencies
 
 * Requires MongoDB running on port 27017
+* Requires Kafka running on port 9092  
 * Requires Zebedee running on port 8082
 * Requires Search API running on port 23900  
 * No further dependencies other than those defined in `go.mod`
@@ -66,10 +67,10 @@ if not then set one up by following these instructions: https://github.com/ONSdi
 | MONGODB_REPLICA_SET           | _unset_               | The name of the MongoDB replica set
 | MONGODB_USERNAME              | _unset_               | The MongoDB Username
 | MONGODB_VERIFY_CERT           | false                 | Switch for whether the Mongo server certificate is to be validated or not (a major security breach not doing so)
-| ZEBEDEE_URL                   | http://localhost:8082 | The URL to Zebedee (for authorisation)
-| TASK_NAME_VALUES              | dataset-api,zebedee   | The list of permissible values that can be used for the task_name when creating a new task for a reindex job
 | SEARCH_API_URL                | http://localhost:23900| The URL to the Search API (for creating new ElasticSearch indexes)
 | SERVICE_AUTH_TOKEN            | _unset_               | This is required to identify the Search Reindex API when it calls the Search API POST /search endpoint
+| TASK_NAME_VALUES              | dataset-api,zebedee   | The list of permissible values that can be used for the task_name when creating a new task for a reindex job
+| ZEBEDEE_URL                   | http://localhost:8082 | The URL to Zebedee (for authorisation)
 
 **Notes:**
 
@@ -96,6 +97,7 @@ The endpoint also requires a body, which should contain the task name, and the n
 }`
 - GET: http://localhost:25700/jobs/ID/tasks/TASK_NAME (should get a task from the data store)
 - GET: http://localhost:25700/jobs/ID/tasks (should get all the tasks, for a particular job, from the data store)
+- PATCH: http://localhost:25700/jobs/41f72483-aeee-4693-9fed-a45ebaa370f2 -H 'Authorization: Bearer fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67' -H 'If-Match: *' -H 'Content-Type: application/json' -d '[{"op":"replace","path":"/state","value":"created"},{"op":"replace","path":"/total_search_documents","value":208},{"op":"replace","path":"/number_of_tasks","value":2}]'
 
 ### Contributing
 

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
-	"github.com/globalsign/mgo/bson"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 //go:generate moq -out ./mock/data_storer.go -pkg mock . DataStorer

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-authorisation/auth"
 	dpHTTP "github.com/ONSdigital/dp-net/v2/http"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
 	"github.com/globalsign/mgo/bson"
@@ -19,7 +20,7 @@ import (
 // DataStorer is an interface for a type that can store and retrieve jobs
 type DataStorer interface {
 	AcquireJobLock(ctx context.Context, id string) (lockID string, err error)
-	CheckInProgressJob(ctx context.Context) error
+	CheckInProgressJob(ctx context.Context, cfg *config.Config) error
 	CreateJob(ctx context.Context, job models.Job) error
 	GetJob(ctx context.Context, id string) (*models.Job, error)
 	GetJobs(ctx context.Context, options mongo.Options) (job *models.Jobs, err error)

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -17,9 +17,9 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
 	"github.com/ONSdigital/dp-search-reindex-api/pagination"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 var (

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -35,7 +35,7 @@ func (api *API) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 	log.Info(ctx, "starting post operation of reindex job")
 
 	// check if a new reindex job can be created
-	err := api.dataStore.CheckInProgressJob(ctx)
+	err := api.dataStore.CheckInProgressJob(ctx, api.cfg)
 	if err != nil {
 		log.Error(ctx, "error occurred when checking to create a new reindex job", err)
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -116,7 +116,7 @@ func TestCreateJobHandler(t *testing.T) {
 	}
 
 	dataStorerMock := &apiMock.DataStorerMock{
-		CheckInProgressJobFunc: func(ctx context.Context) error {
+		CheckInProgressJobFunc: func(ctx context.Context, cfg *config.Config) error {
 			return nil
 		},
 		CreateJobFunc: func(ctx context.Context, job models.Job) error {
@@ -194,7 +194,7 @@ func TestCreateJobHandler(t *testing.T) {
 
 	Convey("Given an existing reindex job is in progress", t, func() {
 		jobInProgressDataStorerMock := &apiMock.DataStorerMock{
-			CheckInProgressJobFunc: func(ctx context.Context) error {
+			CheckInProgressJobFunc: func(ctx context.Context, cfg *config.Config) error {
 				return mongo.ErrExistingJobInProgress
 			},
 		}
@@ -224,7 +224,7 @@ func TestCreateJobHandler(t *testing.T) {
 
 	Convey("Given an error with the datastore", t, func() {
 		dataStorerFailMock := &apiMock.DataStorerMock{
-			CheckInProgressJobFunc: func(ctx context.Context) error {
+			CheckInProgressJobFunc: func(ctx context.Context, cfg *config.Config) error {
 				return errUnexpected
 			},
 		}
@@ -353,7 +353,7 @@ func TestCreateJobHandler(t *testing.T) {
 
 	Convey("Given an error to create a reindex job in the datastore", t, func() {
 		createJobDataStorerFailMock := &apiMock.DataStorerMock{
-			CheckInProgressJobFunc: func(ctx context.Context) error {
+			CheckInProgressJobFunc: func(ctx context.Context, cfg *config.Config) error {
 				return nil
 			},
 			CreateJobFunc: func(ctx context.Context, job models.Job) error {

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
-	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // Constants for testing

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
-	"github.com/globalsign/mgo/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"sync"
 )
 
@@ -47,7 +47,7 @@ var _ api.DataStorer = &DataStorerMock{}
 // 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
 // 				panic("mock out the UnlockJob method")
 // 			},
-// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 			UpdateJobFunc: func(ctx context.Context, id string, updates primitive.M) error {
 // 				panic("mock out the UpdateJob method")
 // 			},
 // 			UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
@@ -85,7 +85,7 @@ type DataStorerMock struct {
 	UnlockJobFunc func(ctx context.Context, lockID string)
 
 	// UpdateJobFunc mocks the UpdateJob method.
-	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
+	UpdateJobFunc func(ctx context.Context, id string, updates primitive.M) error
 
 	// UpsertTaskFunc mocks the UpsertTask method.
 	UpsertTaskFunc func(ctx context.Context, jobID string, taskName string, task models.Task) error
@@ -159,7 +159,7 @@ type DataStorerMock struct {
 			// ID is the id argument value.
 			ID string
 			// Updates is the updates argument value.
-			Updates bson.M
+			Updates primitive.M
 		}
 		// UpsertTask holds details about calls to the UpsertTask method.
 		UpsertTask []struct {
@@ -474,14 +474,14 @@ func (mock *DataStorerMock) UnlockJobCalls() []struct {
 }
 
 // UpdateJob calls UpdateJobFunc.
-func (mock *DataStorerMock) UpdateJob(ctx context.Context, id string, updates bson.M) error {
+func (mock *DataStorerMock) UpdateJob(ctx context.Context, id string, updates primitive.M) error {
 	if mock.UpdateJobFunc == nil {
 		panic("DataStorerMock.UpdateJobFunc: method is nil but DataStorer.UpdateJob was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
 		ID      string
-		Updates bson.M
+		Updates primitive.M
 	}{
 		Ctx:     ctx,
 		ID:      id,
@@ -499,12 +499,12 @@ func (mock *DataStorerMock) UpdateJob(ctx context.Context, id string, updates bs
 func (mock *DataStorerMock) UpdateJobCalls() []struct {
 	Ctx     context.Context
 	ID      string
-	Updates bson.M
+	Updates primitive.M
 } {
 	var calls []struct {
 		Ctx     context.Context
 		ID      string
-		Updates bson.M
+		Updates primitive.M
 	}
 	mock.lockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob

--- a/api/mock/data_storer.go
+++ b/api/mock/data_storer.go
@@ -6,78 +6,65 @@ package mock
 import (
 	"context"
 	"github.com/ONSdigital/dp-search-reindex-api/api"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
 	"github.com/globalsign/mgo/bson"
 	"sync"
 )
 
-var (
-	lockDataStorerMockAcquireJobLock     sync.RWMutex
-	lockDataStorerMockCheckInProgressJob sync.RWMutex
-	lockDataStorerMockCreateJob          sync.RWMutex
-	lockDataStorerMockGetJob             sync.RWMutex
-	lockDataStorerMockGetJobs            sync.RWMutex
-	lockDataStorerMockGetTask            sync.RWMutex
-	lockDataStorerMockGetTasks           sync.RWMutex
-	lockDataStorerMockPutNumberOfTasks   sync.RWMutex
-	lockDataStorerMockUnlockJob          sync.RWMutex
-	lockDataStorerMockUpdateJob          sync.RWMutex
-	lockDataStorerMockUpsertTask         sync.RWMutex
-)
-
-// Ensure, that DataStorerMock does implement DataStorer.
+// Ensure, that DataStorerMock does implement api.DataStorer.
 // If this is not the case, regenerate this file with moq.
 var _ api.DataStorer = &DataStorerMock{}
 
 // DataStorerMock is a mock implementation of api.DataStorer.
 //
-//     func TestSomethingThatUsesDataStorer(t *testing.T) {
+// 	func TestSomethingThatUsesDataStorer(t *testing.T) {
 //
-//         // make and configure a mocked api.DataStorer
-//         mockedDataStorer := &DataStorerMock{
-//             AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
-// 	               panic("mock out the AcquireJobLock method")
-//             },
-//             CheckInProgressJobFunc: func(ctx context.Context) error {
-// 	               panic("mock out the CheckInProgressJob method")
-//             },
-//             CreateJobFunc: func(ctx context.Context, job models.Job) error {
-// 	               panic("mock out the CreateJob method")
-//             },
-//             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
-// 	               panic("mock out the GetJob method")
-//             },
-//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
-// 	               panic("mock out the GetJobs method")
-//             },
-//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
-// 	               panic("mock out the GetTask method")
-//             },
-//             GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
-// 	               panic("mock out the GetTasks method")
-//             },
-//             UnlockJobFunc: func(ctx context.Context, lockID string)  {
-// 	               panic("mock out the UnlockJob method")
-//             },
-//             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
-// 	               panic("mock out the UpdateJob method")
-//             },
-//             UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
-// 	               panic("mock out the UpsertTask method")
-//             },
-//         }
+// 		// make and configure a mocked api.DataStorer
+// 		mockedDataStorer := &DataStorerMock{
+// 			AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+// 				panic("mock out the AcquireJobLock method")
+// 			},
+// 			CheckInProgressJobFunc: func(ctx context.Context, cfg *config.Config) error {
+// 				panic("mock out the CheckInProgressJob method")
+// 			},
+// 			CreateJobFunc: func(ctx context.Context, job models.Job) error {
+// 				panic("mock out the CreateJob method")
+// 			},
+// 			GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
+// 				panic("mock out the GetJob method")
+// 			},
+// 			GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
+// 				panic("mock out the GetJobs method")
+// 			},
+// 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
+// 				panic("mock out the GetTask method")
+// 			},
+// 			GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
+// 				panic("mock out the GetTasks method")
+// 			},
+// 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
+// 				panic("mock out the UnlockJob method")
+// 			},
+// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 				panic("mock out the UpdateJob method")
+// 			},
+// 			UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
+// 				panic("mock out the UpsertTask method")
+// 			},
+// 		}
 //
-//         // use mockedDataStorer in code that requires api.DataStorer
-//         // and then make assertions.
+// 		// use mockedDataStorer in code that requires api.DataStorer
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type DataStorerMock struct {
 	// AcquireJobLockFunc mocks the AcquireJobLock method.
 	AcquireJobLockFunc func(ctx context.Context, id string) (string, error)
 
 	// CheckInProgressJobFunc mocks the CheckInProgressJob method.
-	CheckInProgressJobFunc func(ctx context.Context) error
+	CheckInProgressJobFunc func(ctx context.Context, cfg *config.Config) error
 
 	// CreateJobFunc mocks the CreateJob method.
 	CreateJobFunc func(ctx context.Context, job models.Job) error
@@ -116,6 +103,8 @@ type DataStorerMock struct {
 		CheckInProgressJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// Cfg is the cfg argument value.
+			Cfg *config.Config
 		}
 		// CreateJob holds details about calls to the CreateJob method.
 		CreateJob []struct {
@@ -184,6 +173,16 @@ type DataStorerMock struct {
 			Task models.Task
 		}
 	}
+	lockAcquireJobLock     sync.RWMutex
+	lockCheckInProgressJob sync.RWMutex
+	lockCreateJob          sync.RWMutex
+	lockGetJob             sync.RWMutex
+	lockGetJobs            sync.RWMutex
+	lockGetTask            sync.RWMutex
+	lockGetTasks           sync.RWMutex
+	lockUnlockJob          sync.RWMutex
+	lockUpdateJob          sync.RWMutex
+	lockUpsertTask         sync.RWMutex
 }
 
 // AcquireJobLock calls AcquireJobLockFunc.
@@ -198,9 +197,9 @@ func (mock *DataStorerMock) AcquireJobLock(ctx context.Context, id string) (stri
 		Ctx: ctx,
 		ID:  id,
 	}
-	lockDataStorerMockAcquireJobLock.Lock()
+	mock.lockAcquireJobLock.Lock()
 	mock.calls.AcquireJobLock = append(mock.calls.AcquireJobLock, callInfo)
-	lockDataStorerMockAcquireJobLock.Unlock()
+	mock.lockAcquireJobLock.Unlock()
 	return mock.AcquireJobLockFunc(ctx, id)
 }
 
@@ -215,26 +214,28 @@ func (mock *DataStorerMock) AcquireJobLockCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	lockDataStorerMockAcquireJobLock.RLock()
+	mock.lockAcquireJobLock.RLock()
 	calls = mock.calls.AcquireJobLock
-	lockDataStorerMockAcquireJobLock.RUnlock()
+	mock.lockAcquireJobLock.RUnlock()
 	return calls
 }
 
 // CheckInProgressJob calls CheckInProgressJobFunc.
-func (mock *DataStorerMock) CheckInProgressJob(ctx context.Context) error {
+func (mock *DataStorerMock) CheckInProgressJob(ctx context.Context, cfg *config.Config) error {
 	if mock.CheckInProgressJobFunc == nil {
 		panic("DataStorerMock.CheckInProgressJobFunc: method is nil but DataStorer.CheckInProgressJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
+		Cfg *config.Config
 	}{
 		Ctx: ctx,
+		Cfg: cfg,
 	}
-	lockDataStorerMockCheckInProgressJob.Lock()
+	mock.lockCheckInProgressJob.Lock()
 	mock.calls.CheckInProgressJob = append(mock.calls.CheckInProgressJob, callInfo)
-	lockDataStorerMockCheckInProgressJob.Unlock()
-	return mock.CheckInProgressJobFunc(ctx)
+	mock.lockCheckInProgressJob.Unlock()
+	return mock.CheckInProgressJobFunc(ctx, cfg)
 }
 
 // CheckInProgressJobCalls gets all the calls that were made to CheckInProgressJob.
@@ -242,13 +243,15 @@ func (mock *DataStorerMock) CheckInProgressJob(ctx context.Context) error {
 //     len(mockedDataStorer.CheckInProgressJobCalls())
 func (mock *DataStorerMock) CheckInProgressJobCalls() []struct {
 	Ctx context.Context
+	Cfg *config.Config
 } {
 	var calls []struct {
 		Ctx context.Context
+		Cfg *config.Config
 	}
-	lockDataStorerMockCheckInProgressJob.RLock()
+	mock.lockCheckInProgressJob.RLock()
 	calls = mock.calls.CheckInProgressJob
-	lockDataStorerMockCheckInProgressJob.RUnlock()
+	mock.lockCheckInProgressJob.RUnlock()
 	return calls
 }
 
@@ -264,9 +267,9 @@ func (mock *DataStorerMock) CreateJob(ctx context.Context, job models.Job) error
 		Ctx: ctx,
 		Job: job,
 	}
-	lockDataStorerMockCreateJob.Lock()
+	mock.lockCreateJob.Lock()
 	mock.calls.CreateJob = append(mock.calls.CreateJob, callInfo)
-	lockDataStorerMockCreateJob.Unlock()
+	mock.lockCreateJob.Unlock()
 	return mock.CreateJobFunc(ctx, job)
 }
 
@@ -281,9 +284,9 @@ func (mock *DataStorerMock) CreateJobCalls() []struct {
 		Ctx context.Context
 		Job models.Job
 	}
-	lockDataStorerMockCreateJob.RLock()
+	mock.lockCreateJob.RLock()
 	calls = mock.calls.CreateJob
-	lockDataStorerMockCreateJob.RUnlock()
+	mock.lockCreateJob.RUnlock()
 	return calls
 }
 
@@ -299,9 +302,9 @@ func (mock *DataStorerMock) GetJob(ctx context.Context, id string) (*models.Job,
 		Ctx: ctx,
 		ID:  id,
 	}
-	lockDataStorerMockGetJob.Lock()
+	mock.lockGetJob.Lock()
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
-	lockDataStorerMockGetJob.Unlock()
+	mock.lockGetJob.Unlock()
 	return mock.GetJobFunc(ctx, id)
 }
 
@@ -316,9 +319,9 @@ func (mock *DataStorerMock) GetJobCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	lockDataStorerMockGetJob.RLock()
+	mock.lockGetJob.RLock()
 	calls = mock.calls.GetJob
-	lockDataStorerMockGetJob.RUnlock()
+	mock.lockGetJob.RUnlock()
 	return calls
 }
 
@@ -334,9 +337,9 @@ func (mock *DataStorerMock) GetJobs(ctx context.Context, options mongo.Options) 
 		Ctx:     ctx,
 		Options: options,
 	}
-	lockDataStorerMockGetJobs.Lock()
+	mock.lockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	lockDataStorerMockGetJobs.Unlock()
+	mock.lockGetJobs.Unlock()
 	return mock.GetJobsFunc(ctx, options)
 }
 
@@ -351,9 +354,9 @@ func (mock *DataStorerMock) GetJobsCalls() []struct {
 		Ctx     context.Context
 		Options mongo.Options
 	}
-	lockDataStorerMockGetJobs.RLock()
+	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs
-	lockDataStorerMockGetJobs.RUnlock()
+	mock.lockGetJobs.RUnlock()
 	return calls
 }
 
@@ -371,9 +374,9 @@ func (mock *DataStorerMock) GetTask(ctx context.Context, jobID string, taskName 
 		JobID:    jobID,
 		TaskName: taskName,
 	}
-	lockDataStorerMockGetTask.Lock()
+	mock.lockGetTask.Lock()
 	mock.calls.GetTask = append(mock.calls.GetTask, callInfo)
-	lockDataStorerMockGetTask.Unlock()
+	mock.lockGetTask.Unlock()
 	return mock.GetTaskFunc(ctx, jobID, taskName)
 }
 
@@ -390,9 +393,9 @@ func (mock *DataStorerMock) GetTaskCalls() []struct {
 		JobID    string
 		TaskName string
 	}
-	lockDataStorerMockGetTask.RLock()
+	mock.lockGetTask.RLock()
 	calls = mock.calls.GetTask
-	lockDataStorerMockGetTask.RUnlock()
+	mock.lockGetTask.RUnlock()
 	return calls
 }
 
@@ -410,9 +413,9 @@ func (mock *DataStorerMock) GetTasks(ctx context.Context, jobID string, options 
 		JobID:   jobID,
 		Options: options,
 	}
-	lockDataStorerMockGetTasks.Lock()
+	mock.lockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
-	lockDataStorerMockGetTasks.Unlock()
+	mock.lockGetTasks.Unlock()
 	return mock.GetTasksFunc(ctx, jobID, options)
 }
 
@@ -429,9 +432,9 @@ func (mock *DataStorerMock) GetTasksCalls() []struct {
 		JobID   string
 		Options mongo.Options
 	}
-	lockDataStorerMockGetTasks.RLock()
+	mock.lockGetTasks.RLock()
 	calls = mock.calls.GetTasks
-	lockDataStorerMockGetTasks.RUnlock()
+	mock.lockGetTasks.RUnlock()
 	return calls
 }
 
@@ -447,9 +450,9 @@ func (mock *DataStorerMock) UnlockJob(ctx context.Context, lockID string) {
 		Ctx:    ctx,
 		LockID: lockID,
 	}
-	lockDataStorerMockUnlockJob.Lock()
+	mock.lockUnlockJob.Lock()
 	mock.calls.UnlockJob = append(mock.calls.UnlockJob, callInfo)
-	lockDataStorerMockUnlockJob.Unlock()
+	mock.lockUnlockJob.Unlock()
 	mock.UnlockJobFunc(ctx, lockID)
 }
 
@@ -464,9 +467,9 @@ func (mock *DataStorerMock) UnlockJobCalls() []struct {
 		Ctx    context.Context
 		LockID string
 	}
-	lockDataStorerMockUnlockJob.RLock()
+	mock.lockUnlockJob.RLock()
 	calls = mock.calls.UnlockJob
-	lockDataStorerMockUnlockJob.RUnlock()
+	mock.lockUnlockJob.RUnlock()
 	return calls
 }
 
@@ -484,9 +487,9 @@ func (mock *DataStorerMock) UpdateJob(ctx context.Context, id string, updates bs
 		ID:      id,
 		Updates: updates,
 	}
-	lockDataStorerMockUpdateJob.Lock()
+	mock.lockUpdateJob.Lock()
 	mock.calls.UpdateJob = append(mock.calls.UpdateJob, callInfo)
-	lockDataStorerMockUpdateJob.Unlock()
+	mock.lockUpdateJob.Unlock()
 	return mock.UpdateJobFunc(ctx, id, updates)
 }
 
@@ -503,9 +506,9 @@ func (mock *DataStorerMock) UpdateJobCalls() []struct {
 		ID      string
 		Updates bson.M
 	}
-	lockDataStorerMockUpdateJob.RLock()
+	mock.lockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
-	lockDataStorerMockUpdateJob.RUnlock()
+	mock.lockUpdateJob.RUnlock()
 	return calls
 }
 
@@ -525,9 +528,9 @@ func (mock *DataStorerMock) UpsertTask(ctx context.Context, jobID string, taskNa
 		TaskName: taskName,
 		Task:     task,
 	}
-	lockDataStorerMockUpsertTask.Lock()
+	mock.lockUpsertTask.Lock()
 	mock.calls.UpsertTask = append(mock.calls.UpsertTask, callInfo)
-	lockDataStorerMockUpsertTask.Unlock()
+	mock.lockUpsertTask.Unlock()
 	return mock.UpsertTaskFunc(ctx, jobID, taskName, task)
 }
 
@@ -546,8 +549,8 @@ func (mock *DataStorerMock) UpsertTaskCalls() []struct {
 		TaskName string
 		Task     models.Task
 	}
-	lockDataStorerMockUpsertTask.RLock()
+	mock.lockUpsertTask.RLock()
 	calls = mock.calls.UpsertTask
-	lockDataStorerMockUpsertTask.RUnlock()
+	mock.lockUpsertTask.RUnlock()
 	return calls
 }

--- a/config/config.go
+++ b/config/config.go
@@ -95,9 +95,9 @@ func Get() (*Config, error) {
 				ConnectTimeout:                5 * time.Second,
 				QueryTimeout:                  15 * time.Second,
 				TLSConnectionConfig: mongodriver.TLSConnectionConfig{
-					IsSSL:              false,
-					VerifyCert:         false,
-					CACertChain:        "",
+					IsSSL:       false,
+					VerifyCert:  false,
+					CACertChain: "",
 				},
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,10 @@ func Get() (*Config, error) {
 				ConnectTimeout:                5 * time.Second,
 				QueryTimeout:                  15 * time.Second,
 				TLSConnectionConfig: mongodriver.TLSConnectionConfig{
-					IsSSL: false,
+					IsSSL:              false,
+					VerifyCert:         false,
+					CACertChain:        "",
+					RealHostnameForSSH: "",
 				},
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -60,18 +60,18 @@ func Get() (*Config, error) {
 
 	cfg = &Config{
 		BindAddr:                   "localhost:25700",
-		DefaultLimit:     20,
-		DefaultMaxLimit:  1000,
-		DefaultOffset:    0,
+		DefaultLimit:               20,
+		DefaultMaxLimit:            1000,
+		DefaultOffset:              0,
 		GracefulShutdownTimeout:    20 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		LatestVersion:              "v1",
 		MaxReindexJobRuntime:       3600 * time.Second,
-		SearchAPIURL:     "http://localhost:23900",
-		ServiceAuthToken: "",
-		TaskNameValues:   "dataset-api,zebedee",
-		ZebedeeURL:       "http://localhost:8082",
+		SearchAPIURL:               "http://localhost:23900",
+		ServiceAuthToken:           "",
+		TaskNameValues:             "dataset-api,zebedee",
+		ZebedeeURL:                 "http://localhost:8082",
 		KafkaConfig: KafkaConfig{
 			Brokers:               []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 			Version:               "1.0.2",
@@ -84,7 +84,7 @@ func Get() (*Config, error) {
 		},
 		MongoConfig: MongoConfig{
 			MongoDriverConfig: mongodriver.MongoDriverConfig{
-				ClusterEndpoint:               "localhost:27017",
+				ClusterEndpoint:               "localhost:27017", // Although this is named ClusterEndpoint the environment variable name is MONGODB_BIND_ADDR
 				Username:                      "",
 				Password:                      "",
 				Database:                      "search",

--- a/config/config.go
+++ b/config/config.go
@@ -98,7 +98,6 @@ func Get() (*Config, error) {
 					IsSSL:              false,
 					VerifyCert:         false,
 					CACertChain:        "",
-					RealHostnameForSSH: "",
 				},
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -12,20 +12,20 @@ var cfg *Config
 // Config represents service configuration for dp-search-reindex-api
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
-	LatestVersion              string        `envconfig:"LATEST_VERSION"`
+	DefaultLimit               int           `envconfig:"DEFAULT_LIMIT"`
+	DefaultMaxLimit            int           `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
+	DefaultOffset              int           `envconfig:"DEFAULT_OFFSET"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	LatestVersion              string        `envconfig:"LATEST_VERSION"`
 	MaxReindexJobRuntime       time.Duration `envconfig:"MAX_REINDEX_JOB_RUNTIME"`
-	MongoConfig                MongoConfig
-	DefaultMaxLimit            int    `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
-	DefaultLimit               int    `envconfig:"DEFAULT_LIMIT"`
-	DefaultOffset              int    `envconfig:"DEFAULT_OFFSET"`
-	ZebedeeURL                 string `envconfig:"ZEBEDEE_URL"`
-	TaskNameValues             string `envconfig:"TASK_NAME_VALUES"`
-	SearchAPIURL               string `envconfig:"SEARCH_API_URL"`
-	ServiceAuthToken           string `envconfig:"SERVICE_AUTH_TOKEN"   json:"-"`
+	SearchAPIURL               string        `envconfig:"SEARCH_API_URL"`
+	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"   json:"-"`
+	TaskNameValues             string        `envconfig:"TASK_NAME_VALUES"`
+	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
 	KafkaConfig                KafkaConfig
+	MongoConfig                MongoConfig
 }
 
 // MongoConfig contains the config required to connect to DocumentDB.
@@ -46,9 +46,9 @@ type KafkaConfig struct {
 }
 
 const (
-	JobsCollection          = "JobsCollection"
-	LocksCollection         = "LocksCollection"
-	TasksCollection         = "TasksCollection"
+	JobsCollection  = "JobsCollection"
+	LocksCollection = "LocksCollection"
+	TasksCollection = "TasksCollection"
 )
 
 // Get returns the default config with any modifications through environment
@@ -60,11 +60,28 @@ func Get() (*Config, error) {
 
 	cfg = &Config{
 		BindAddr:                   "localhost:25700",
-		LatestVersion:              "v1",
+		DefaultLimit:     20,
+		DefaultMaxLimit:  1000,
+		DefaultOffset:    0,
 		GracefulShutdownTimeout:    20 * time.Second,
-		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
+		HealthCheckInterval:        30 * time.Second,
+		LatestVersion:              "v1",
 		MaxReindexJobRuntime:       3600 * time.Second,
+		SearchAPIURL:     "http://localhost:23900",
+		ServiceAuthToken: "",
+		TaskNameValues:   "dataset-api,zebedee",
+		ZebedeeURL:       "http://localhost:8082",
+		KafkaConfig: KafkaConfig{
+			Brokers:               []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+			Version:               "1.0.2",
+			SecProtocol:           "",
+			SecCACerts:            "",
+			SecClientCert:         "",
+			SecClientKey:          "",
+			SecSkipVerify:         false,
+			ReindexRequestedTopic: "reindex-requested",
+		},
 		MongoConfig: MongoConfig{
 			MongoDriverConfig: mongodriver.MongoDriverConfig{
 				ClusterEndpoint:               "localhost:27017",
@@ -81,23 +98,6 @@ func Get() (*Config, error) {
 					IsSSL: false,
 				},
 			},
-		},
-		DefaultMaxLimit:  1000,
-		DefaultLimit:     20,
-		DefaultOffset:    0,
-		ZebedeeURL:       "http://localhost:8082",
-		TaskNameValues:   "dataset-api,zebedee",
-		SearchAPIURL:     "http://localhost:23900",
-		ServiceAuthToken: "",
-		KafkaConfig: KafkaConfig{
-			Brokers:               []string{"localhost:9092", "localhost:9093", "localhost:9094"},
-			Version:               "1.0.2",
-			SecProtocol:           "",
-			SecCACerts:            "",
-			SecClientCert:         "",
-			SecClientKey:          "",
-			SecSkipVerify:         false,
-			ReindexRequestedTopic: "reindex-requested",
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -30,11 +31,23 @@ func TestConfig(t *testing.T) {
 					HealthCheckCriticalTimeout: 90 * time.Second,
 					MaxReindexJobRuntime:       3600 * time.Second,
 					MongoConfig: MongoConfig{
-						BindAddr:        "localhost:27017",
-						JobsCollection:  "jobs",
-						LocksCollection: "jobs_locks",
-						TasksCollection: "tasks",
-						Database:        "search",
+						MongoDriverConfig: mongodriver.MongoDriverConfig{
+							ClusterEndpoint:               "localhost:27017",
+							Username:                      "",
+							Password:                      "",
+							Database:                      "search",
+							Collections:                   map[string]string{JobsCollection: "jobs", LocksCollection: "jobs_locks", TasksCollection: "tasks"},
+							ReplicaSet:                    "",
+							IsStrongReadConcernEnabled:    false,
+							IsWriteConcernMajorityEnabled: true,
+							ConnectTimeout:                5 * time.Second,
+							QueryTimeout:                  15 * time.Second,
+							TLSConnectionConfig: mongodriver.TLSConnectionConfig{
+								IsSSL:       false,
+								VerifyCert:  false,
+								CACertChain: "",
+							},
+						},
 					},
 					DefaultMaxLimit:  1000,
 					DefaultLimit:     20,

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -4,7 +4,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	"net/http"
 
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
@@ -15,6 +14,7 @@ import (
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"github.com/ONSdigital/dp-kafka/v2/kafkatest"
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	dpHTTP "github.com/ONSdigital/dp-net/v2/http"
 	"github.com/ONSdigital/dp-search-reindex-api/api"
 	"github.com/ONSdigital/dp-search-reindex-api/config"

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -4,6 +4,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	"net/http"
 
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
@@ -79,7 +80,17 @@ func NewSearchReindexAPIFeature(mongoFeature *componentTest.MongoFeature,
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
 
-	mongodb := &mongo.JobStore{}
+	mongodb := &mongo.JobStore{
+		MongoConfig: config.MongoConfig{
+			MongoDriverConfig: mongodriver.MongoDriverConfig{
+				ClusterEndpoint: mongoFeature.Server.URI(),
+				Database:        utils.RandomDatabase(),
+				Collections:     cfg.MongoConfig.Collections,
+				ConnectTimeout:  cfg.MongoConfig.ConnectTimeout,
+				QueryTimeout:    cfg.MongoConfig.QueryTimeout,
+			},
+		},
+	}
 
 	ctx := context.Background()
 	if dbErr := mongodb.Init(ctx); dbErr != nil {

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -159,7 +159,6 @@ func (f *SearchReindexAPIFeature) InitAPIFeature() *componentTest.APIFeature {
 func (f *SearchReindexAPIFeature) Reset(mongoFail bool) error {
 	if mongoFail {
 		// Close the connection to mimic mongo failing
-		f.MongoClient.LockClient.Close(context.Background())
 		f.MongoClient.Connection.Close(context.Background())
 	} else {
 		f.MongoClient.Database = utils.RandomDatabase()

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -158,7 +158,9 @@ func (f *SearchReindexAPIFeature) InitAPIFeature() *componentTest.APIFeature {
 // Reset sets the resources within a specific SearchReindexAPIFeature back to their default values.
 func (f *SearchReindexAPIFeature) Reset(mongoFail bool) error {
 	if mongoFail {
-		f.MongoClient.MongoConfig = config.MongoConfig{}
+		// Close the connection to mimic mongo failing
+		f.MongoClient.LockClient.Close(context.Background())
+		f.MongoClient.Connection.Close(context.Background())
 	} else {
 		f.MongoClient.Database = utils.RandomDatabase()
 	}

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -158,7 +158,7 @@ func (f *SearchReindexAPIFeature) InitAPIFeature() *componentTest.APIFeature {
 // Reset sets the resources within a specific SearchReindexAPIFeature back to their default values.
 func (f *SearchReindexAPIFeature) Reset(mongoFail bool) error {
 	if mongoFail {
-		f.MongoClient.Database = "lost database connection"
+		f.MongoClient.MongoConfig = config.MongoConfig{}
 	} else {
 		f.MongoClient.Database = utils.RandomDatabase()
 	}

--- a/features/steps/api_feature.go
+++ b/features/steps/api_feature.go
@@ -79,15 +79,10 @@ func NewSearchReindexAPIFeature(mongoFeature *componentTest.MongoFeature,
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
 
-	mongodb := &mongo.JobStore{
-		JobsCollection:  jobsCol,
-		TasksCollection: tasksCol,
-		Database:        utils.RandomDatabase(),
-		URI:             mongoFeature.Server.URI(),
-	}
+	mongodb := &mongo.JobStore{}
 
 	ctx := context.Background()
-	if dbErr := mongodb.Init(ctx, cfg); dbErr != nil {
+	if dbErr := mongodb.Init(ctx); dbErr != nil {
 		return nil, fmt.Errorf("failed to initialise mongo DB: %w", dbErr)
 	}
 
@@ -205,7 +200,7 @@ func (f *SearchReindexAPIFeature) DoGetHealthcheckOk(cfg *config.Config, curTime
 }
 
 // DoGetMongoDB returns a MongoDB, for the component test, which has a random database name and different URI to the one used by the API under test.
-func (f *SearchReindexAPIFeature) DoGetMongoDB(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error) {
+func (f *SearchReindexAPIFeature) DoGetMongoDB(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error) {
 	return f.MongoClient, nil
 }
 

--- a/features/steps/job_steps.go
+++ b/features/steps/job_steps.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v16"
-	"github.com/globalsign/mgo/bson"
 	"github.com/rdumont/assistdog"
 	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // setAPIVersionForPath is a feature step that sets the API version future steps will use when calling the API
@@ -159,24 +159,6 @@ func (f *SearchReindexAPIFeature) iCallPATCHJobsIDUsingTheGeneratedID(patchReqBo
 
 	return f.ErrorFeature.StepError()
 }
-
-// // iHaveCreatedATaskForTheGeneratedJob is a feature step that can be defined for a specific SearchReindexAPIFeature.
-// // It gets the job id from the response to calling POST /jobs and uses it to call POST /jobs/{job id}/tasks/{task name}
-// // in order to create a task for that job. It passes the taskToCreate request body to the POST endpoint.
-// func (f *SearchReindexAPIFeature) iHaveCreatedATaskForTheGeneratedJob(taskToCreate *godog.DocString) error {
-// 	err := f.getAndSetCreatedJobFromResponse()
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	path := getPath(f.apiVersion, fmt.Sprintf("/jobs/%s/tasks", f.createdJob.ID))
-// 	err = f.APIFeature.IPostToWithBody(path, taskToCreate)
-// 	if err != nil {
-// 		return fmt.Errorf("error occurred in IPostToWithBody: %w", err)
-// 	}
-
-// 	return f.ErrorFeature.StepError()
-// }
 
 // iSetIfMatchHeaderToValidETagForJobs gets the etag of the jobs resource which contains all the jobs
 // and then sets If-Match header to that eTag

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/cucumber/godog v0.12.5
 	github.com/cucumber/messages-go/v16 v16.0.1
-	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gorilla/mux v1.8.0
 	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -23,6 +22,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/smartystreets/goconvey v1.7.2
 	github.com/stretchr/testify v1.7.2
+	go.mongodb.org/mongo-driver v1.9.1
 )
 
 require (
@@ -81,7 +81,6 @@ require (
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
-	go.mongodb.org/mongo-driver v1.9.1 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/ONSdigital/dp-component-test v0.7.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-kafka/v2 v2.5.0
-	github.com/ONSdigital/dp-mongodb v1.8.0
 	github.com/ONSdigital/dp-mongodb/v3 v3.0.2
 	github.com/ONSdigital/dp-net/v2 v2.4.0
 	github.com/ONSdigital/log.go/v2 v2.2.0
@@ -45,6 +44,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-avro/avro v0.0.0-20171219232920-444163702c11 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/go-test/deep v1.0.7 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-kafka/v2 v2.5.0
 	github.com/ONSdigital/dp-mongodb v1.8.0
+	github.com/ONSdigital/dp-mongodb/v3 v3.0.2
 	github.com/ONSdigital/dp-net/v2 v2.4.0
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/cucumber/godog v0.12.5
@@ -75,7 +76,7 @@ require (
 	github.com/smartystreets/assertions v1.2.1 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0 // indirect
+	github.com/square/mongo-lock v0.0.0-20220601164918-701ecf357cd7 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/ONSdigital/dp-kafka/v2 v2.5.0 h1:VIhJwf5soKGxtiVjdG2Td21M08acrPwfsDLl
 github.com/ONSdigital/dp-kafka/v2 v2.5.0/go.mod h1:8fTKJ8F06nmTA3ixRnbUwfi9n+sQDfltw5d9uLJQtug=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
-github.com/ONSdigital/dp-mongodb v1.8.0 h1:7opxTS5LJdB7KYhdYYwFv0w4MlXzjgW2OkrRgnmAciQ=
-github.com/ONSdigital/dp-mongodb v1.8.0/go.mod h1:DMVcvTIuIbm4F/4ww5iMRKq+dFa6QinyXWUaYd+0+bM=
 github.com/ONSdigital/dp-mongodb-in-memory v1.3.1 h1:E2xSPOBr5B0riB1qN+z+m8ouWymnLWu+XHBUpgYLXWc=
 github.com/ONSdigital/dp-mongodb-in-memory v1.3.1/go.mod h1:QuDIrDBBsmL9Jh/kmpKI1ENslO8yBCDLlAQ6qL10Pac=
 github.com/ONSdigital/dp-mongodb/v3 v3.0.2 h1:CbIGAnhMvqwfKg3Dc3LCP6ALcFV4I9vdWRDOTi/QPdc=
@@ -433,7 +431,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610/go.mod h1:xyZcxcSxyRLfj4CDZzyycsGRcwfpY07ncmD2keFr548=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -513,7 +510,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0/go.mod h1:wR5++/O5fpa0UtI+9T8gKIi5jjl10va/EIEMRySqic4=
 github.com/square/mongo-lock v0.0.0-20220601164918-701ecf357cd7 h1:L3YYgLiZ/nxdVU71RvgFH8fYd62uiDdq1EiRz+fCFTM=
 github.com/square/mongo-lock v0.0.0-20220601164918-701ecf357cd7/go.mod h1:bLPJcGVut+NBtZhrqY/jTnfluDrZeuIvf66VjuwU/eU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -908,7 +904,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,6 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
-github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-avro/avro v0.0.0-20171219232920-444163702c11 h1:yswqe8UdKNWn4kjh1YTaAbvOSPeg95xhW7h4qeICL5E=
 github.com/go-avro/avro v0.0.0-20171219232920-444163702c11/go.mod h1:kxj6THYP0dmFPk4Z+bijIAhJoGgeBfyOKXMduhvdJPA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/ONSdigital/dp-mongodb v1.8.0 h1:7opxTS5LJdB7KYhdYYwFv0w4MlXzjgW2OkrRg
 github.com/ONSdigital/dp-mongodb v1.8.0/go.mod h1:DMVcvTIuIbm4F/4ww5iMRKq+dFa6QinyXWUaYd+0+bM=
 github.com/ONSdigital/dp-mongodb-in-memory v1.3.1 h1:E2xSPOBr5B0riB1qN+z+m8ouWymnLWu+XHBUpgYLXWc=
 github.com/ONSdigital/dp-mongodb-in-memory v1.3.1/go.mod h1:QuDIrDBBsmL9Jh/kmpKI1ENslO8yBCDLlAQ6qL10Pac=
+github.com/ONSdigital/dp-mongodb/v3 v3.0.2 h1:CbIGAnhMvqwfKg3Dc3LCP6ALcFV4I9vdWRDOTi/QPdc=
+github.com/ONSdigital/dp-mongodb/v3 v3.0.2/go.mod h1:5EtdWLz6X+S6mtFLvmsYqaP/uzGCFLmEbzjbepZwHgE=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
@@ -203,6 +205,7 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
+github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
@@ -248,6 +251,7 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -429,7 +433,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610 h1:tNI2PtIri0WEQONCJnhrOquQTZDfd2worapaCSUKES0=
 github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610/go.mod h1:xyZcxcSxyRLfj4CDZzyycsGRcwfpY07ncmD2keFr548=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -510,8 +513,9 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0 h1:Ae3eHg4QrqbpLdF/Y6jeREKvgqlgrftOglYY4RHdv9s=
 github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0/go.mod h1:wR5++/O5fpa0UtI+9T8gKIi5jjl10va/EIEMRySqic4=
+github.com/square/mongo-lock v0.0.0-20220601164918-701ecf357cd7 h1:L3YYgLiZ/nxdVU71RvgFH8fYd62uiDdq1EiRz+fCFTM=
+github.com/square/mongo-lock v0.0.0-20220601164918-701ecf357cd7/go.mod h1:bLPJcGVut+NBtZhrqY/jTnfluDrZeuIvf66VjuwU/eU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -671,6 +675,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=

--- a/main.go
+++ b/main.go
@@ -19,11 +19,12 @@ const serviceName = "dp-search-reindex-api"
 
 var (
 	// BuildTime represents the time in which the service was built
-	BuildTime string
+	//BuildTime = "2022-07-07T09:30:03+01:00"
+	BuildTime = "1657189133"
 	// GitCommit represents the commit (SHA-1) hash of the service that is running
-	GitCommit string
+	GitCommit = "7b1fcc412086dae938b12a6d8c17317d694eabc9"
 	// Version represents the version of the service that is running
-	Version string
+	Version = "1.2.3"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -19,12 +19,11 @@ const serviceName = "dp-search-reindex-api"
 
 var (
 	// BuildTime represents the time in which the service was built
-	//BuildTime = "2022-07-07T09:30:03+01:00"
-	BuildTime = "1657189133"
+	BuildTime string
 	// GitCommit represents the commit (SHA-1) hash of the service that is running
-	GitCommit = "7b1fcc412086dae938b12a6d8c17317d694eabc9"
+	GitCommit string
 	// Version represents the version of the service that is running
-	Version = "1.2.3"
+	Version string
 )
 
 func main() {

--- a/models/etag.go
+++ b/models/etag.go
@@ -6,7 +6,7 @@ import (
 
 	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/globalsign/mgo/bson"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // GenerateETagForJob generates a new eTag for a job resource

--- a/mongo/data_store.go
+++ b/mongo/data_store.go
@@ -4,13 +4,10 @@ import (
 	"context"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
-
-	//dpMongodb "github.com/ONSdigital/dp-mongodb"
 	mongolock "github.com/ONSdigital/dp-mongodb/v3/dplock"
 	mongohealth "github.com/ONSdigital/dp-mongodb/v3/health"
 	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	"github.com/ONSdigital/dp-search-reindex-api/config"
-	//"github.com/globalsign/mgo"
 )
 
 // JobStore is a type that contains an implementation of the MongoJobStorer interface, which can be used for creating

--- a/mongo/data_store.go
+++ b/mongo/data_store.go
@@ -26,7 +26,7 @@ type JobStore struct {
 	//client          *dpMongoHealth.Client
 	//healthClient    *dpMongoHealth.CheckMongoClient
 	//lockClient      *dpMongoLock.Lock
-	cfg             *config.Config
+	cfg *config.Config
 	mongodriver.MongoDriverConfig
 
 	Connection   *mongodriver.MongoConnection

--- a/mongo/data_store.go
+++ b/mongo/data_store.go
@@ -27,7 +27,8 @@ type JobStore struct {
 	//healthClient    *dpMongoHealth.CheckMongoClient
 	//lockClient      *dpMongoLock.Lock
 	cfg *config.Config
-	mongodriver.MongoDriverConfig
+	//mongodriver.MongoDriverConfig
+	config.MongoConfig
 
 	Connection   *mongodriver.MongoConnection
 	HealthClient *mongohealth.CheckMongoClient

--- a/mongo/data_store.go
+++ b/mongo/data_store.go
@@ -17,17 +17,6 @@ import (
 // and getting Job resources. It also represents a simplistic MongoDB configuration, with session,
 // health and lock clients
 type JobStore struct {
-	//Session         *mgo.Session
-	//URI             string
-	//Database        string
-	//JobsCollection  string
-	//LocksCollection string
-	//TasksCollection string
-	//client          *dpMongoHealth.Client
-	//healthClient    *dpMongoHealth.CheckMongoClient
-	//lockClient      *dpMongoLock.Lock
-	//cfg *config.Config
-	//mongodriver.MongoDriverConfig
 	config.MongoConfig
 
 	Connection   *mongodriver.MongoConnection

--- a/mongo/data_store.go
+++ b/mongo/data_store.go
@@ -2,31 +2,36 @@ package mongo
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
-	dpMongodb "github.com/ONSdigital/dp-mongodb"
-	dpMongoLock "github.com/ONSdigital/dp-mongodb/dplock"
-	dpMongoHealth "github.com/ONSdigital/dp-mongodb/health"
+
+	//dpMongodb "github.com/ONSdigital/dp-mongodb"
+	mongolock "github.com/ONSdigital/dp-mongodb/v3/dplock"
+	mongohealth "github.com/ONSdigital/dp-mongodb/v3/health"
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	"github.com/ONSdigital/dp-search-reindex-api/config"
-	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/globalsign/mgo"
+	//"github.com/globalsign/mgo"
 )
 
 // JobStore is a type that contains an implementation of the MongoJobStorer interface, which can be used for creating
 // and getting Job resources. It also represents a simplistic MongoDB configuration, with session,
 // health and lock clients
 type JobStore struct {
-	Session         *mgo.Session
-	URI             string
-	Database        string
-	JobsCollection  string
-	LocksCollection string
-	TasksCollection string
-	client          *dpMongoHealth.Client
-	healthClient    *dpMongoHealth.CheckMongoClient
-	lockClient      *dpMongoLock.Lock
+	//Session         *mgo.Session
+	//URI             string
+	//Database        string
+	//JobsCollection  string
+	//LocksCollection string
+	//TasksCollection string
+	//client          *dpMongoHealth.Client
+	//healthClient    *dpMongoHealth.CheckMongoClient
+	//lockClient      *dpMongoLock.Lock
 	cfg             *config.Config
+	mongodriver.MongoDriverConfig
+
+	Connection   *mongodriver.MongoConnection
+	HealthClient *mongohealth.CheckMongoClient
+	LockClient   *mongolock.Lock
 }
 
 // Options contains information for pagination which includes offset and limit
@@ -35,51 +40,33 @@ type Options struct {
 	Limit  int
 }
 
-// Init creates a new mgo.Session with a strong consistency and a write mode of "majority".
-func (m *JobStore) Init(ctx context.Context, cfg *config.Config) (err error) {
-	m.cfg = cfg
-	if m.Session != nil {
-		return errors.New("session already exists")
-	}
-
-	// create session
-	if m.Session, err = mgo.Dial(m.URI); err != nil {
+// Init returns an initialised Mongo object encapsulating a connection to the mongo server/cluster with the given configuration,
+// a health client to check the health of the mongo server/cluster, and a lock client
+func (m *JobStore) Init(ctx context.Context) (err error) {
+	m.Connection, err = mongodriver.Open(&m.MongoDriverConfig)
+	if err != nil {
 		return err
 	}
-	m.Session.EnsureSafe(&mgo.Safe{WMode: "majority"})
-	m.Session.SetMode(mgo.Strong, true)
 
-	databaseCollectionBuilder := make(map[dpMongoHealth.Database][]dpMongoHealth.Collection)
-	databaseCollectionBuilder[dpMongoHealth.Database(m.Database)] = []dpMongoHealth.Collection{dpMongoHealth.Collection(m.JobsCollection),
-		dpMongoHealth.Collection(m.LocksCollection), dpMongoHealth.Collection(m.TasksCollection)}
-
-	// create client and healthClient from session
-	m.client = dpMongoHealth.NewClientWithCollections(m.Session, databaseCollectionBuilder)
-	m.healthClient = &dpMongoHealth.CheckMongoClient{
-		Client:      *m.client,
-		Healthcheck: m.client.Healthcheck,
+	databaseCollectionBuilder := map[mongohealth.Database][]mongohealth.Collection{
+		(mongohealth.Database)(m.Database): {
+			mongohealth.Collection(m.ActualCollectionName(config.JobsCollection)),
+			mongohealth.Collection(m.ActualCollectionName(config.TasksCollection)),
+		},
 	}
-
-	// create MongoDB lock client, which also starts the purger loop
-	if m.lockClient, err = dpMongoLock.New(ctx, m.Session, m.Database, m.JobsCollection, nil); err != nil {
-		logData := log.Data{
-			"database":        m.Database,
-			"jobs_collection": m.JobsCollection,
-		}
-		log.Error(ctx, "failed to create a mongodb lock client", err, logData)
-		return err
-	}
+	m.HealthClient = mongohealth.NewClientWithCollections(m.Connection, databaseCollectionBuilder)
+	m.LockClient = mongolock.New(ctx, m.Connection, m.ActualCollectionName(config.JobsCollection))
 
 	return nil
 }
 
 // Checker is called by the healthcheck library to check the health state of this mongoDB instance
 func (m *JobStore) Checker(ctx context.Context, state *healthcheck.CheckState) error {
-	return m.healthClient.Checker(ctx, state)
+	return m.HealthClient.Checker(ctx, state)
 }
 
-// Close closes the mongo session and returns any error
+// Close disconnects the mongo session
 func (m *JobStore) Close(ctx context.Context) error {
-	m.lockClient.Close(ctx)
-	return dpMongodb.Close(ctx, m.Session)
+	m.LockClient.Close(ctx)
+	return m.Connection.Close(ctx)
 }

--- a/mongo/data_store.go
+++ b/mongo/data_store.go
@@ -26,7 +26,7 @@ type JobStore struct {
 	//client          *dpMongoHealth.Client
 	//healthClient    *dpMongoHealth.CheckMongoClient
 	//lockClient      *dpMongoLock.Lock
-	cfg *config.Config
+	//cfg *config.Config
 	//mongodriver.MongoDriverConfig
 	config.MongoConfig
 

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -132,7 +132,7 @@ func (m *JobStore) GetJobs(ctx context.Context, option Options) (*models.Jobs, e
 	// create and populate jobsList
 	jobsList := make([]models.Job, numJobs)
 	_, err = m.Connection.Collection(m.ActualCollectionName(config.JobsCollection)).Find(ctx, bson.M{}, &jobsList,
-		mongodriver.Sort(bson.M{"_id": 1}), mongodriver.Offset(option.Offset), mongodriver.Limit(option.Limit))
+		mongodriver.Sort(bson.M{"last_updated": 1}), mongodriver.Offset(option.Offset), mongodriver.Limit(option.Limit))
 	if err != nil {
 		log.Error(ctx, "failed to populate jobs list", err, logData)
 		return nil, err

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/globalsign/mgo/bson"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // AcquireJobLock tries to lock the provided jobID.

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -28,7 +28,7 @@ func (m *JobStore) UnlockJob(ctx context.Context, lockID string) {
 
 // CheckInProgressJob checks if a new reindex job can be created depending on if a reindex job is currently in progress between cfg.MaxReindexJobRuntime before now and now
 // It returns an error if a reindex job already exists which is in_progress state
-func (m *JobStore) CheckInProgressJob(ctx context.Context, cfg config.Config) error {
+func (m *JobStore) CheckInProgressJob(ctx context.Context, cfg *config.Config) error {
 	log.Info(ctx, "checking if an existing reindex job is in progress")
 
 	// checkFromTime is the time of configured variable "MaxReindexJobRuntime" from now

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -172,7 +172,7 @@ func (m *JobStore) getJobsCount(ctx context.Context) (int, error) {
 func (m *JobStore) UpdateJob(ctx context.Context, id string, updates bson.M) error {
 	update := bson.M{"$set": updates}
 
-	if _, err := m.Connection.Collection(m.ActualCollectionName(config.JobsCollection)).Must().Update(ctx, bson.M{"id": id}, update); err != nil {
+	if _, err := m.Connection.Collection(m.ActualCollectionName(config.JobsCollection)).Must().Update(ctx, bson.M{"_id": id}, update); err != nil {
 		logData := log.Data{
 			"job_id":  id,
 			"updates": updates,

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -28,11 +28,11 @@ func (m *JobStore) UnlockJob(ctx context.Context, lockID string) {
 
 // CheckInProgressJob checks if a new reindex job can be created depending on if a reindex job is currently in progress between cfg.MaxReindexJobRuntime before now and now
 // It returns an error if a reindex job already exists which is in_progress state
-func (m *JobStore) CheckInProgressJob(ctx context.Context) error {
+func (m *JobStore) CheckInProgressJob(ctx context.Context, cfg config.Config) error {
 	log.Info(ctx, "checking if an existing reindex job is in progress")
 
 	// checkFromTime is the time of configured variable "MaxReindexJobRuntime" from now
-	checkFromTime := time.Now().Add(-1 * m.cfg.MaxReindexJobRuntime)
+	checkFromTime := time.Now().Add(-1 * cfg.MaxReindexJobRuntime)
 
 	var job models.Job
 

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -3,13 +3,12 @@ package mongo
 import (
 	"context"
 	"errors"
-	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
-	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"time"
 
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 )
 
@@ -106,7 +105,7 @@ func (m *JobStore) GetJob(ctx context.Context, id string) (*models.Job, error) {
 
 	job, err := m.findJob(ctx, id)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
 			log.Error(ctx, "job not found in mongo", err, logData)
 			return nil, ErrJobNotFound
 		}

--- a/mongo/jobs.go
+++ b/mongo/jobs.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"time"
 
-	//dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/globalsign/mgo"
@@ -42,7 +41,7 @@ func (m *JobStore) CheckInProgressJob(ctx context.Context) error {
 		FindOne(ctx, bson.M{
 			"state":           "in-progress",
 			"reindex_started": bson.M{"$gte": checkFromTime, "$lte": time.Now()},
-			}, &job)
+		}, &job)
 	if err != nil {
 		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
 			log.Info(ctx, "no reindex jobs with state in progress")

--- a/mongo/tasks.go
+++ b/mongo/tasks.go
@@ -54,14 +54,8 @@ func (m *JobStore) GetTasks(ctx context.Context, jobID string, options Options) 
 
 	// create and populate taskList using the given job_id
 	taskList := make([]models.Task, numTasks)
-	//_, err = m.Connection.Collection(m.ActualCollectionName(config.TasksCollection)).Find(ctx, bson.M{"job_id": jobID}, &taskList,
-	//	mongodriver.Sort("last_updated"), mongodriver.Offset(options.Offset), mongodriver.Limit(options.Limit))
-
 	_, err = m.Connection.Collection(m.ActualCollectionName(config.TasksCollection)).Find(ctx, bson.M{"job_id": jobID}, &taskList,
 		mongodriver.Sort(bson.M{"last_updated": 1}), mongodriver.Offset(options.Offset), mongodriver.Limit(options.Limit))
-
-	//_, err = m.Connection.Collection(m.ActualCollectionName(config.TasksCollection)).Find(ctx, bson.M{"job_id": jobID}, &taskList,
-	//	mongodriver.Offset(options.Offset), mongodriver.Limit(options.Limit))
 	if err != nil {
 		log.Error(ctx, "failed to populate task list", err, logData)
 		return nil, err

--- a/mongo/tasks.go
+++ b/mongo/tasks.go
@@ -54,8 +54,14 @@ func (m *JobStore) GetTasks(ctx context.Context, jobID string, options Options) 
 
 	// create and populate taskList using the given job_id
 	taskList := make([]models.Task, numTasks)
+	//_, err = m.Connection.Collection(m.ActualCollectionName(config.TasksCollection)).Find(ctx, bson.M{"job_id": jobID}, &taskList,
+	//	mongodriver.Sort("last_updated"), mongodriver.Offset(options.Offset), mongodriver.Limit(options.Limit))
+
 	_, err = m.Connection.Collection(m.ActualCollectionName(config.TasksCollection)).Find(ctx, bson.M{"job_id": jobID}, &taskList,
-		mongodriver.Sort("last_updated"), mongodriver.Offset(options.Offset), mongodriver.Limit(options.Limit))
+		mongodriver.Sort(bson.M{"last_updated": 1}), mongodriver.Offset(options.Offset), mongodriver.Limit(options.Limit))
+
+	//_, err = m.Connection.Collection(m.ActualCollectionName(config.TasksCollection)).Find(ctx, bson.M{"job_id": jobID}, &taskList,
+	//	mongodriver.Offset(options.Offset), mongodriver.Limit(options.Limit))
 	if err != nil {
 		log.Error(ctx, "failed to populate task list", err, logData)
 		return nil, err

--- a/mongo/tasks.go
+++ b/mongo/tasks.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/globalsign/mgo/bson"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // GetTask retrieves the details of a particular task, from the collection, specified by its task name and associated job id

--- a/mongo/tasks.go
+++ b/mongo/tasks.go
@@ -3,10 +3,10 @@ package mongo
 import (
 	"context"
 	"errors"
-	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
-	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"time"
 
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
 	"go.mongodb.org/mongo-driver/bson"

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -50,8 +50,8 @@ func (e *ExternalServiceList) GetHTTPServer(bindAddr string, router http.Handler
 }
 
 // GetMongoDB creates a mongoDB client and sets the Mongo flag to true
-func (e *ExternalServiceList) GetMongoDB(ctx context.Context, cfg *config.Config) (MongoDataStorer, error) {
-	mongoDB, err := e.Init.DoGetMongoDB(ctx, cfg)
+func (e *ExternalServiceList) GetMongoDB(ctx context.Context, mgoCfg config.MongoConfig) (MongoDataStorer, error) {
+	mongoDB, err := e.Init.DoGetMongoDB(ctx, mgoCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -144,17 +144,14 @@ func (e *Init) DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, versio
 }
 
 // DoGetMongoDB returns a MongoDB
-func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (MongoDataStorer, error) {
+func (e *Init) DoGetMongoDB(ctx context.Context, mgoCfg config.MongoConfig) (MongoDataStorer, error) {
 	mongodb := &mongo.JobStore{
-		JobsCollection:  cfg.MongoConfig.JobsCollection,
-		LocksCollection: cfg.MongoConfig.LocksCollection,
-		TasksCollection: cfg.MongoConfig.TasksCollection,
-		Database:        cfg.MongoConfig.Database,
-		URI:             cfg.MongoConfig.BindAddr,
+		MongoConfig: mgoCfg,
 	}
-	if err := mongodb.Init(ctx, cfg); err != nil {
+	if err := mongodb.Init(ctx); err != nil {
 		return nil, err
 	}
+	log.Info(ctx, "listening to mongo db session", log.Data{"URI": mongodb.ClusterEndpoint})
 	return mongodb, nil
 }
 

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -21,7 +21,7 @@ type Initialiser interface {
 	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
 	DoGetHealthClient(name, url string) *health.Client
-	DoGetMongoDB(ctx context.Context, cfg *config.Config) (MongoDataStorer, error)
+	DoGetMongoDB(ctx context.Context, mgoCfg config.MongoConfig) (MongoDataStorer, error)
 	DoGetAuthorisationHandlers(ctx context.Context, cfg *config.Config) api.AuthHandler
 	DoGetKafkaProducer(ctx context.Context, cfg *config.Config) (KafkaProducer, error)
 }

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -13,49 +13,40 @@ import (
 	"sync"
 )
 
-var (
-	lockInitialiserMockDoGetAuthorisationHandlers sync.RWMutex
-	lockInitialiserMockDoGetHTTPServer            sync.RWMutex
-	lockInitialiserMockDoGetHealthCheck           sync.RWMutex
-	lockInitialiserMockDoGetHealthClient          sync.RWMutex
-	lockInitialiserMockDoGetKafkaProducer         sync.RWMutex
-	lockInitialiserMockDoGetMongoDB               sync.RWMutex
-)
-
-// Ensure, that InitialiserMock does implement Initialiser.
+// Ensure, that InitialiserMock does implement service.Initialiser.
 // If this is not the case, regenerate this file with moq.
 var _ service.Initialiser = &InitialiserMock{}
 
 // InitialiserMock is a mock implementation of service.Initialiser.
 //
-//     func TestSomethingThatUsesInitialiser(t *testing.T) {
+// 	func TestSomethingThatUsesInitialiser(t *testing.T) {
 //
-//         // make and configure a mocked service.Initialiser
-//         mockedInitialiser := &InitialiserMock{
-//             DoGetAuthorisationHandlersFunc: func(ctx context.Context, cfg *config.Config) api.AuthHandler {
-// 	               panic("mock out the DoGetAuthorisationHandlers method")
-//             },
-//             DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
-// 	               panic("mock out the DoGetHTTPServer method")
-//             },
-//             DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
-// 	               panic("mock out the DoGetHealthCheck method")
-//             },
-//             DoGetHealthClientFunc: func(name string, url string) *health.Client {
-// 	               panic("mock out the DoGetHealthClient method")
-//             },
-//             DoGetKafkaProducerFunc: func(ctx context.Context, cfg *config.Config) (service.KafkaProducer, error) {
-// 	               panic("mock out the DoGetKafkaProducer method")
-//             },
-//             DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error) {
-// 	               panic("mock out the DoGetMongoDB method")
-//             },
-//         }
+// 		// make and configure a mocked service.Initialiser
+// 		mockedInitialiser := &InitialiserMock{
+// 			DoGetAuthorisationHandlersFunc: func(ctx context.Context, cfg *config.Config) api.AuthHandler {
+// 				panic("mock out the DoGetAuthorisationHandlers method")
+// 			},
+// 			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
+// 				panic("mock out the DoGetHTTPServer method")
+// 			},
+// 			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
+// 				panic("mock out the DoGetHealthCheck method")
+// 			},
+// 			DoGetHealthClientFunc: func(name string, url string) *health.Client {
+// 				panic("mock out the DoGetHealthClient method")
+// 			},
+// 			DoGetKafkaProducerFunc: func(ctx context.Context, cfg *config.Config) (service.KafkaProducer, error) {
+// 				panic("mock out the DoGetKafkaProducer method")
+// 			},
+// 			DoGetMongoDBFunc: func(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error) {
+// 				panic("mock out the DoGetMongoDB method")
+// 			},
+// 		}
 //
-//         // use mockedInitialiser in code that requires service.Initialiser
-//         // and then make assertions.
+// 		// use mockedInitialiser in code that requires service.Initialiser
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type InitialiserMock struct {
 	// DoGetAuthorisationHandlersFunc mocks the DoGetAuthorisationHandlers method.
 	DoGetAuthorisationHandlersFunc func(ctx context.Context, cfg *config.Config) api.AuthHandler
@@ -73,7 +64,7 @@ type InitialiserMock struct {
 	DoGetKafkaProducerFunc func(ctx context.Context, cfg *config.Config) (service.KafkaProducer, error)
 
 	// DoGetMongoDBFunc mocks the DoGetMongoDB method.
-	DoGetMongoDBFunc func(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error)
+	DoGetMongoDBFunc func(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -120,10 +111,16 @@ type InitialiserMock struct {
 		DoGetMongoDB []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Cfg is the cfg argument value.
-			Cfg *config.Config
+			// MgoCfg is the mgoCfg argument value.
+			MgoCfg config.MongoConfig
 		}
 	}
+	lockDoGetAuthorisationHandlers sync.RWMutex
+	lockDoGetHTTPServer            sync.RWMutex
+	lockDoGetHealthCheck           sync.RWMutex
+	lockDoGetHealthClient          sync.RWMutex
+	lockDoGetKafkaProducer         sync.RWMutex
+	lockDoGetMongoDB               sync.RWMutex
 }
 
 // DoGetAuthorisationHandlers calls DoGetAuthorisationHandlersFunc.
@@ -138,9 +135,9 @@ func (mock *InitialiserMock) DoGetAuthorisationHandlers(ctx context.Context, cfg
 		Ctx: ctx,
 		Cfg: cfg,
 	}
-	lockInitialiserMockDoGetAuthorisationHandlers.Lock()
+	mock.lockDoGetAuthorisationHandlers.Lock()
 	mock.calls.DoGetAuthorisationHandlers = append(mock.calls.DoGetAuthorisationHandlers, callInfo)
-	lockInitialiserMockDoGetAuthorisationHandlers.Unlock()
+	mock.lockDoGetAuthorisationHandlers.Unlock()
 	return mock.DoGetAuthorisationHandlersFunc(ctx, cfg)
 }
 
@@ -155,9 +152,9 @@ func (mock *InitialiserMock) DoGetAuthorisationHandlersCalls() []struct {
 		Ctx context.Context
 		Cfg *config.Config
 	}
-	lockInitialiserMockDoGetAuthorisationHandlers.RLock()
+	mock.lockDoGetAuthorisationHandlers.RLock()
 	calls = mock.calls.DoGetAuthorisationHandlers
-	lockInitialiserMockDoGetAuthorisationHandlers.RUnlock()
+	mock.lockDoGetAuthorisationHandlers.RUnlock()
 	return calls
 }
 
@@ -173,9 +170,9 @@ func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handle
 		BindAddr: bindAddr,
 		Router:   router,
 	}
-	lockInitialiserMockDoGetHTTPServer.Lock()
+	mock.lockDoGetHTTPServer.Lock()
 	mock.calls.DoGetHTTPServer = append(mock.calls.DoGetHTTPServer, callInfo)
-	lockInitialiserMockDoGetHTTPServer.Unlock()
+	mock.lockDoGetHTTPServer.Unlock()
 	return mock.DoGetHTTPServerFunc(bindAddr, router)
 }
 
@@ -190,9 +187,9 @@ func (mock *InitialiserMock) DoGetHTTPServerCalls() []struct {
 		BindAddr string
 		Router   http.Handler
 	}
-	lockInitialiserMockDoGetHTTPServer.RLock()
+	mock.lockDoGetHTTPServer.RLock()
 	calls = mock.calls.DoGetHTTPServer
-	lockInitialiserMockDoGetHTTPServer.RUnlock()
+	mock.lockDoGetHTTPServer.RUnlock()
 	return calls
 }
 
@@ -212,9 +209,9 @@ func (mock *InitialiserMock) DoGetHealthCheck(cfg *config.Config, buildTime stri
 		GitCommit: gitCommit,
 		Version:   version,
 	}
-	lockInitialiserMockDoGetHealthCheck.Lock()
+	mock.lockDoGetHealthCheck.Lock()
 	mock.calls.DoGetHealthCheck = append(mock.calls.DoGetHealthCheck, callInfo)
-	lockInitialiserMockDoGetHealthCheck.Unlock()
+	mock.lockDoGetHealthCheck.Unlock()
 	return mock.DoGetHealthCheckFunc(cfg, buildTime, gitCommit, version)
 }
 
@@ -233,9 +230,9 @@ func (mock *InitialiserMock) DoGetHealthCheckCalls() []struct {
 		GitCommit string
 		Version   string
 	}
-	lockInitialiserMockDoGetHealthCheck.RLock()
+	mock.lockDoGetHealthCheck.RLock()
 	calls = mock.calls.DoGetHealthCheck
-	lockInitialiserMockDoGetHealthCheck.RUnlock()
+	mock.lockDoGetHealthCheck.RUnlock()
 	return calls
 }
 
@@ -251,9 +248,9 @@ func (mock *InitialiserMock) DoGetHealthClient(name string, url string) *health.
 		Name: name,
 		URL:  url,
 	}
-	lockInitialiserMockDoGetHealthClient.Lock()
+	mock.lockDoGetHealthClient.Lock()
 	mock.calls.DoGetHealthClient = append(mock.calls.DoGetHealthClient, callInfo)
-	lockInitialiserMockDoGetHealthClient.Unlock()
+	mock.lockDoGetHealthClient.Unlock()
 	return mock.DoGetHealthClientFunc(name, url)
 }
 
@@ -268,9 +265,9 @@ func (mock *InitialiserMock) DoGetHealthClientCalls() []struct {
 		Name string
 		URL  string
 	}
-	lockInitialiserMockDoGetHealthClient.RLock()
+	mock.lockDoGetHealthClient.RLock()
 	calls = mock.calls.DoGetHealthClient
-	lockInitialiserMockDoGetHealthClient.RUnlock()
+	mock.lockDoGetHealthClient.RUnlock()
 	return calls
 }
 
@@ -286,9 +283,9 @@ func (mock *InitialiserMock) DoGetKafkaProducer(ctx context.Context, cfg *config
 		Ctx: ctx,
 		Cfg: cfg,
 	}
-	lockInitialiserMockDoGetKafkaProducer.Lock()
+	mock.lockDoGetKafkaProducer.Lock()
 	mock.calls.DoGetKafkaProducer = append(mock.calls.DoGetKafkaProducer, callInfo)
-	lockInitialiserMockDoGetKafkaProducer.Unlock()
+	mock.lockDoGetKafkaProducer.Unlock()
 	return mock.DoGetKafkaProducerFunc(ctx, cfg)
 }
 
@@ -303,43 +300,43 @@ func (mock *InitialiserMock) DoGetKafkaProducerCalls() []struct {
 		Ctx context.Context
 		Cfg *config.Config
 	}
-	lockInitialiserMockDoGetKafkaProducer.RLock()
+	mock.lockDoGetKafkaProducer.RLock()
 	calls = mock.calls.DoGetKafkaProducer
-	lockInitialiserMockDoGetKafkaProducer.RUnlock()
+	mock.lockDoGetKafkaProducer.RUnlock()
 	return calls
 }
 
 // DoGetMongoDB calls DoGetMongoDBFunc.
-func (mock *InitialiserMock) DoGetMongoDB(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error) {
+func (mock *InitialiserMock) DoGetMongoDB(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error) {
 	if mock.DoGetMongoDBFunc == nil {
 		panic("InitialiserMock.DoGetMongoDBFunc: method is nil but Initialiser.DoGetMongoDB was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
-		Cfg *config.Config
+		Ctx    context.Context
+		MgoCfg config.MongoConfig
 	}{
-		Ctx: ctx,
-		Cfg: cfg,
+		Ctx:    ctx,
+		MgoCfg: mgoCfg,
 	}
-	lockInitialiserMockDoGetMongoDB.Lock()
+	mock.lockDoGetMongoDB.Lock()
 	mock.calls.DoGetMongoDB = append(mock.calls.DoGetMongoDB, callInfo)
-	lockInitialiserMockDoGetMongoDB.Unlock()
-	return mock.DoGetMongoDBFunc(ctx, cfg)
+	mock.lockDoGetMongoDB.Unlock()
+	return mock.DoGetMongoDBFunc(ctx, mgoCfg)
 }
 
 // DoGetMongoDBCalls gets all the calls that were made to DoGetMongoDB.
 // Check the length with:
 //     len(mockedInitialiser.DoGetMongoDBCalls())
 func (mock *InitialiserMock) DoGetMongoDBCalls() []struct {
-	Ctx context.Context
-	Cfg *config.Config
+	Ctx    context.Context
+	MgoCfg config.MongoConfig
 } {
 	var calls []struct {
-		Ctx context.Context
-		Cfg *config.Config
+		Ctx    context.Context
+		MgoCfg config.MongoConfig
 	}
-	lockInitialiserMockDoGetMongoDB.RLock()
+	mock.lockDoGetMongoDB.RLock()
 	calls = mock.calls.DoGetMongoDB
-	lockInitialiserMockDoGetMongoDB.RUnlock()
+	mock.lockDoGetMongoDB.RUnlock()
 	return calls
 }

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
 	"github.com/ONSdigital/dp-search-reindex-api/service"
-	"github.com/globalsign/mgo/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"sync"
 )
 
@@ -54,7 +54,7 @@ var _ service.MongoDataStorer = &MongoDataStorerMock{}
 // 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
 // 				panic("mock out the UnlockJob method")
 // 			},
-// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 			UpdateJobFunc: func(ctx context.Context, id string, updates primitive.M) error {
 // 				panic("mock out the UpdateJob method")
 // 			},
 // 			UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
@@ -98,7 +98,7 @@ type MongoDataStorerMock struct {
 	UnlockJobFunc func(ctx context.Context, lockID string)
 
 	// UpdateJobFunc mocks the UpdateJob method.
-	UpdateJobFunc func(ctx context.Context, id string, updates bson.M) error
+	UpdateJobFunc func(ctx context.Context, id string, updates primitive.M) error
 
 	// UpsertTaskFunc mocks the UpsertTask method.
 	UpsertTaskFunc func(ctx context.Context, jobID string, taskName string, task models.Task) error
@@ -184,7 +184,7 @@ type MongoDataStorerMock struct {
 			// ID is the id argument value.
 			ID string
 			// Updates is the updates argument value.
-			Updates bson.M
+			Updates primitive.M
 		}
 		// UpsertTask holds details about calls to the UpsertTask method.
 		UpsertTask []struct {
@@ -567,14 +567,14 @@ func (mock *MongoDataStorerMock) UnlockJobCalls() []struct {
 }
 
 // UpdateJob calls UpdateJobFunc.
-func (mock *MongoDataStorerMock) UpdateJob(ctx context.Context, id string, updates bson.M) error {
+func (mock *MongoDataStorerMock) UpdateJob(ctx context.Context, id string, updates primitive.M) error {
 	if mock.UpdateJobFunc == nil {
 		panic("MongoDataStorerMock.UpdateJobFunc: method is nil but MongoDataStorer.UpdateJob was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
 		ID      string
-		Updates bson.M
+		Updates primitive.M
 	}{
 		Ctx:     ctx,
 		ID:      id,
@@ -592,12 +592,12 @@ func (mock *MongoDataStorerMock) UpdateJob(ctx context.Context, id string, updat
 func (mock *MongoDataStorerMock) UpdateJobCalls() []struct {
 	Ctx     context.Context
 	ID      string
-	Updates bson.M
+	Updates primitive.M
 } {
 	var calls []struct {
 		Ctx     context.Context
 		ID      string
-		Updates bson.M
+		Updates primitive.M
 	}
 	mock.lockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob

--- a/service/mock/mongo_data_storer.go
+++ b/service/mock/mongo_data_storer.go
@@ -6,6 +6,7 @@ package mock
 import (
 	"context"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/ONSdigital/dp-search-reindex-api/config"
 	"github.com/ONSdigital/dp-search-reindex-api/models"
 	"github.com/ONSdigital/dp-search-reindex-api/mongo"
 	"github.com/ONSdigital/dp-search-reindex-api/service"
@@ -13,80 +14,64 @@ import (
 	"sync"
 )
 
-var (
-	lockMongoDataStorerMockAcquireJobLock     sync.RWMutex
-	lockMongoDataStorerMockCheckInProgressJob sync.RWMutex
-	lockMongoDataStorerMockChecker            sync.RWMutex
-	lockMongoDataStorerMockClose              sync.RWMutex
-	lockMongoDataStorerMockCreateJob          sync.RWMutex
-	lockMongoDataStorerMockGetJob             sync.RWMutex
-	lockMongoDataStorerMockGetJobs            sync.RWMutex
-	lockMongoDataStorerMockGetTask            sync.RWMutex
-	lockMongoDataStorerMockGetTasks           sync.RWMutex
-	lockMongoDataStorerMockPutNumberOfTasks   sync.RWMutex
-	lockMongoDataStorerMockUnlockJob          sync.RWMutex
-	lockMongoDataStorerMockUpdateJob          sync.RWMutex
-	lockMongoDataStorerMockUpsertTask         sync.RWMutex
-)
-
-// Ensure, that MongoDataStorerMock does implement MongoDataStorer.
+// Ensure, that MongoDataStorerMock does implement service.MongoDataStorer.
 // If this is not the case, regenerate this file with moq.
 var _ service.MongoDataStorer = &MongoDataStorerMock{}
 
 // MongoDataStorerMock is a mock implementation of service.MongoDataStorer.
 //
-//     func TestSomethingThatUsesMongoDataStorer(t *testing.T) {
+// 	func TestSomethingThatUsesMongoDataStorer(t *testing.T) {
 //
-//         // make and configure a mocked service.MongoDataStorer
-//         mockedMongoDataStorer := &MongoDataStorerMock{
-//             AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
-// 	               panic("mock out the AcquireJobLock method")
-//             },
-//             CheckInProgressJobFunc: func(ctx context.Context) error {
-// 	               panic("mock out the CheckInProgressJob method")
-//             },
-//             CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
-// 	               panic("mock out the Checker method")
-//             },
-//             CloseFunc: func(ctx context.Context) error {
-// 	               panic("mock out the Close method")
-//             },
-//             CreateJobFunc: func(ctx context.Context, job models.Job) error {
-// 	               panic("mock out the CreateJob method")
-//             },
-//             GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
-// 	               panic("mock out the GetJob method")
-//             },
-//             GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
-// 	               panic("mock out the GetJobs method")
-//             },
-//             GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
-// 	               panic("mock out the GetTask method")
-//             },
-//             GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
-// 	               panic("mock out the GetTasks method")
-//             },
-//             UnlockJobFunc: func(ctx context.Context, lockID string)  {
-// 	               panic("mock out the UnlockJob method")
-//             },
-//             UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
-// 	               panic("mock out the UpdateJob method")
-//             },
-//             UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
-// 	               panic("mock out the UpsertTask method")
-//             },
-//         }
+// 		// make and configure a mocked service.MongoDataStorer
+// 		mockedMongoDataStorer := &MongoDataStorerMock{
+// 			AcquireJobLockFunc: func(ctx context.Context, id string) (string, error) {
+// 				panic("mock out the AcquireJobLock method")
+// 			},
+// 			CheckInProgressJobFunc: func(ctx context.Context, cfg *config.Config) error {
+// 				panic("mock out the CheckInProgressJob method")
+// 			},
+// 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
+// 				panic("mock out the Checker method")
+// 			},
+// 			CloseFunc: func(ctx context.Context) error {
+// 				panic("mock out the Close method")
+// 			},
+// 			CreateJobFunc: func(ctx context.Context, job models.Job) error {
+// 				panic("mock out the CreateJob method")
+// 			},
+// 			GetJobFunc: func(ctx context.Context, id string) (*models.Job, error) {
+// 				panic("mock out the GetJob method")
+// 			},
+// 			GetJobsFunc: func(ctx context.Context, options mongo.Options) (*models.Jobs, error) {
+// 				panic("mock out the GetJobs method")
+// 			},
+// 			GetTaskFunc: func(ctx context.Context, jobID string, taskName string) (*models.Task, error) {
+// 				panic("mock out the GetTask method")
+// 			},
+// 			GetTasksFunc: func(ctx context.Context, jobID string, options mongo.Options) (*models.Tasks, error) {
+// 				panic("mock out the GetTasks method")
+// 			},
+// 			UnlockJobFunc: func(ctx context.Context, lockID string)  {
+// 				panic("mock out the UnlockJob method")
+// 			},
+// 			UpdateJobFunc: func(ctx context.Context, id string, updates bson.M) error {
+// 				panic("mock out the UpdateJob method")
+// 			},
+// 			UpsertTaskFunc: func(ctx context.Context, jobID string, taskName string, task models.Task) error {
+// 				panic("mock out the UpsertTask method")
+// 			},
+// 		}
 //
-//         // use mockedMongoDataStorer in code that requires service.MongoDataStorer
-//         // and then make assertions.
+// 		// use mockedMongoDataStorer in code that requires service.MongoDataStorer
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type MongoDataStorerMock struct {
 	// AcquireJobLockFunc mocks the AcquireJobLock method.
 	AcquireJobLockFunc func(ctx context.Context, id string) (string, error)
 
 	// CheckInProgressJobFunc mocks the CheckInProgressJob method.
-	CheckInProgressJobFunc func(ctx context.Context) error
+	CheckInProgressJobFunc func(ctx context.Context, cfg *config.Config) error
 
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *healthcheck.CheckState) error
@@ -131,6 +116,8 @@ type MongoDataStorerMock struct {
 		CheckInProgressJob []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// Cfg is the cfg argument value.
+			Cfg *config.Config
 		}
 		// Checker holds details about calls to the Checker method.
 		Checker []struct {
@@ -211,6 +198,18 @@ type MongoDataStorerMock struct {
 			Task models.Task
 		}
 	}
+	lockAcquireJobLock     sync.RWMutex
+	lockCheckInProgressJob sync.RWMutex
+	lockChecker            sync.RWMutex
+	lockClose              sync.RWMutex
+	lockCreateJob          sync.RWMutex
+	lockGetJob             sync.RWMutex
+	lockGetJobs            sync.RWMutex
+	lockGetTask            sync.RWMutex
+	lockGetTasks           sync.RWMutex
+	lockUnlockJob          sync.RWMutex
+	lockUpdateJob          sync.RWMutex
+	lockUpsertTask         sync.RWMutex
 }
 
 // AcquireJobLock calls AcquireJobLockFunc.
@@ -225,9 +224,9 @@ func (mock *MongoDataStorerMock) AcquireJobLock(ctx context.Context, id string) 
 		Ctx: ctx,
 		ID:  id,
 	}
-	lockMongoDataStorerMockAcquireJobLock.Lock()
+	mock.lockAcquireJobLock.Lock()
 	mock.calls.AcquireJobLock = append(mock.calls.AcquireJobLock, callInfo)
-	lockMongoDataStorerMockAcquireJobLock.Unlock()
+	mock.lockAcquireJobLock.Unlock()
 	return mock.AcquireJobLockFunc(ctx, id)
 }
 
@@ -242,26 +241,28 @@ func (mock *MongoDataStorerMock) AcquireJobLockCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	lockMongoDataStorerMockAcquireJobLock.RLock()
+	mock.lockAcquireJobLock.RLock()
 	calls = mock.calls.AcquireJobLock
-	lockMongoDataStorerMockAcquireJobLock.RUnlock()
+	mock.lockAcquireJobLock.RUnlock()
 	return calls
 }
 
 // CheckInProgressJob calls CheckInProgressJobFunc.
-func (mock *MongoDataStorerMock) CheckInProgressJob(ctx context.Context) error {
+func (mock *MongoDataStorerMock) CheckInProgressJob(ctx context.Context, cfg *config.Config) error {
 	if mock.CheckInProgressJobFunc == nil {
 		panic("MongoDataStorerMock.CheckInProgressJobFunc: method is nil but MongoDataStorer.CheckInProgressJob was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
+		Cfg *config.Config
 	}{
 		Ctx: ctx,
+		Cfg: cfg,
 	}
-	lockMongoDataStorerMockCheckInProgressJob.Lock()
+	mock.lockCheckInProgressJob.Lock()
 	mock.calls.CheckInProgressJob = append(mock.calls.CheckInProgressJob, callInfo)
-	lockMongoDataStorerMockCheckInProgressJob.Unlock()
-	return mock.CheckInProgressJobFunc(ctx)
+	mock.lockCheckInProgressJob.Unlock()
+	return mock.CheckInProgressJobFunc(ctx, cfg)
 }
 
 // CheckInProgressJobCalls gets all the calls that were made to CheckInProgressJob.
@@ -269,13 +270,15 @@ func (mock *MongoDataStorerMock) CheckInProgressJob(ctx context.Context) error {
 //     len(mockedMongoDataStorer.CheckInProgressJobCalls())
 func (mock *MongoDataStorerMock) CheckInProgressJobCalls() []struct {
 	Ctx context.Context
+	Cfg *config.Config
 } {
 	var calls []struct {
 		Ctx context.Context
+		Cfg *config.Config
 	}
-	lockMongoDataStorerMockCheckInProgressJob.RLock()
+	mock.lockCheckInProgressJob.RLock()
 	calls = mock.calls.CheckInProgressJob
-	lockMongoDataStorerMockCheckInProgressJob.RUnlock()
+	mock.lockCheckInProgressJob.RUnlock()
 	return calls
 }
 
@@ -291,9 +294,9 @@ func (mock *MongoDataStorerMock) Checker(ctx context.Context, state *healthcheck
 		Ctx:   ctx,
 		State: state,
 	}
-	lockMongoDataStorerMockChecker.Lock()
+	mock.lockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	lockMongoDataStorerMockChecker.Unlock()
+	mock.lockChecker.Unlock()
 	return mock.CheckerFunc(ctx, state)
 }
 
@@ -308,9 +311,9 @@ func (mock *MongoDataStorerMock) CheckerCalls() []struct {
 		Ctx   context.Context
 		State *healthcheck.CheckState
 	}
-	lockMongoDataStorerMockChecker.RLock()
+	mock.lockChecker.RLock()
 	calls = mock.calls.Checker
-	lockMongoDataStorerMockChecker.RUnlock()
+	mock.lockChecker.RUnlock()
 	return calls
 }
 
@@ -324,9 +327,9 @@ func (mock *MongoDataStorerMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	lockMongoDataStorerMockClose.Lock()
+	mock.lockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	lockMongoDataStorerMockClose.Unlock()
+	mock.lockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -339,9 +342,9 @@ func (mock *MongoDataStorerMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	lockMongoDataStorerMockClose.RLock()
+	mock.lockClose.RLock()
 	calls = mock.calls.Close
-	lockMongoDataStorerMockClose.RUnlock()
+	mock.lockClose.RUnlock()
 	return calls
 }
 
@@ -357,9 +360,9 @@ func (mock *MongoDataStorerMock) CreateJob(ctx context.Context, job models.Job) 
 		Ctx: ctx,
 		Job: job,
 	}
-	lockMongoDataStorerMockCreateJob.Lock()
+	mock.lockCreateJob.Lock()
 	mock.calls.CreateJob = append(mock.calls.CreateJob, callInfo)
-	lockMongoDataStorerMockCreateJob.Unlock()
+	mock.lockCreateJob.Unlock()
 	return mock.CreateJobFunc(ctx, job)
 }
 
@@ -374,9 +377,9 @@ func (mock *MongoDataStorerMock) CreateJobCalls() []struct {
 		Ctx context.Context
 		Job models.Job
 	}
-	lockMongoDataStorerMockCreateJob.RLock()
+	mock.lockCreateJob.RLock()
 	calls = mock.calls.CreateJob
-	lockMongoDataStorerMockCreateJob.RUnlock()
+	mock.lockCreateJob.RUnlock()
 	return calls
 }
 
@@ -392,9 +395,9 @@ func (mock *MongoDataStorerMock) GetJob(ctx context.Context, id string) (*models
 		Ctx: ctx,
 		ID:  id,
 	}
-	lockMongoDataStorerMockGetJob.Lock()
+	mock.lockGetJob.Lock()
 	mock.calls.GetJob = append(mock.calls.GetJob, callInfo)
-	lockMongoDataStorerMockGetJob.Unlock()
+	mock.lockGetJob.Unlock()
 	return mock.GetJobFunc(ctx, id)
 }
 
@@ -409,9 +412,9 @@ func (mock *MongoDataStorerMock) GetJobCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	lockMongoDataStorerMockGetJob.RLock()
+	mock.lockGetJob.RLock()
 	calls = mock.calls.GetJob
-	lockMongoDataStorerMockGetJob.RUnlock()
+	mock.lockGetJob.RUnlock()
 	return calls
 }
 
@@ -427,9 +430,9 @@ func (mock *MongoDataStorerMock) GetJobs(ctx context.Context, options mongo.Opti
 		Ctx:     ctx,
 		Options: options,
 	}
-	lockMongoDataStorerMockGetJobs.Lock()
+	mock.lockGetJobs.Lock()
 	mock.calls.GetJobs = append(mock.calls.GetJobs, callInfo)
-	lockMongoDataStorerMockGetJobs.Unlock()
+	mock.lockGetJobs.Unlock()
 	return mock.GetJobsFunc(ctx, options)
 }
 
@@ -444,9 +447,9 @@ func (mock *MongoDataStorerMock) GetJobsCalls() []struct {
 		Ctx     context.Context
 		Options mongo.Options
 	}
-	lockMongoDataStorerMockGetJobs.RLock()
+	mock.lockGetJobs.RLock()
 	calls = mock.calls.GetJobs
-	lockMongoDataStorerMockGetJobs.RUnlock()
+	mock.lockGetJobs.RUnlock()
 	return calls
 }
 
@@ -464,9 +467,9 @@ func (mock *MongoDataStorerMock) GetTask(ctx context.Context, jobID string, task
 		JobID:    jobID,
 		TaskName: taskName,
 	}
-	lockMongoDataStorerMockGetTask.Lock()
+	mock.lockGetTask.Lock()
 	mock.calls.GetTask = append(mock.calls.GetTask, callInfo)
-	lockMongoDataStorerMockGetTask.Unlock()
+	mock.lockGetTask.Unlock()
 	return mock.GetTaskFunc(ctx, jobID, taskName)
 }
 
@@ -483,9 +486,9 @@ func (mock *MongoDataStorerMock) GetTaskCalls() []struct {
 		JobID    string
 		TaskName string
 	}
-	lockMongoDataStorerMockGetTask.RLock()
+	mock.lockGetTask.RLock()
 	calls = mock.calls.GetTask
-	lockMongoDataStorerMockGetTask.RUnlock()
+	mock.lockGetTask.RUnlock()
 	return calls
 }
 
@@ -503,9 +506,9 @@ func (mock *MongoDataStorerMock) GetTasks(ctx context.Context, jobID string, opt
 		JobID:   jobID,
 		Options: options,
 	}
-	lockMongoDataStorerMockGetTasks.Lock()
+	mock.lockGetTasks.Lock()
 	mock.calls.GetTasks = append(mock.calls.GetTasks, callInfo)
-	lockMongoDataStorerMockGetTasks.Unlock()
+	mock.lockGetTasks.Unlock()
 	return mock.GetTasksFunc(ctx, jobID, options)
 }
 
@@ -522,9 +525,9 @@ func (mock *MongoDataStorerMock) GetTasksCalls() []struct {
 		JobID   string
 		Options mongo.Options
 	}
-	lockMongoDataStorerMockGetTasks.RLock()
+	mock.lockGetTasks.RLock()
 	calls = mock.calls.GetTasks
-	lockMongoDataStorerMockGetTasks.RUnlock()
+	mock.lockGetTasks.RUnlock()
 	return calls
 }
 
@@ -540,9 +543,9 @@ func (mock *MongoDataStorerMock) UnlockJob(ctx context.Context, lockID string) {
 		Ctx:    ctx,
 		LockID: lockID,
 	}
-	lockMongoDataStorerMockUnlockJob.Lock()
+	mock.lockUnlockJob.Lock()
 	mock.calls.UnlockJob = append(mock.calls.UnlockJob, callInfo)
-	lockMongoDataStorerMockUnlockJob.Unlock()
+	mock.lockUnlockJob.Unlock()
 	mock.UnlockJobFunc(ctx, lockID)
 }
 
@@ -557,9 +560,9 @@ func (mock *MongoDataStorerMock) UnlockJobCalls() []struct {
 		Ctx    context.Context
 		LockID string
 	}
-	lockMongoDataStorerMockUnlockJob.RLock()
+	mock.lockUnlockJob.RLock()
 	calls = mock.calls.UnlockJob
-	lockMongoDataStorerMockUnlockJob.RUnlock()
+	mock.lockUnlockJob.RUnlock()
 	return calls
 }
 
@@ -577,9 +580,9 @@ func (mock *MongoDataStorerMock) UpdateJob(ctx context.Context, id string, updat
 		ID:      id,
 		Updates: updates,
 	}
-	lockMongoDataStorerMockUpdateJob.Lock()
+	mock.lockUpdateJob.Lock()
 	mock.calls.UpdateJob = append(mock.calls.UpdateJob, callInfo)
-	lockMongoDataStorerMockUpdateJob.Unlock()
+	mock.lockUpdateJob.Unlock()
 	return mock.UpdateJobFunc(ctx, id, updates)
 }
 
@@ -596,9 +599,9 @@ func (mock *MongoDataStorerMock) UpdateJobCalls() []struct {
 		ID      string
 		Updates bson.M
 	}
-	lockMongoDataStorerMockUpdateJob.RLock()
+	mock.lockUpdateJob.RLock()
 	calls = mock.calls.UpdateJob
-	lockMongoDataStorerMockUpdateJob.RUnlock()
+	mock.lockUpdateJob.RUnlock()
 	return calls
 }
 
@@ -618,9 +621,9 @@ func (mock *MongoDataStorerMock) UpsertTask(ctx context.Context, jobID string, t
 		TaskName: taskName,
 		Task:     task,
 	}
-	lockMongoDataStorerMockUpsertTask.Lock()
+	mock.lockUpsertTask.Lock()
 	mock.calls.UpsertTask = append(mock.calls.UpsertTask, callInfo)
-	lockMongoDataStorerMockUpsertTask.Unlock()
+	mock.lockUpsertTask.Unlock()
 	return mock.UpsertTaskFunc(ctx, jobID, taskName, task)
 }
 
@@ -639,8 +642,8 @@ func (mock *MongoDataStorerMock) UpsertTaskCalls() []struct {
 		TaskName string
 		Task     models.Task
 	}
-	lockMongoDataStorerMockUpsertTask.RLock()
+	mock.lockUpsertTask.RLock()
 	calls = mock.calls.UpsertTask
-	lockMongoDataStorerMockUpsertTask.RUnlock()
+	mock.lockUpsertTask.RUnlock()
 	return calls
 }

--- a/service/service.go
+++ b/service/service.go
@@ -39,7 +39,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	s := serviceList.GetHTTPServer(cfg.BindAddr, middleware.Then(r))
 
 	// Get MongoDB client
-	mongoDB, err := serviceList.GetMongoDB(ctx, cfg)
+	mongoDB, err := serviceList.GetMongoDB(ctx, cfg.MongoConfig)
 	if err != nil {
 		log.Fatal(ctx, "failed to initialise mongo DB", err)
 		return nil, err

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -33,7 +33,7 @@ var (
 	errHealthcheck = errors.New("healthCheck error")
 )
 
-var funcDoGetMongoDBErr = func(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error) {
+var funcDoGetMongoDBErr = func(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error) {
 	return nil, errMongoDB
 }
 
@@ -85,7 +85,7 @@ func TestRun(t *testing.T) {
 			CloseFunc: func(ctx context.Context) error { return nil },
 		}
 
-		funcDoGetMongoDBOk := func(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error) {
+		funcDoGetMongoDBOk := func(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error) {
 			return mongoDBMock, nil
 		}
 
@@ -301,7 +301,7 @@ func TestClose(t *testing.T) {
 		Convey("Closing the service results in all the dependencies being closed in the expected order", func() {
 			initMock := &serviceMock.InitialiserMock{
 				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer { return serverMock },
-				DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error) {
+				DoGetMongoDBFunc: func(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error) {
 					return mongoDBMock, nil
 				},
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
@@ -339,7 +339,7 @@ func TestClose(t *testing.T) {
 
 			initMock := &serviceMock.InitialiserMock{
 				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer { return failingServerMock },
-				DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.MongoDataStorer, error) {
+				DoGetMongoDBFunc: func(ctx context.Context, mgoCfg config.MongoConfig) (service.MongoDataStorer, error) {
 					return mongoDBMock, nil
 				},
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The Search Reindex API has been updated to use Document DB instead of Mongo DB. For this the following code changes have been made:
1. In go.mod - the latest version of dp-mongodb has been pulled in:
github.com/ONSdigital/dp-mongodb/v3 v3.0.2
2. In config.go - the MongoDriverConfig struct, from dp-mongodb, replaces the previous mongo configuration variables.
3. In mongo/data_store.go - the JobStore struct now uses the new config variables. 
- the Init function uses the latest dp-mongodb functions for opening the connection to document db and for creating the required collections and clients (the health client and lock client).
- the Close function uses the latest dp-mongodb function to close the connection to document db. 
4. All old mongo errors, such as ErrNotFound, are replaced with the new ones, such as ErrNoDocumentFound.
5. All uses of Session have been deleted.
6. New Update function replaces the old UpdateId function.
7. New Find function, which uses Sort, Offset, and Limit in its input parameters instead of calling them separately, and which specifies what list variable to put the returned documents into, replaces the old one used in the GetJobs and GetTasks functions.
8. The use of Count after the Find function has been replaced with use of Count with a filter for what needs to be found.
9. The README has been updated with the changes to the config variables.

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct. Follow instructions in the README if you would like to test it locally.

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
